### PR TITLE
(ast) add color_hdr support

### DIFF
--- a/crates/hdx_ast/src/css/values/color_hdr/impls.rs
+++ b/crates/hdx_ast/src/css/values/color_hdr/impls.rs
@@ -1,1 +1,20 @@
 pub(crate) use crate::traits::StyleValue;
+pub(crate) use hdx_proc_macro::*;
+
+#[cfg(test)]
+mod tests {
+	use super::super::*;
+	use crate::test_helpers::*;
+
+	#[test]
+	fn size_test() {
+		assert_size!(DynamicRangeLimit, 56);
+	}
+
+	#[test]
+	fn test_writes() {
+		assert_parse!(DynamicRangeLimit, "high");
+		assert_parse!(DynamicRangeLimit, "dynamic-range-limit-mix(high 80%,standard 20%)");
+		assert_parse!(DynamicRangeLimit, "dynamic-range-limit-mix(high 8%,standard 2%)");
+	}
+}

--- a/crates/hdx_ast/src/css/values/color_hdr/mod.rs
+++ b/crates/hdx_ast/src/css/values/color_hdr/mod.rs
@@ -8,12 +8,12 @@ use impls::*;
  * CSS Color HDR Module Level 1
  */
 
-// // https://drafts.csswg.org/css-color-hdr-1/#dynamic-range-limit
-// #[value(" standard | high | constrained-high | <dynamic-range-limit-mix()> ")]
-// #[initial("high")]
-// #[applies_to("all elements")]
-// #[inherited("no")]
-// #[percentages("n/a")]
-// #[canonical_order("per grammar")]
-// #[animation_type("by dynamic-range-limit-mix()")]
-// pub enum DynamicRangeLimit {}
+// https://drafts.csswg.org/css-color-hdr-1/#dynamic-range-limit
+#[value(" standard | high | constrained-high | <dynamic-range-limit-mix()> ")]
+#[initial("high")]
+#[applies_to("all elements")]
+#[inherited("no")]
+#[percentages("n/a")]
+#[canonical_order("per grammar")]
+#[animation_type("by dynamic-range-limit-mix()")]
+pub enum DynamicRangeLimit<'a> {}

--- a/crates/hdx_ast/src/css/values/color_hdr/types.rs
+++ b/crates/hdx_ast/src/css/values/color_hdr/types.rs
@@ -1,2 +1,82 @@
-pub(crate) use crate::css::types::*;
-pub(crate) use crate::css::units::*;
+use bumpalo::collections::Vec;
+use hdx_lexer::Cursor;
+use hdx_parser::{diagnostics, CursorStream, Is, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
+
+mod func {
+	use hdx_parser::custom_function;
+	custom_function!(DynamicRangeLimitMix, atom!("dynamic-range-limit-mix"));
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+pub struct DynamicRangeLimitMix<'a> {
+	function: T![Function],
+	values: Vec<'a, (T![Ident], T![Dimension::%], Option<T![,]>)>,
+	close: Option<T![')']>,
+}
+
+impl<'a> Peek<'a> for DynamicRangeLimitMix<'a> {
+	fn peek(p: &Parser<'a>) -> bool {
+		p.peek::<func::DynamicRangeLimitMix>()
+	}
+}
+
+impl<'a> Parse<'a> for DynamicRangeLimitMix<'a> {
+	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
+		let function = p.parse::<T![Function]>()?;
+		let c = function.into();
+		if !func::DynamicRangeLimitMix::is(p, c) {
+			Err(diagnostics::Unexpected(c.into(), c.into()))?;
+		}
+		let mut values = Vec::new_in(p.bump());
+		loop {
+			if p.at_end() {
+				return Ok(Self { function, values, close: None });
+			}
+			if p.peek::<T![')']>() {
+				return Ok(Self { function, values, close: Some(p.parse::<T![')']>()?) });
+			}
+			let ident = p.parse::<T![Ident]>()?;
+			let length = p.parse::<T![Dimension::%]>()?;
+			let c: Cursor = length.into();
+			if !(0.0..=100.0).contains(&c.token().value()) {
+				Err(diagnostics::NumberOutOfBounds(c.token().value(), format!("{:?}", 0.0..=100.0), c.into()))?
+			}
+			let comma = p.parse_if_peek::<T![,]>()?;
+			values.push((ident, length, comma));
+		}
+	}
+}
+
+impl<'a> ToCursors<'a> for DynamicRangeLimitMix<'a> {
+	fn to_cursors(&self, s: &mut CursorStream<'a>) {
+		s.append(self.function.into());
+		for (ident, length, comma) in &self.values {
+			s.append(ident.into());
+			s.append(length.into());
+			if let Some(comma) = comma {
+				s.append(comma.into());
+			}
+		}
+		if let Some(close) = self.close {
+			s.append(close.into());
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::test_helpers::*;
+
+	#[test]
+	fn size_test() {
+		assert_size!(DynamicRangeLimitMix, 56);
+	}
+
+	#[test]
+	fn test_writes() {
+		assert_parse!(DynamicRangeLimitMix, "dynamic-range-limit-mix(high 80%,standard 20%)");
+		assert_parse!(DynamicRangeLimitMix, "dynamic-range-limit-mix(high 8%,standard 2%)");
+	}
+}

--- a/crates/hdx_proc_macro/src/def.rs
+++ b/crates/hdx_proc_macro/src/def.rs
@@ -1350,8 +1350,8 @@ impl DefType {
 
 	pub fn requires_allocator_lifetime(&self) -> bool {
 		if let Self::Custom(DefIdent(ident), _) = self {
-			return matches!(ident, &atom!("OutlineColor") | &atom!("BorderTopColor") | &atom!("AnchorName"));
-		}
+			return matches!(ident, &atom!("OutlineColor") | &atom!("BorderTopColor") | &atom!("AnchorName") | &atom!("DynamicRangeLimitMix"));
+		} 
 		matches!(self, Self::Image | Self::Image1D)
 	}
 }


### PR DESCRIPTION
This adds supports for the [CSS color-hdr](https://drafts.csswg.org/css-color-hdr-1/), by commenting out the `DynamicRangeLimit` enum and adding a new `DynamicRangeLimitMix` struct in the `crates/hdx_ast/src/css/values/color_hdr/types.rs` file. 

DynamicRangeLimitMix is a struct that represents the `dynamic-range-limit-mix()` function in CSS.