### PR TITLE
(lsp) scaffold out basic lsp server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 website/_site
 *.wasm
 *.snap.new
+.vscode-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,15 +282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "closestmatch"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad079302f93284b34259c2fc0e3c8f575d50d6a75b6345b796a6b00ca6f1f13"
-dependencies = [
- "rayon 0.7.1",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,7 +336,7 @@ dependencies = [
  "once_cell",
  "oorandom",
  "plotters",
- "rayon 1.10.0",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -362,6 +353,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -394,6 +394,20 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "debugid"
@@ -489,6 +503,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +583,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
@@ -573,11 +602,14 @@ dependencies = [
  "hdx_ast",
  "hdx_atom",
  "hdx_lexer",
+ "hdx_lsp",
  "hdx_parser",
  "hdx_syntax",
  "miette",
  "serde",
  "serde_json",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -632,6 +664,7 @@ dependencies = [
  "hdx_parser",
  "insta",
  "similar",
+ "strum",
 ]
 
 [[package]]
@@ -655,12 +688,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdx_lsp"
+version = "0.0.0"
+dependencies = [
+ "bitmask-enum",
+ "bumpalo",
+ "console",
+ "criterion",
+ "crossbeam-channel",
+ "dashmap",
+ "glob",
+ "hdx_ast",
+ "hdx_highlight",
+ "hdx_parser",
+ "httparse",
+ "insta",
+ "itertools 0.13.0",
+ "lsp-types",
+ "miette",
+ "pprof",
+ "serde",
+ "serde_json",
+ "similar",
+ "smallvec",
+ "strum",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "hdx_parser"
 version = "0.0.1"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
- "closestmatch",
  "glob",
  "hdx_atom",
  "hdx_lexer",
@@ -733,13 +794,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "httparse"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
 name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -871,6 +938,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +1033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1081,12 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -1039,6 +1135,12 @@ checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "plotters"
@@ -1175,15 +1277,6 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
-dependencies = [
- "rayon-core",
-]
-
-[[package]]
-name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
@@ -1269,6 +1362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1435,26 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1408,6 +1527,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "supports-color"
@@ -1538,6 +1679,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1696,63 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1576,6 +1784,12 @@ name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,15 +3,16 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-authors = ["Keith Cirkel <hdx@keithcirkel.co.uk>"]
+authors = ["Keith Cirkel (https://keithcirkel.co.uk)"]
 description = "Refreshing CSS!"
 edition = "2021"
-homepage = "https://github.com/keithamus/hdx"
+homepage = "https://hdx.rs"
 keywords = ["CSS", "parser"]
 license = "MIT"
 repository = "https://github.com/keithamus/hdx"
 
 [workspace.dependencies]
+# Local packages
 hdx = { version = "0.0.1", path = "crates/hdx" }
 hdx_atom = { version = "0.0.0", path = "crates/hdx_atom" }
 hdx_proc_macro = { version = "0.0.0", path = "crates/hdx_proc_macro" }
@@ -20,41 +21,68 @@ hdx_lexer = { version = "0.0.1", path = "crates/hdx_lexer" }
 hdx_syntax = { version = "0.0.0", path = "crates/hdx_syntax" }
 hdx_ast = { version = "0.0.0", path = "crates/hdx_ast" }
 hdx_transform = { version = "0.0.0", path = "crates/hdx_transform" }
+hdx_highlight = { version = "0.0.0", path = "crates/hdx_highlight" }
+hdx_lsp = { version = "0.0.0", path = "crates/hdx_lsp" }
 
+# Memory 
 bumpalo = { version = "3.16.0" }
 
-clap = { version = "4.5.23" }
+# Data structure libraries/helpers
+smallvec = { version = "1.13.2" }
+itertools = { version = "0.13.0" }
+strum = { version = "0.26.3" }
+bitmask-enum = { version = "2.2.5" }
 
-closestmatch = { version = "0.1.2" }
+# CLI
+clap = { version = "4.5.23" }
+glob = { version = "0.3.1" }
+project-root = { version = "0.2.2" }
+
+# LSP packages
+lsp-types = { version = "0.97.0" }
+httparse = { version = "1.9.5" }
+
+# Multithreading
+crossbeam-channel = { version = "0.5.13" }
+dashmap = { version = "6.1.0" }
+
+# Logging
+log = { version = "0.4.22" }
+tracing = { version = "0.1.41" }
+tracing-subscriber = { version = "0.3.19" }
+console = { version = "0.15.8" }
+
+# Error handling
 miette = { version = "7.4.0", default-features = false }
 thiserror = { version = "2.0.6" }
-serde = { version = "1.0.215" }
-serde_json = { version = "1.0.133" }
+
+# Procc Macro Tools
 syn = { version = "2.0.90" }
 quote = { version = "1.0.37" }
 proc-macro2 = { version = "1.0.92" }
-bitmask-enum = { version = "2.2.5" }
-smallvec = { version = "1.13.2" }
-itertools = { version = "0.13.0" }
 
-glob = { version = "0.3.1" }
-pico-args = { version = "0.5.0" }
-project-root = { version = "0.2.2" }
+# Serialization
+serde = { version = "1.0.215" }
+serde_json = { version = "1.0.133" }
+
+# Testing, benchmarking
 similar = { version = "2.6.0" }
 criterion = { version = "0.5.1" }
 pprof = { version = "0.14.0" }
 flate2 = { version = "1.0.35" }
 insta = { version = "1.41.1" }
-console = { version = "0.15.8" }
 prettyplease = { version = "0.2.25" }
 
+# String interning
 string_cache = { version = "0.8.7" }
 string_cache_codegen = { version = "0.5.2" }
 
+# Build tools
 grep-regex = { version = "0.1.13" }
 grep-matcher = { version = "0.1.7" }
 grep-searcher = { version = "0.1.14" }
 
+# Wasm
 wasm-bindgen = { version = "0.2.99" }
 serde-wasm-bindgen = { version = "0.6.5" }
 console_error_panic_hook = { version = "0.1.7" }
@@ -79,6 +107,7 @@ inherits = "release"
 strip = false
 debug = true
 
+# For faster compiles during development, opt-level some dynamic libraries
 [profile.dev.package]
 criterion.opt-level = 3
 insta.opt-level = 3

--- a/crates/hdx/Cargo.toml
+++ b/crates/hdx/Cargo.toml
@@ -15,6 +15,7 @@ hdx_syntax = { workspace = true }
 hdx_ast = { workspace = true }
 hdx_parser = { workspace = true }
 hdx_atom = { workspace = true }
+hdx_lsp = { workspace = true }
 
 clap = { workspace = true, features = ["derive", "cargo"] }
 miette = { workspace = true }
@@ -23,6 +24,9 @@ bumpalo = { workspace = true, features = ["collections", "boxed"] }
 
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [features]
 default = ["fancy"]

--- a/crates/hdx_ast/src/css/rules/moz.rs
+++ b/crates/hdx_ast/src/css/rules/moz.rs
@@ -43,9 +43,9 @@ impl<'a> ToCursors for MozDocumentRule<'a> {
 }
 
 impl<'a> Visitable<'a> for MozDocumentRule<'a> {
-    fn accept<V: Visit<'a>>(&self, v: &mut V) {
-			todo!();
-    }
+	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+		v.visit_moz_document_rule(self);
+	}
 }
 
 #[cfg(test)]

--- a/crates/hdx_ast/src/css/selector/mod.rs
+++ b/crates/hdx_ast/src/css/selector/mod.rs
@@ -26,11 +26,15 @@ pub use class::*;
 pub use combinator::*;
 pub use functional_pseudo_class::*;
 pub use functional_pseudo_element::*;
+pub use moz::*;
+pub use ms::*;
 pub use namespace::*;
 pub use nth::*;
+pub use o::*;
 pub use pseudo_class::*;
 pub use pseudo_element::*;
 pub use tag::*;
+pub use webkit::*;
 
 use super::{Visit, Visitable};
 

--- a/crates/hdx_ast/src/css/selector/moz.rs
+++ b/crates/hdx_ast/src/css/selector/moz.rs
@@ -1,12 +1,16 @@
 use hdx_atom::atom;
 use hdx_lexer::{Cursor, KindSet};
 use hdx_parser::{diagnostics, todo, CursorSink, Parse, Parser, Result as ParserResult, ToCursors, T};
+use hdx_proc_macro::visit;
+
+use crate::css::{Visit, Visitable};
 
 use super::functional_pseudo_class::DirValue;
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#pseudo-elements_and_pseudo-classes
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
+#[visit]
 pub enum MozPseudoElement {
 	AnonymousBlock(T![::], T![Ident]),
 	AnonymousItem(T![::], T![Ident]),
@@ -476,8 +480,15 @@ impl<'a> ToCursors for MozPseudoElement {
 	}
 }
 
+impl<'a> Visitable<'a> for MozPseudoElement {
+	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+		v.visit_moz_pseudo_element(self);
+	}
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
+#[visit]
 pub enum MozFunctionalPseudoElement {
 	TreeCell(()),
 	TreeCellText(()),
@@ -514,9 +525,16 @@ impl<'a> Parse<'a> for MozFunctionalPseudoElement {
 	}
 }
 
+impl<'a> Visitable<'a> for MozFunctionalPseudoElement {
+	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+		v.visit_moz_functional_pseudo_element(self);
+	}
+}
+
 // https://searchfox.org/mozilla-central/source/xpcom/ds/StaticAtoms.py#2502
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
+#[visit]
 pub enum MozPseudoClass {
 	Any(T![:], T![Ident]),
 	AnyLink(T![:], T![Ident]),
@@ -700,8 +718,15 @@ impl<'a> ToCursors for MozPseudoClass {
 	}
 }
 
+impl<'a> Visitable<'a> for MozPseudoClass {
+	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+		v.visit_moz_pseudo_class(self);
+	}
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
+#[visit]
 pub enum MozFunctionalPseudoClass {
 	LocaleDir(MozLocaleDirFunctionalPseudoClass),
 }
@@ -727,6 +752,12 @@ impl<'a> ToCursors for MozFunctionalPseudoClass {
 		match self {
 			Self::LocaleDir(c) => ToCursors::to_cursors(c, s),
 		}
+	}
+}
+
+impl<'a> Visitable<'a> for MozFunctionalPseudoClass {
+	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+		v.visit_moz_functional_pseudo_class(self);
 	}
 }
 

--- a/crates/hdx_ast/src/css/selector/ms.rs
+++ b/crates/hdx_ast/src/css/selector/ms.rs
@@ -1,9 +1,13 @@
 use hdx_atom::atom;
 use hdx_lexer::{Cursor, KindSet};
 use hdx_parser::{diagnostics, CursorSink, Parse, Parser, Result as ParserResult, ToCursors, T};
+use hdx_proc_macro::visit;
+
+use crate::css::{Visitable, Visit};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub enum MsPseudoElement {
 	Backdrop(T![::], T![Ident]),
 	Browse(T![::], T![Ident]),
@@ -137,8 +141,15 @@ impl<'a> ToCursors for MsPseudoElement {
 	}
 }
 
+impl<'a> Visitable<'a> for MsPseudoElement {
+	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+		v.visit_ms_pseudo_element(self);
+	}
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub enum MsPseudoClass {
 	Fullscreen(T![:], T![Ident]),
 	InputPlaceholder(T![:], T![Ident]),
@@ -173,5 +184,11 @@ impl<'a> ToCursors for MsPseudoClass {
 				s.append(ident.into());
 			}
 		}
+	}
+}
+
+impl<'a> Visitable<'a> for MsPseudoClass {
+	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+		v.visit_ms_pseudo_class(self);
 	}
 }

--- a/crates/hdx_ast/src/css/selector/o.rs
+++ b/crates/hdx_ast/src/css/selector/o.rs
@@ -1,9 +1,13 @@
 use hdx_atom::atom;
 use hdx_lexer::{Cursor, KindSet};
 use hdx_parser::{diagnostics, CursorSink, Parse, Parser, Result as ParserResult, ToCursors, T};
+use hdx_proc_macro::visit;
+
+use crate::css::{Visit, Visitable};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub enum OPseudoElement {
 	InnerSpinButton(T![::], T![Ident]),
 	OuterSpinButton(T![::], T![Ident]),
@@ -77,8 +81,15 @@ impl<'a> ToCursors for OPseudoElement {
 	}
 }
 
+impl<'a> Visitable<'a> for OPseudoElement {
+	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+		v.visit_o_pseudo_element(self);
+	}
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub enum OPseudoClass {
 	Prefocus(T![:], T![Ident]),
 }
@@ -107,5 +118,11 @@ impl<'a> ToCursors for OPseudoClass {
 				s.append(ident.into());
 			}
 		}
+	}
+}
+
+impl<'a> Visitable<'a> for OPseudoClass {
+	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+		v.visit_o_pseudo_class(self);
 	}
 }

--- a/crates/hdx_ast/src/css/selector/pseudo_class.rs
+++ b/crates/hdx_ast/src/css/selector/pseudo_class.rs
@@ -1,6 +1,7 @@
 use hdx_atom::atom;
-use hdx_lexer::Cursor;
+use hdx_lexer::{Cursor, Span};
 use hdx_parser::{diagnostics, Parse, Parser, Result as ParserResult, ToCursors, T};
+use hdx_proc_macro::visit;
 
 use crate::css::{Visit, Visitable};
 
@@ -8,6 +9,7 @@ use super::{moz::MozPseudoClass, ms::MsPseudoClass, o::OPseudoClass, webkit::Web
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
+#[visit]
 pub enum PseudoClass {
 	Active(T![:], T![Ident]),
 	AnyLink(T![:], T![Ident]),
@@ -145,203 +147,56 @@ impl<'a> Parse<'a> for PseudoClass {
 impl<'a> ToCursors for PseudoClass {
 	fn to_cursors(&self, s: &mut impl hdx_parser::CursorSink) {
 		match self {
-			Self::Active(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::AnyLink(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Autofill(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Blank(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Checked(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Current(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Default(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Defined(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Disabled(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Empty(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Enabled(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::First(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::FirstChild(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::FirstOfType(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Fullscreen(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Future(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Focus(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::FocusVisible(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::FocusWithin(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Host(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Hover(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Indeterminate(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::InRange(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Invalid(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::LastChild(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::LastOfType(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Left(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Link(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::LocalLink(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Modal(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::OnlyChild(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::OnlyOfType(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Optional(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::OutOfRange(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Past(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::PictureInPicture(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::PlaceholderShown(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::PopoverOpen(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Paused(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Playing(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::ReadOnly(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::ReadWrite(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Required(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Right(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Root(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Scope(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Target(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::TargetWithin(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Valid(colon, ident) => {
-				s.append(colon.into());
-				s.append(ident.into());
-			}
-			Self::Visited(colon, ident) => {
+			Self::Active(colon, ident)
+			| Self::AnyLink(colon, ident)
+			| Self::Autofill(colon, ident)
+			| Self::Blank(colon, ident)
+			| Self::Checked(colon, ident)
+			| Self::Current(colon, ident)
+			| Self::Default(colon, ident)
+			| Self::Defined(colon, ident)
+			| Self::Disabled(colon, ident)
+			| Self::Empty(colon, ident)
+			| Self::Enabled(colon, ident)
+			| Self::First(colon, ident)
+			| Self::FirstChild(colon, ident)
+			| Self::FirstOfType(colon, ident)
+			| Self::Fullscreen(colon, ident)
+			| Self::Future(colon, ident)
+			| Self::Focus(colon, ident)
+			| Self::FocusVisible(colon, ident)
+			| Self::FocusWithin(colon, ident)
+			| Self::Host(colon, ident)
+			| Self::Hover(colon, ident)
+			| Self::Indeterminate(colon, ident)
+			| Self::InRange(colon, ident)
+			| Self::Invalid(colon, ident)
+			| Self::LastChild(colon, ident)
+			| Self::LastOfType(colon, ident)
+			| Self::Left(colon, ident)
+			| Self::Link(colon, ident)
+			| Self::LocalLink(colon, ident)
+			| Self::Modal(colon, ident)
+			| Self::OnlyChild(colon, ident)
+			| Self::OnlyOfType(colon, ident)
+			| Self::Optional(colon, ident)
+			| Self::OutOfRange(colon, ident)
+			| Self::Past(colon, ident)
+			| Self::PictureInPicture(colon, ident)
+			| Self::PlaceholderShown(colon, ident)
+			| Self::PopoverOpen(colon, ident)
+			| Self::Paused(colon, ident)
+			| Self::Playing(colon, ident)
+			| Self::ReadOnly(colon, ident)
+			| Self::ReadWrite(colon, ident)
+			| Self::Required(colon, ident)
+			| Self::Right(colon, ident)
+			| Self::Root(colon, ident)
+			| Self::Scope(colon, ident)
+			| Self::Target(colon, ident)
+			| Self::TargetWithin(colon, ident)
+			| Self::Valid(colon, ident)
+			| Self::Visited(colon, ident) => {
 				s.append(colon.into());
 				s.append(ident.into());
 			}
@@ -353,9 +208,78 @@ impl<'a> ToCursors for PseudoClass {
 	}
 }
 
+impl<'a> From<&PseudoClass> for Span {
+	fn from(value: &PseudoClass) -> Self {
+		match value {
+			PseudoClass::Active(colon, ident)
+			| PseudoClass::AnyLink(colon, ident)
+			| PseudoClass::Autofill(colon, ident)
+			| PseudoClass::Blank(colon, ident)
+			| PseudoClass::Checked(colon, ident)
+			| PseudoClass::Current(colon, ident)
+			| PseudoClass::Default(colon, ident)
+			| PseudoClass::Defined(colon, ident)
+			| PseudoClass::Disabled(colon, ident)
+			| PseudoClass::Empty(colon, ident)
+			| PseudoClass::Enabled(colon, ident)
+			| PseudoClass::First(colon, ident)
+			| PseudoClass::FirstChild(colon, ident)
+			| PseudoClass::FirstOfType(colon, ident)
+			| PseudoClass::Fullscreen(colon, ident)
+			| PseudoClass::Future(colon, ident)
+			| PseudoClass::Focus(colon, ident)
+			| PseudoClass::FocusVisible(colon, ident)
+			| PseudoClass::FocusWithin(colon, ident)
+			| PseudoClass::Host(colon, ident)
+			| PseudoClass::Hover(colon, ident)
+			| PseudoClass::Indeterminate(colon, ident)
+			| PseudoClass::InRange(colon, ident)
+			| PseudoClass::Invalid(colon, ident)
+			| PseudoClass::LastChild(colon, ident)
+			| PseudoClass::LastOfType(colon, ident)
+			| PseudoClass::Left(colon, ident)
+			| PseudoClass::Link(colon, ident)
+			| PseudoClass::LocalLink(colon, ident)
+			| PseudoClass::Modal(colon, ident)
+			| PseudoClass::OnlyChild(colon, ident)
+			| PseudoClass::OnlyOfType(colon, ident)
+			| PseudoClass::Optional(colon, ident)
+			| PseudoClass::OutOfRange(colon, ident)
+			| PseudoClass::Past(colon, ident)
+			| PseudoClass::PictureInPicture(colon, ident)
+			| PseudoClass::PlaceholderShown(colon, ident)
+			| PseudoClass::PopoverOpen(colon, ident)
+			| PseudoClass::Paused(colon, ident)
+			| PseudoClass::Playing(colon, ident)
+			| PseudoClass::ReadOnly(colon, ident)
+			| PseudoClass::ReadWrite(colon, ident)
+			| PseudoClass::Required(colon, ident)
+			| PseudoClass::Right(colon, ident)
+			| PseudoClass::Root(colon, ident)
+			| PseudoClass::Scope(colon, ident)
+			| PseudoClass::Target(colon, ident)
+			| PseudoClass::TargetWithin(colon, ident)
+			| PseudoClass::Valid(colon, ident)
+			| PseudoClass::Visited(colon, ident) => Into::<Span>::into(colon) + ident.into(),
+			PseudoClass::Webkit(c) => todo!(),
+			PseudoClass::Moz(c) => todo!(),
+			PseudoClass::Ms(c) => todo!(),
+			PseudoClass::O(c) => todo!(),
+		}
+	}
+}
+
 impl<'a> Visitable<'a> for PseudoClass {
 	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		todo!();
+		dbg!("visit pseudo_class");
+		v.visit_pseudo_class(self);
+		match self {
+			Self::Webkit(c) => Visitable::accept(c, v),
+			Self::Moz(c) => Visitable::accept(c, v),
+			Self::Ms(c) => Visitable::accept(c, v),
+			Self::O(c) => Visitable::accept(c, v),
+			_ => {}
+		}
 	}
 }
 

--- a/crates/hdx_ast/src/css/selector/tag.rs
+++ b/crates/hdx_ast/src/css/selector/tag.rs
@@ -106,7 +106,7 @@ impl<'a> Is<'a> for CustomElementTag {
 			return false;
 		}
 		let mut has_dash = false;
-		while let Some(char) = chars.next() {
+		for char in chars {
 			if char == '-' {
 				has_dash = true;
 				continue;
@@ -133,7 +133,7 @@ impl<'a> Is<'a> for CustomElementTag {
 				return false;
 			}
 		}
-		return has_dash;
+		has_dash
 	}
 }
 

--- a/crates/hdx_highlight/Cargo.toml
+++ b/crates/hdx_highlight/Cargo.toml
@@ -12,7 +12,9 @@ repository.workspace = true
 [dependencies]
 hdx_ast = { workspace = true }
 hdx_lexer = { workspace = true }
+
 bitmask-enum = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 hdx_parser = { workspace = true }

--- a/crates/hdx_highlight/src/lib.rs
+++ b/crates/hdx_highlight/src/lib.rs
@@ -2,6 +2,7 @@ use bitmask_enum::bitmask;
 use core::fmt;
 use hdx_lexer::Span;
 use std::collections::HashMap;
+use strum::{Display, VariantNames};
 
 mod css;
 #[cfg(test)]
@@ -12,26 +13,45 @@ mod tests;
 use css::*;
 
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokenTypes
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Display, VariantNames, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SemanticKind {
+	/* Selector Elements */
+	Id,
 	Tag,
-	Property,
+	Class,
+	Wildcard,
+	Attribute,
+	Namespace,
+	Combinator,
+	PseudoClass,
+	PseudoElement,
+	LegacyPseudoElement,
+	FunctionalPseudoClass,
+	FunctionalPseudoElement,
+
+	/* Rule Elements */
+	AtKeyword,
+	Prelude,
+
+	/* Property Declarations */
+	Declaration,
+	StyleValueKeyword,
+	StyleValueDimension,
+	StyleValueNumber,
+
 	Punctuation,
 }
 
-impl fmt::Display for SemanticKind {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			Self::Tag => write!(f, "tag"),
-			Self::Property => write!(f, "property"),
-			Self::Punctuation => write!(f, "punctuation"),
-		}
+impl SemanticKind {
+	pub fn bits(&self) -> u8 {
+		*self as u8
 	}
 }
 
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokenModifiers
+#[derive(VariantNames)]
 #[bitmask(u8)]
-enum SemanticModifier {
+pub enum SemanticModifier {
 	Unknown,
 	Deprecated,
 	Experimental,
@@ -63,6 +83,23 @@ pub struct Highlight {
 	span: Span,
 }
 
+impl Highlight {
+	#[inline(always)]
+	pub fn span(&self) -> Span {
+		self.span
+	}
+
+	#[inline(always)]
+	pub fn modifier(&self) -> SemanticModifier {
+		self.modifier
+	}
+
+	#[inline(always)]
+	pub fn kind(&self) -> SemanticKind {
+		self.kind
+	}
+}
+
 #[derive(Default)]
 pub struct TokenHighlighter {
 	highlights: HashMap<Span, Highlight>,
@@ -75,6 +112,10 @@ impl TokenHighlighter {
 
 	pub fn get(&self, span: Span) -> Option<&Highlight> {
 		self.highlights.get(&span)
+	}
+
+	pub fn highlights(&self) -> impl Iterator<Item = &Highlight> {
+		self.highlights.values()
 	}
 
 	fn insert(&mut self, span: Span, kind: SemanticKind, modifier: SemanticModifier) {

--- a/crates/hdx_highlight/src/snapshots/hdx_highlight__tests__basic.snap
+++ b/crates/hdx_highlight/src/snapshots/hdx_highlight__tests__basic.snap
@@ -9,6 +9,7 @@ expression: actual
 		.tag { color: #8ddb8c }
 		.punctuation { color: #d1d7e0 }
 		.property { color: #6cb6ff }
+		.pseudo-class { color: #6cb6ff }
 
 		.unknown { color: grey }
 		.deprecated { text-decoration: line-through }
@@ -18,7 +19,7 @@ expression: actual
 <body>
 	<pre>
 		<code>
-		<span class="tag">body</span><span class="punctuation">{</span><span class="property">appearance</span><span class="punctuation">:</span>initial<span class="punctuation">;</span><span class="property">color</span><span class="punctuation">:</span>blue<span class="punctuation">;</span><span class="property unknown">will-ever-exist</span><span class="punctuation">:</span> foo<span class="punctuation">;</span><span class="punctuation">}</span>
+		<span class="Tag">body</span><span class="Punctuation">{</span><span class="Declaration">appearance</span><span class="Punctuation">:</span>initial<span class="Punctuation">;</span><span class="Declaration">color</span><span class="Punctuation">:</span>blue<span class="Punctuation">;</span><span class="Declaration unknown">will-ever-exist</span><span class="Punctuation">:</span> foo<span class="Punctuation">;</span><span class="Punctuation">}</span>
 					</code>
 				</pre>
 			</body>

--- a/crates/hdx_highlight/src/snapshots/hdx_highlight__tests__nesting.snap
+++ b/crates/hdx_highlight/src/snapshots/hdx_highlight__tests__nesting.snap
@@ -9,6 +9,7 @@ expression: actual
 		.tag { color: #8ddb8c }
 		.punctuation { color: #d1d7e0 }
 		.property { color: #6cb6ff }
+		.pseudo-class { color: #6cb6ff }
 
 		.unknown { color: grey }
 		.deprecated { text-decoration: line-through }
@@ -18,7 +19,7 @@ expression: actual
 <body>
 	<pre>
 		<code>
-		<span class="tag">body</span><span class="punctuation">{</span><span class="tag">main</span><span class="punctuation">{</span><span class="tag">dialog</span><span class="punctuation">{</span><span class="tag">input</span><span class="punctuation">{</span><span class="punctuation">}</span><span class="punctuation">}</span><span class="punctuation">}</span><span class="punctuation">}</span>
+		<span class="Tag">body</span><span class="Punctuation">{</span><span class="Tag">main</span><span class="Punctuation">{</span><span class="Tag">dialog</span><span class="Punctuation">{</span><span class="Tag">input</span><span class="Punctuation">{</span><span class="Punctuation">}</span><span class="Punctuation">}</span><span class="Punctuation">}</span><span class="Punctuation">}</span>
 					</code>
 				</pre>
 			</body>

--- a/crates/hdx_highlight/src/snapshots/hdx_highlight__tests__tags.snap
+++ b/crates/hdx_highlight/src/snapshots/hdx_highlight__tests__tags.snap
@@ -9,6 +9,7 @@ expression: actual
 		.tag { color: #8ddb8c }
 		.punctuation { color: #d1d7e0 }
 		.property { color: #6cb6ff }
+		.pseudo-class { color: #6cb6ff }
 
 		.unknown { color: grey }
 		.deprecated { text-decoration: line-through }
@@ -18,7 +19,7 @@ expression: actual
 <body>
 	<pre>
 		<code>
-		<span class="tag">body</span>,<span class="tag">dialog</span>,<span class="tag unknown">madeup</span>,<span class="tag deprecated">marquee</span>,<span class="tag experimental">portal</span>,<span class="tag custom">custom-element</span><span class="punctuation">{</span><span class="punctuation">}</span>
+		<span class="Tag">body</span>,<span class="Tag">dialog</span>,<span class="Tag unknown">madeup</span>,<span class="Tag deprecated">marquee</span>,<span class="Tag experimental">portal</span>,<span class="Tag custom">custom-element</span><span class="Punctuation">{</span><span class="Punctuation">}</span>
 					</code>
 				</pre>
 			</body>

--- a/crates/hdx_highlight/src/tests.rs
+++ b/crates/hdx_highlight/src/tests.rs
@@ -22,3 +22,8 @@ fn test_tags() {
 fn test_nesting() {
 	assert_highlight!("nesting", r#"body{main{dialog{input{}}}}"#);
 }
+
+#[test]
+fn test_pseudo_classes() {
+	assert_highlight!("pseudo_classes", r#"body:focus,dialog:modal{}"#);
+}

--- a/crates/hdx_lexer/src/span.rs
+++ b/crates/hdx_lexer/src/span.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, hash::Hash};
+use std::{fmt::Display, hash::Hash, ops::Add};
 
 use crate::SourceOffset;
 use miette::SourceSpan;
@@ -36,8 +36,57 @@ impl Span {
 		self.end.0 - self.start.0
 	}
 
-	pub fn source_text<'a>(&self, source_text: &'a str) -> &'a str {
-		&source_text[self.start.0 as usize..self.end.0 as usize]
+	pub fn span_contents(self, source: &'_ str) -> SpanContents<'_> {
+		SpanContents::new(self, source)
+	}
+}
+
+impl Add for Span {
+	type Output = Self;
+	fn add(self, rhs: Self) -> Self::Output {
+		let start = if self.start < rhs.start { self.start } else { rhs.start };
+		let end = if self.end > rhs.end { self.end } else { rhs.end };
+		Self { start, end }
+	}
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct SpanContents<'a> {
+	span: Span,
+	source: &'a str,
+}
+
+impl<'a> SpanContents<'a> {
+	pub fn new(span: Span, source: &'a str) -> SpanContents<'a> {
+		SpanContents { span, source }
+	}
+
+	pub fn line_and_column(&self) -> (u32, u32) {
+		let mut line = 0;
+		let mut column = 0;
+		let mut offset = self.span.start.0;
+		for char in self.source.chars() {
+			if offset == 0 {
+				break;
+			}
+			if char == '\n' {
+				column = 0;
+				line += 1;
+			} else {
+				column += 1;
+			}
+			offset -= char.len_utf8() as u32;
+		}
+		(line, column)
+	}
+
+	pub fn contents(&self) -> &'a str {
+		&self.source[self.span.start.0 as usize..self.span.end.0 as usize]
+	}
+
+	pub fn size(&self) -> u32 {
+		self.span.size()
 	}
 }
 

--- a/crates/hdx_lsp/Cargo.toml
+++ b/crates/hdx_lsp/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "hdx_lsp"
+version = "0.0.0"
+authors.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+bench = false
+
+[dependencies]
+hdx_parser = { workspace = true }
+hdx_ast = { workspace = true }
+hdx_highlight = { workspace = true }
+
+bumpalo = { workspace = true, features = ["collections", "boxed"] }
+miette = { workspace = true, features = ["derive"] }
+
+smallvec = { workspace = true }
+bitmask-enum = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
+itertools = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+lsp-types = { workspace = true, features = ["proposed"] }
+crossbeam-channel = { workspace = true }
+httparse = { workspace = true }
+dashmap = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+glob = { workspace = true }
+criterion = { workspace = true, features = ["html_reports"] }
+pprof = { workspace = true, features = ["flamegraph", "criterion"] }
+insta = { workspace = true, features = ["json"] }
+similar = { workspace = true }
+console = { workspace = true }
+
+[features]
+default = []
+fancy = ["miette/fancy-no-backtrace"]

--- a/crates/hdx_lsp/src/handlers.rs
+++ b/crates/hdx_lsp/src/handlers.rs
@@ -1,0 +1,135 @@
+use bumpalo::Bump;
+use dashmap::DashMap;
+use hdx_ast::css::{StyleSheet, Visitable};
+use hdx_highlight::{SemanticKind, SemanticModifier, TokenHighlighter};
+use hdx_parser::{Features, Parser};
+use itertools::Itertools;
+use lsp_types::{
+	notification::DidOpenTextDocument,
+	request::{Initialize, SemanticTokensFullRequest},
+	InitializeResult, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
+	SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions, SemanticTokensResult,
+	SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind,
+	TextDocumentSyncOptions, TextDocumentSyncSaveOptions, Uri, WorkDoneProgressOptions,
+};
+use std::{io, sync::Arc};
+use strum::VariantNames;
+use tracing::trace;
+
+use crate::Server;
+
+pub fn server_with_handlers(version: &'static str) -> Server {
+	let files = Arc::new(DashMap::<Uri, String>::new());
+	let files_for_semantic_tokens = files.clone();
+	let files_for_open_doc = files.clone();
+	Server::new()
+		.handle::<Initialize>(move |_| -> Result<InitializeResult, io::Error> {
+			Ok(InitializeResult {
+				capabilities: ServerCapabilities {
+					// position_encoding: (),
+					text_document_sync: Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
+						open_close: Some(true),
+						change: Some(TextDocumentSyncKind::FULL),
+						will_save: Some(true),
+						will_save_wait_until: Some(false),
+						save: Some(TextDocumentSyncSaveOptions::Supported(false)),
+					})),
+					// notebook_document_sync: (),
+					// selection_range_provider: (),
+					// hover_provider: (),
+					// completion_provider: (),
+					// signature_help_provider: (),
+					// definition_provider: (),
+					// type_definition_provider: (),
+					// implementation_provider: (),
+					// references_provider: (),
+					// document_highlight_provider: (),
+					// document_symbol_provider: (),
+					// workspace_symbol_provider: (),
+					// code_action_provider: (),
+					// code_lens_provider: (),
+					// document_formatting_provider: (),
+					// document_range_formatting_provider: (),
+					// document_on_type_formatting_provider: (),
+					// rename_provider: (),
+					// document_link_provider: (),
+					// color_provider: (),
+					// folding_range_provider: (),
+					// declaration_provider: (),
+					// execute_command_provider: (),
+					// workspace: (),
+					// call_hierarchy_provider: (),
+					semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
+						SemanticTokensOptions {
+							work_done_progress_options: WorkDoneProgressOptions { work_done_progress: Some(false) },
+							legend: SemanticTokensLegend {
+								token_types: SemanticKind::VARIANTS.iter().map(|v| SemanticTokenType::new(v)).collect(),
+								token_modifiers: SemanticModifier::VARIANTS
+									.iter()
+									.map(|v| SemanticTokenModifier::new(v))
+									.collect(),
+							},
+							range: Some(false),
+							full: Some(SemanticTokensFullOptions::Delta { delta: Some(true) }),
+						},
+					)),
+					// moniker_provider: (),
+					// linked_editing_range_provider: (),
+					// inline_value_provider: (),
+					// inlay_hint_provider: (),
+					// diagnostic_provider: (),
+					// inline_completion_provider: (),
+					// experimental: (),
+					..Default::default()
+				},
+				server_info: Some(ServerInfo { name: String::from("hdx-lsp"), version: Some(version.into()) }),
+				offset_encoding: None,
+			})
+		})
+		.handle::<SemanticTokensFullRequest>(move |params| -> Result<Option<SemanticTokensResult>, io::Error> {
+			let uri = params.text_document.uri;
+			let allocator = Bump::default();
+			if let Some(source_text) = files_for_semantic_tokens.clone().get(&uri) {
+				trace!("Asked for SemanticTokens");
+				let result =
+					Parser::new(&allocator, source_text.as_str(), Features::default()).parse_entirely::<StyleSheet>();
+				if let Some(stylesheet) = result.output {
+					trace!("Sucessfully parsed stylesheet: {:#?}", &stylesheet);
+					let mut highlighter = TokenHighlighter::new();
+					stylesheet.accept(&mut highlighter);
+					let mut current_line = 0;
+					let mut current_start = 0;
+					let data = highlighter
+						.highlights()
+						.sorted_by(|a, b| Ord::cmp(&a.span(), &b.span()))
+						.map(|highlight| {
+							trace!("Highlight: {:?}", &highlight);
+							let span_contents = highlight.span().span_contents(source_text.as_str());
+							let (line, start) = span_contents.line_and_column();
+							let delta_line = line - current_line;
+							current_line = line;
+							let delta_start = if delta_line == 0 { start - current_start } else { start };
+							current_start = start;
+							SemanticToken {
+								token_type: highlight.kind().bits() as u32,
+								token_modifiers_bitset: highlight.modifier().bits() as u32,
+								delta_line,
+								delta_start,
+								length: span_contents.size(),
+							}
+						})
+						.collect();
+					return Ok(Some(SemanticTokensResult::Tokens(SemanticTokens { result_id: None, data })));
+				} else if !result.errors.is_empty() {
+					trace!("\n\nParse on {:?} failed. Saw error {:?}", &uri, result.errors);
+				}
+			}
+			Ok(None)
+		})
+		.on::<DidOpenTextDocument>(move |params| -> Result<(), io::Error> {
+			let uri = params.text_document.uri;
+			let source_text = params.text_document.text;
+			files_for_open_doc.clone().insert(uri, source_text);
+			Ok(())
+		})
+}

--- a/crates/hdx_lsp/src/jsonrpc/error_code.rs
+++ b/crates/hdx_lsp/src/jsonrpc/error_code.rs
@@ -1,0 +1,121 @@
+use serde::{Deserialize, Serialize};
+
+/// An ErrorCode representing either a [JSON-RPC Error Code](https://www.jsonrpc.org/specification#error_object) or [LSP
+/// defined error
+/// code](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#errorCodes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(into = "i32", from = "i32")]
+pub enum ErrorCode {
+	// JSON RPC Generic
+	/// Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.
+	/// [JSON-RPC defined](https://www.jsonrpc.org/specification#error_object). `-32700`.
+	ParseError,
+
+	/// The JSON sent is not a valid Request object.
+	/// [JSON-RPC defined](https://www.jsonrpc.org/specification#error_object). `-32600`.
+	InvalidRequest,
+
+	/// The method does not exist / is not available.
+	/// [JSON-RPC defined](https://www.jsonrpc.org/specification#error_object). `-32601`.
+	MethodNotFound,
+
+	/// Invalid method parameter(s).
+	/// [JSON-RPC defined](https://www.jsonrpc.org/specification#error_object). `-32602`.
+	InvalidParams,
+
+	/// Internal JSON-RPC error.
+	/// [JSON-RPC defined](https://www.jsonrpc.org/specification#error_object). `-32603`.
+	InternalError,
+
+	/// [JSON RPC Reserved Range Start](https://www.jsonrpc.org/specification#error_object).
+	/// Reserved for implementation-defined server-errors. (`-32000` to `-32099`).
+	ReservedErrorStart,
+
+	/// Error code indicating that a server received a notification or
+	/// request before the server has received the `initialize` request.
+	/// [LSP defined](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#errorCodes). `-32002`.
+	ServerNotInitialized,
+
+	/// [LSP defined](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#errorCodes). `-32001`.
+	UnknownErrorCode,
+
+	/// [JSON RPC Reserved Range End](https://www.jsonrpc.org/specification#error_object).
+	/// Reserved for implementation-defined server-errors. (`-32000` to `-32099`).
+	ReservedErrorEnd,
+
+	/// [LSP Reserved Range Start](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#errorCodes).
+	/// This is the start range of LSP reserved error codes. It doesn't denote a real error code. (`-32899` to `-32800`)
+	LspReservedErrorStart,
+
+	/// The server detected that the content of a document got modified outside normal conditions. A server should NOT
+	/// send this error code if it detects a content change in its unprocessed messages. The result even computed on
+	/// an older state might still be useful for the client.
+	///
+	/// If a client decides that a result is not of any use anymore the client should cancel the request.
+	///
+	/// [LSP defined](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#errorCodes). `-32801`.
+	ContentModified,
+
+	/// The client has canceled a request and a server has detected the cancel.
+	///
+	/// [LSP defined](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#errorCodes). `-32800`.
+	RequestCancelled,
+
+	/// [LSP Reserved Range Start](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#errorCodes).
+	/// This is the start range of LSP reserved error codes. It doesn't denote a real error code. (`-32899` to `-32800`)
+	LspReservedErrorEnd,
+
+	/// The error code is not known.
+	Unknown(i32),
+}
+
+// https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#responseMessage
+impl From<ErrorCode> for i32 {
+	fn from(value: ErrorCode) -> Self {
+		match value {
+			ErrorCode::ParseError => -32700,
+			ErrorCode::InvalidRequest => -32600,
+			ErrorCode::MethodNotFound => -32601,
+			ErrorCode::InvalidParams => -32602,
+			ErrorCode::InternalError => -32603,
+
+			// JSON RPC Reserved Range
+			ErrorCode::ReservedErrorStart => -32099,
+			ErrorCode::ServerNotInitialized => -32002,
+			ErrorCode::UnknownErrorCode => -32001,
+			ErrorCode::ReservedErrorEnd => -32000,
+
+			// LSP Reserved Range
+			ErrorCode::LspReservedErrorStart => -32899,
+			ErrorCode::ContentModified => -32801,
+			ErrorCode::RequestCancelled => -32800,
+			ErrorCode::LspReservedErrorEnd => -32800,
+
+			ErrorCode::Unknown(code) => code,
+		}
+	}
+}
+
+impl From<i32> for ErrorCode {
+	fn from(value: i32) -> Self {
+		match value {
+			-32700 => ErrorCode::ParseError,
+			-32600 => ErrorCode::InvalidRequest,
+			-32601 => ErrorCode::MethodNotFound,
+			-32602 => ErrorCode::InvalidParams,
+			-32603 => ErrorCode::InternalError,
+			// JSON RPC Reserved Range
+			-32099 => ErrorCode::ReservedErrorStart,
+			-32002 => ErrorCode::ServerNotInitialized,
+			-32001 => ErrorCode::UnknownErrorCode,
+			-32000 => ErrorCode::ReservedErrorEnd,
+
+			// LSP Reserved Range
+			-32899 => ErrorCode::LspReservedErrorStart,
+			-32801 => ErrorCode::ContentModified,
+			-32800 => ErrorCode::RequestCancelled,
+
+			code => ErrorCode::Unknown(code),
+		}
+	}
+}

--- a/crates/hdx_lsp/src/jsonrpc/id.rs
+++ b/crates/hdx_lsp/src/jsonrpc/id.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+/// A identifier for tracking [`Request`s](super::Request) and [`Response`s](super::Response).
+/// An identifier can be a String or Number if included.
+///
+/// The [JSON-RPC spec]() defines the number as ["containing no fractional
+/// parts"](https://www.jsonrpc.org/specification#id2), and LSP defines Numbers as integers
+/// ["in the range of -2^31 to 2^31 - 1"](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#integer)
+/// (so they're [`i32`] in Rust parlance).
+///
+/// Strings have no constraints on them, but for example could be a UUID.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Id {
+	Number(i32),
+	String(String),
+}
+
+impl From<&str> for Id {
+	fn from(value: &str) -> Self {
+		Self::String(value.into())
+	}
+}
+
+impl From<String> for Id {
+	fn from(value: String) -> Self {
+		Self::String(value)
+	}
+}
+
+impl From<i32> for Id {
+	fn from(value: i32) -> Self {
+		Self::Number(value)
+	}
+}

--- a/crates/hdx_lsp/src/jsonrpc/message.rs
+++ b/crates/hdx_lsp/src/jsonrpc/message.rs
@@ -1,0 +1,230 @@
+use httparse::{parse_headers, EMPTY_HEADER};
+use lsp_types::notification::{Exit, Notification as NotificationTrait};
+use serde::{Deserialize, Serialize};
+use serde_json::to_string;
+use std::io;
+
+use crate::{Notification, Request, Response};
+
+/// JSON RPC Message
+/// This represents a single message coming in or going out, that is
+/// compliant with the [JSON-RPC 2.0 spec](https://www.jsonrpc.org/specification).
+/// It wraps the [`Request`], [`Response`] and [`Notification`] structs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Message {
+	/// Wraps the [`Request`] object.
+	Request(Request),
+	/// Wraps the [`Response`] object.
+	Response(Response),
+	/// Wraps the [`Notification`] object.
+	Notification(Notification),
+}
+
+impl Message {
+	#[doc(hidden)]
+	#[inline]
+	pub fn is_exit_notification(&self) -> bool {
+		if let Message::Notification(notification) = self {
+			matches!(notification.method.as_str(), "exit")
+		} else {
+			false
+		}
+	}
+}
+
+impl Message {
+	pub fn read(r: &mut impl io::BufRead) -> Result<Option<Message>, ParseError> {
+		let mut buf = String::new();
+		// Consume all headers - either end of stream or "\r\n\r\n"
+		loop {
+			// No more content, therefore no message
+			if r.read_line(&mut buf)? == 0 {
+				return Ok(None);
+			}
+			if buf.ends_with("\r\n\r\n") {
+				break;
+			}
+		}
+		let mut headers = [EMPTY_HEADER; 2];
+		if let httparse::Status::Complete((size, _)) = parse_headers(buf.as_bytes(), &mut headers)? {
+			if size != buf.len() {
+				Err(ParseError::HeaderDecodeMismatch(size, buf.len()))?
+			}
+		}
+		let mut content_length = 0;
+		for header in &headers {
+			if header.name.eq_ignore_ascii_case("content-length") {
+				content_length = std::str::from_utf8(header.value)?.parse::<usize>()?;
+			} else if header.name.eq_ignore_ascii_case("content-type") {
+				// ¯\_(ツ)_/¯
+			} else if header != &EMPTY_HEADER {
+				Err(ParseError::InvalidHeader(header.name.to_owned()))?
+			}
+		}
+		if content_length == 0 {
+			Err(ParseError::NoLength)?
+		}
+		buf.clear();
+		let mut buf = buf.into_bytes();
+		buf.resize(content_length, 0);
+		r.read_exact(&mut buf)?;
+		let message: Message = serde_json::from_slice(buf.as_slice())?;
+		Ok(Some(message))
+	}
+
+	pub fn write(self, w: &mut impl io::Write) -> io::Result<()> {
+		#[derive(Serialize)]
+		struct JSONRPCMessage {
+			jsonrpc: &'static str,
+			#[serde(flatten)]
+			message: Message,
+		}
+		let msg = to_string(&JSONRPCMessage { jsonrpc: "2.0", message: self })?;
+		write!(w, "Content-Length: {}\r\n\r\n", msg.len())?;
+		w.write_all(msg.as_bytes())?;
+		w.flush()?;
+		Ok(())
+	}
+}
+
+#[derive(Debug)]
+pub enum ParseError {
+	NoLength,
+	CouldNotDecodeHeader,
+	HeaderDecodeMismatch(usize, usize),
+	InvalidHeader(String),
+	Encode(io::Error),
+	Utf8(std::str::Utf8Error),
+	InvalidContentLength(std::num::ParseIntError),
+	Headers(httparse::Error),
+	Body(serde_json::Error),
+}
+
+impl From<ParseError> for io::Error {
+	fn from(error: ParseError) -> Self {
+		match error {
+			ParseError::NoLength => io::Error::new(io::ErrorKind::InvalidData, "could not read content-length header"),
+			ParseError::CouldNotDecodeHeader => io::Error::new(io::ErrorKind::InvalidData, "could not decode headers"),
+			ParseError::HeaderDecodeMismatch(expected, actual) => io::Error::new(
+				io::ErrorKind::InvalidData,
+				format!("failed to fully parse headers, expected {expected} but parsing ended at {actual} bytes"),
+			),
+			ParseError::InvalidHeader(string) => {
+				io::Error::new(io::ErrorKind::InvalidData, format!("saw invalid header {string}"))
+			}
+			ParseError::Encode(e) => e,
+			ParseError::Utf8(e) => io::Error::new(io::ErrorKind::InvalidData, format!("Utf8 decode error: {e}")),
+			ParseError::InvalidContentLength(e) => {
+				io::Error::new(io::ErrorKind::InvalidData, format!("invalid content-length: {e}"))
+			}
+			ParseError::Headers(e) => io::Error::new(io::ErrorKind::InvalidData, format!("invalid headers: {e}")),
+			ParseError::Body(e) => io::Error::new(io::ErrorKind::InvalidData, format!("invalid body: {e}")),
+		}
+	}
+}
+
+impl From<io::Error> for ParseError {
+	fn from(error: io::Error) -> Self {
+		ParseError::Encode(error)
+	}
+}
+
+impl From<httparse::Error> for ParseError {
+	fn from(error: httparse::Error) -> Self {
+		ParseError::Headers(error)
+	}
+}
+
+impl From<serde_json::Error> for ParseError {
+	fn from(error: serde_json::Error) -> Self {
+		ParseError::Body(error)
+	}
+}
+
+impl From<std::num::ParseIntError> for ParseError {
+	fn from(error: std::num::ParseIntError) -> Self {
+		ParseError::InvalidContentLength(error)
+	}
+}
+
+impl From<std::str::Utf8Error> for ParseError {
+	fn from(error: std::str::Utf8Error) -> Self {
+		ParseError::Utf8(error)
+	}
+}
+
+impl From<Request> for Message {
+	fn from(request: Request) -> Message {
+		Message::Request(request)
+	}
+}
+
+impl From<Response> for Message {
+	fn from(response: Response) -> Message {
+		Message::Response(response)
+	}
+}
+
+impl From<Notification> for Message {
+	fn from(notification: Notification) -> Message {
+		Message::Notification(notification)
+	}
+}
+
+pub enum MessageError {
+	MethodNotFound,
+	MethodMistmatch(String, String),
+	JsonError(serde_json::Error),
+}
+
+#[cfg(test)]
+mod tests {
+	use std::str::from_utf8;
+
+	use super::*;
+	use lsp_types::request::{Initialize, Request as RequestTrait};
+	use serde_json::{from_str, json};
+
+	pub fn into_http_bytes(str: &str) -> String {
+		format!("Content-Length: {}\r\n\r\n{}", str.len(), str)
+	}
+
+	#[test]
+	fn test_message_deserialize() {
+		assert_eq!(
+			from_str::<Message>(r#"{"jsonrpc": "2.0","method": "initialize", "params": null, "id": 1}"#).unwrap(),
+			Message::Request(Request { id: 1.into(), method: Initialize::METHOD.into(), params: json!(null) })
+		);
+		assert_eq!(
+			from_str::<Message>(r#"{"jsonrpc": "2.0","method": "initialize", "params": [1,2], "id": "a"}"#).unwrap(),
+			Message::Request(Request { id: "a".into(), method: Initialize::METHOD.into(), params: json!([1, 2]) })
+		);
+		assert_eq!(
+			from_str::<Message>(r#"{"jsonrpc": "2.0","result": "foo","id":8}"#).unwrap(),
+			Message::Response(Response::Ok(8.into(), json!("foo")))
+		);
+		assert_eq!(
+			from_str::<Message>(r#"{"jsonrpc": "2.0","method": "exit"}"#).unwrap(),
+			Message::Notification(Notification { method: "exit".into(), params: json!(null) })
+		);
+	}
+
+	#[test]
+	fn test_message_read_from_bufreader() {
+		let r = into_http_bytes(r#"{"jsonrpc": "2.0","method": "initialize", "params": null, "id": 1}"#);
+		assert_eq!(
+			Message::read(&mut r.as_bytes()).unwrap(),
+			Some(Message::Request(Request { id: 1.into(), method: "initialize".into(), params: json!(null) }))
+		);
+	}
+
+	#[test]
+	fn test_message_write_to_bufreader() {
+		let mut bytes = vec![];
+		Message::Request(Request { id: 1.into(), method: "initialize".into(), params: json!(null) })
+			.write(&mut bytes)
+			.unwrap();
+		assert_eq!(from_utf8(&bytes).unwrap(), into_http_bytes(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#));
+	}
+}

--- a/crates/hdx_lsp/src/jsonrpc/mod.rs
+++ b/crates/hdx_lsp/src/jsonrpc/mod.rs
@@ -1,0 +1,17 @@
+mod error_code;
+mod id;
+mod message;
+// mod method;
+mod notification;
+mod request;
+mod response;
+mod tracing_layer;
+
+pub use error_code::ErrorCode;
+pub use id::Id;
+pub use message::{Message, MessageError};
+// pub use method::Method;
+pub use notification::Notification;
+pub use request::Request;
+pub use response::Response;
+pub use tracing_layer::TracingLayer;

--- a/crates/hdx_lsp/src/jsonrpc/notification.rs
+++ b/crates/hdx_lsp/src/jsonrpc/notification.rs
@@ -1,0 +1,21 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{to_value, Value};
+
+/// A notification message. A processed notification message must not send a response back. They work like events.
+///
+/// As defined in [JSON-RPC](https://www.jsonrpc.org/specification#notification) and [LSP](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#notificationMessage).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct Notification {
+	pub method: String,
+	#[serde(default = "serde_json::Value::default", skip_serializing_if = "serde_json::Value::is_null")]
+	pub params: Value,
+}
+
+impl Notification {
+	pub fn new<T>(params: T::Params) -> Notification
+	where
+		T: lsp_types::request::Request,
+	{
+		Notification { method: T::METHOD.into(), params: to_value(params).unwrap() }
+	}
+}

--- a/crates/hdx_lsp/src/jsonrpc/request.rs
+++ b/crates/hdx_lsp/src/jsonrpc/request.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{to_value, Value};
+
+use super::Id;
+
+/// A request message to describe a request between the client and the server. Every processed request must send a response back to the sender of the request.
+///
+/// As defined in [JSON-RPC](https://www.jsonrpc.org/specification#request_object) and [LSP](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#requestMessage).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct Request {
+	pub id: Id,
+	pub method: String,
+	#[serde(default = "serde_json::Value::default", skip_serializing_if = "serde_json::Value::is_null")]
+	pub params: Value,
+}
+
+impl Request {
+	pub fn new<T>(id: Id, params: T::Params) -> Request
+	where
+		T: lsp_types::request::Request,
+	{
+		Request { id, method: T::METHOD.into(), params: to_value(params).unwrap() }
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use lsp_types::request::{Initialize, Request as RequestTrait};
+
+	use super::*;
+
+	#[test]
+	fn test_request_deserialize() {
+		assert_eq!(
+			serde_json::from_str::<Request>(r#"{"id":0, "method": "initialize", "params": null}"#).unwrap(),
+			Request { id: 0.into(), params: Value::Null, method: Initialize::METHOD.into() }
+		);
+	}
+}

--- a/crates/hdx_lsp/src/jsonrpc/response.rs
+++ b/crates/hdx_lsp/src/jsonrpc/response.rs
@@ -1,0 +1,149 @@
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
+use serde_json::{json, to_value, Value};
+
+use super::{ErrorCode, Id};
+
+/// A Response Message sent as a result of a request
+///
+/// As defined in [JSON-RPC](https://www.jsonrpc.org/specification#response_object) and [LSP](https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#responseMessage).
+///
+/// Can either be [`Ok`] (the response had a `result`, and did not have attached `error` information),
+/// or as [`Err`] (the response had no `result`, instead having attached `error` information).
+///
+/// Both [`Ok`] and [`Err`] have an [`Id`] which matches the [`Id`] of the [`super::Request`] object.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Response {
+	/// [`Ok`]s also have an optional payload (serialised as a serde [`Value`]) which may contain more data about the
+	/// response, such as computed values.
+	Ok(Id, Value),
+	/// [`Err`]s also have an [`ErrorCode`] to determine which error occurred, an informatinal [`String`], and may contain
+	/// additional data (serialised as serde [`Value`]).
+	Err(Id, ErrorCode, String, Value),
+}
+
+impl Serialize for Response {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		#[derive(Serialize)]
+		struct Res<'a> {
+			id: &'a Id,
+			result: Option<&'a Value>,
+			error: Option<Value>,
+		}
+		if let Response::Ok(id, value) = self {
+			Res { id, result: Some(value), error: None }.serialize(serializer)
+		} else if let Response::Err(id, code, message, value) = self {
+			Res {
+				id,
+				result: None,
+				error: Some(json!({
+					"code": code, "message": message, "data": value
+				})),
+			}
+			.serialize(serializer)
+		} else {
+			unreachable!()
+		}
+	}
+}
+
+impl<'de> Deserialize<'de> for Response {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		#[derive(Deserialize)]
+		struct Err {
+			code: i32,
+			message: String,
+			#[serde(default = "serde_json::Value::default")]
+			data: Value,
+		}
+
+		#[derive(Deserialize)]
+		struct Res {
+			id: Id,
+			result: Option<Value>,
+			error: Option<Err>,
+		}
+
+		let res = Res::deserialize(deserializer)?;
+		if let Some(result) = res.result {
+			if res.error.is_some() {
+				Err(Error::duplicate_field("error"))?
+			}
+			Ok(Response::Ok(res.id, result))
+		} else if let Some(error) = res.error {
+			if res.result.is_some() {
+				Err(Error::duplicate_field("result"))?
+			}
+			Ok(Response::Err(res.id, error.code.into(), error.message, error.data))
+		} else {
+			Err(Error::missing_field("result"))?
+		}
+	}
+}
+
+impl Response {
+	pub fn new_ok<T>(id: Id, result: T) -> Response
+	where
+		T: Serialize,
+	{
+		Response::Ok(id, to_value(result).unwrap())
+	}
+
+	pub fn new_err<T>(id: Id, error_code: ErrorCode, message: String, value: T) -> Response
+	where
+		T: Serialize,
+	{
+		Response::Err(id, error_code, message, to_value(value).unwrap())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use serde_json::{from_str, json};
+
+	use super::*;
+
+	#[test]
+	fn test_response_deserialize() {
+		assert_eq!(from_str::<Response>(r#"{"id":3, "result":7}"#).unwrap(), Response::Ok(3.into(), json!(7)));
+		assert_eq!(
+			from_str::<Response>(r#"{"id":4, "result":["a", "b"]}"#).unwrap(),
+			Response::Ok(4.into(), json!(["a", "b"]))
+		);
+		assert_eq!(
+			from_str::<Response>(r#"{"id":"a", "error":{"code": -32700, "message": "Parse error"}}"#).unwrap(),
+			Response::Err("a".into(), ErrorCode::ParseError, "Parse error".into(), Value::Null)
+		);
+		assert_eq!(
+			from_str::<Response>(
+				r#"{"id":"foo", "error":{"code": -32600, "message": "Invalid Request", "data": ["foo"]}}"#
+			)
+			.unwrap(),
+			Response::Err("foo".into(), ErrorCode::InvalidRequest, "Invalid Request".into(), json!(["foo"]))
+		);
+	}
+
+	#[test]
+	fn test_response_deserialize_error() {
+		// Missing result/error
+		assert!(matches!(from_str::<Response>(r#"{"id":3}"#), Err(_)));
+
+		// Missing error Code/Message
+		assert!(matches!(from_str::<Response>(r#"{"id":3, "error":{}}"#), Err(_)));
+
+		// Missing error Message
+		assert!(matches!(from_str::<Response>(r#"{"id":3, "error":{"code":0}}"#), Err(_)));
+
+		// Missing error Code
+		assert!(matches!(from_str::<Response>(r#"{"id":3, "error":{"message":""}}"#), Err(_)));
+
+		// Both error/result present
+		assert!(matches!(from_str::<Response>(r#"{"id":3, "error":{"code":0, "message": ""}, "result":7}"#), Err(_)));
+		assert!(matches!(from_str::<Response>(r#"{"id":3, "result":7, "error":{"code":0, "message": ""}}"#), Err(_)));
+	}
+}

--- a/crates/hdx_lsp/src/jsonrpc/tracing_layer.rs
+++ b/crates/hdx_lsp/src/jsonrpc/tracing_layer.rs
@@ -1,0 +1,111 @@
+use std::collections::BTreeMap;
+
+use crossbeam_channel::Sender;
+use lsp_types::{
+	notification::{LogMessage, LogTrace, Notification as NotificationTrait},
+	LogMessageParams, LogTraceParams, MessageType,
+};
+use serde::Serialize;
+use serde_json::{to_string_pretty, to_value};
+use tracing::{level_filters::LevelFilter, Event, Level, Subscriber};
+use tracing_subscriber::{layer::Context, Layer};
+
+use super::{Message, Notification};
+
+pub struct TracingLayer {
+	level: LevelFilter,
+	sender: Sender<Message>,
+}
+
+impl TracingLayer {
+	pub fn new(sender: Sender<Message>) -> Self {
+		Self { level: LevelFilter::OFF, sender }
+	}
+}
+// lsp_types::notification::LogTrace
+// lsp_types::notification::LogMessage
+
+#[derive(Default, Serialize)]
+struct MessageVisitor(BTreeMap<String, String>);
+
+impl MessageVisitor {
+	pub fn insert(&mut self, str: &str, string: String) {
+		self.0.insert(str.into(), string);
+	}
+}
+
+impl tracing::field::Visit for MessageVisitor {
+	fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+		self.insert(field.name(), format!("{:?}", value));
+	}
+
+	fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+		self.insert(field.name(), format!("{:?}", value));
+	}
+
+	fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+		self.insert(field.name(), format!("{:?}", value));
+	}
+
+	fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+		self.insert(field.name(), format!("{:?}", value));
+	}
+
+	fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+		self.insert(field.name(), format!("{:?}", value));
+	}
+
+	fn record_error(&mut self, field: &tracing::field::Field, value: &(dyn std::error::Error + 'static)) {
+		self.insert(field.name(), format!("{:?}", value));
+	}
+
+	fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+		self.insert(field.name(), format!("{:?}", value));
+	}
+}
+
+impl<S> Layer<S> for TracingLayer
+where
+	S: Subscriber,
+{
+	fn on_event(&self, event: &Event, _ctx: Context<'_, S>) {
+		if event.metadata().level() > &self.level {
+			return;
+		}
+		let name = event.metadata().name();
+		let mut fields = MessageVisitor::default();
+		fields.insert("name", event.metadata().name().into());
+		fields.insert("level", event.metadata().level().as_str().into());
+		event.record(&mut fields);
+		let output = serde_json::json!(fields);
+
+		let level = match event.metadata().level() {
+			&Level::ERROR => MessageType::ERROR,
+			&Level::WARN => MessageType::WARNING,
+			&Level::INFO => MessageType::INFO,
+			&Level::DEBUG | &Level::TRACE => {
+				let message = Message::Notification(Notification {
+					method: LogTrace::METHOD.into(),
+					params: to_value(LogTraceParams {
+						verbose: None,
+						message: to_string_pretty(&output).ok().unwrap_or_default(),
+					})
+					.unwrap_or_default(),
+				});
+				self.sender.send(message).ok();
+				return;
+			}
+		};
+
+		let message = Message::Notification(Notification {
+			method: LogMessage::METHOD.into(),
+			params: to_value(LogMessageParams {
+				typ: MessageType::LOG,
+				message: to_string_pretty(&output).ok().unwrap_or_default(),
+			})
+			.unwrap_or_default(),
+		});
+
+		self.sender.send(message).ok();
+	}
+}

--- a/crates/hdx_lsp/src/lib.rs
+++ b/crates/hdx_lsp/src/lib.rs
@@ -1,0 +1,10 @@
+mod handlers;
+mod jsonrpc;
+mod server;
+
+#[doc(inline)]
+pub use jsonrpc::*;
+#[doc(inline)]
+pub use server::*;
+
+pub use handlers::*;

--- a/crates/hdx_lsp/src/server.rs
+++ b/crates/hdx_lsp/src/server.rs
@@ -1,0 +1,297 @@
+//! A library for handling LSP servers
+//!
+//! This implements the core parts of the [LSP Specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/)
+//! which is a [JSON-RPC 2.0](https://www.jsonrpc.org/specification) based protocol.
+//!
+//! A [`Server`] can be instantiated via [`Server::listen_stdio`] (or [`Server::raw_channels`] can be used for testing)
+//!
+
+use crossbeam_channel::{bounded, Receiver, Sender};
+use dashmap::DashMap;
+use lsp_types::request::{Initialize, Request as RequestTrait};
+use serde_json::{from_value, to_value, Value};
+use std::{
+	io,
+	sync::Arc,
+	thread::{Builder, JoinHandle},
+};
+use tracing::{debug, trace, warn};
+
+use crate::{ErrorCode, TracingLayer};
+
+use super::{Message, Notification, Request, Response};
+
+pub struct ThreadConnection {
+	pub sender: JoinHandle<io::Result<()>>,
+	pub receiver: JoinHandle<io::Result<()>>,
+}
+
+impl ThreadConnection {
+	pub fn is_finished(&self) -> bool {
+		self.sender.is_finished() || self.receiver.is_finished()
+	}
+}
+
+/// A set of Sender/Receiver objects for passing [`Message`s](Message) around.
+pub struct Server {
+	write_sender: Sender<Message>,
+	write_receiver: Receiver<Message>,
+	read_sender: Sender<Message>,
+	handler: JoinHandle<io::Result<()>>,
+	read_receiver: Receiver<Message>,
+	request_handlers: Arc<DashMap<&'static str, RequestHandler>>,
+	notification_handlers: Arc<DashMap<&'static str, NotificationHandler>>,
+}
+
+struct RequestHandler {
+	handle: Box<dyn Fn(&Request) -> Response + Send + Sync>,
+}
+
+impl RequestHandler {
+	fn new<T, F>(handle: F) -> Self
+	where
+		T: lsp_types::request::Request,
+		F: Fn(T::Params) -> Result<T::Result, io::Error> + Sized + Send + Sync + 'static,
+	{
+		Self {
+			handle: Box::new(move |request| {
+				trace!("Deserializing params ({:#?}) into value", &request.params);
+				let params = from_value(request.params.clone());
+				if let Ok(params) = params {
+					trace!("Parsed params successfully, calling handler");
+					let result = handle(params);
+					if let Ok(result) = result {
+						trace!("Handler returned good result, turning into generic value");
+						return if let Ok(value) = to_value(result) {
+							trace!("Handler Responding {:?}, {:#?}", &request.id, &value);
+							Response::Ok(request.id.clone(), value)
+						} else {
+							trace!("Result failed to_value encode");
+							Response::Err(
+								request.id.clone(),
+								ErrorCode::InternalError,
+								"failed to encode response".into(),
+								Value::Null,
+							)
+						};
+					}
+				}
+				trace!("Failed to deserialize params");
+				Response::Err(
+					request.id.clone(),
+					ErrorCode::InvalidParams,
+					"could not parse params".into(),
+					Value::Null,
+				)
+			}),
+		}
+	}
+}
+
+struct NotificationHandler {
+	handle: Box<dyn Fn(&Notification) -> Result<(), io::Error> + Send + Sync>,
+}
+
+impl NotificationHandler {
+	fn new<T, F>(handle: F) -> Self
+	where
+		T: lsp_types::notification::Notification,
+		F: Fn(T::Params) -> Result<(), io::Error> + Sized + Send + Sync + 'static,
+	{
+		Self {
+			handle: Box::new(move |request| {
+				trace!("Deserializing params ({:#?}) into value", &request.params);
+				let params = from_value(request.params.clone());
+				if let Ok(params) = params {
+					trace!("Parsed params successfully, calling handler");
+					let result = handle(params);
+					trace!("Handler was: {:?}", &result);
+					result
+				} else {
+					Ok(())
+				}
+			}),
+		}
+	}
+}
+
+impl Default for Server {
+	fn default() -> Self {
+		let (write_sender, write_receiver) = bounded::<Message>(0);
+		let (read_sender, read_receiver) = bounded::<Message>(0);
+		let request_handlers: Arc<DashMap<&'static str, RequestHandler>> = Arc::new(DashMap::new());
+		let notification_handlers: Arc<DashMap<&'static str, NotificationHandler>> = Arc::new(DashMap::new());
+
+		let handler_request_handlers = request_handlers.clone();
+		let handler_notification_handlers = notification_handlers.clone();
+		let handler_receiver = read_receiver.clone();
+		let handler_sender = write_sender.clone();
+		let mut initialized = false;
+		let handler = Builder::new()
+			.name("LspMessageHandler".into())
+			.spawn(move || {
+				while let Ok(message) = handler_receiver.recv() {
+					debug!("LspMessageHandler -> {:#?}", &message);
+					let exit = message.is_exit_notification();
+					if exit {
+						break;
+					}
+					if let Message::Request(request) = &message {
+						if let Some(handler) = handler_request_handlers.get(request.method.as_str()) {
+							if !initialized && request.method.as_str() != Initialize::METHOD {
+								debug!("Skipping method {:?} before initialization", request.method.as_str());
+								continue;
+							}
+							debug!("Found RequestHandler for {:?}", request.method.as_str());
+							let response = (handler.handle)(request);
+							debug!("RequestHandler <- {:#?}", &response);
+							if let Err(e) = handler_sender.send(Message::Response(response)) {
+								warn!("Handler failed to send response {:?}", &e);
+								return Err(io::Error::new(io::ErrorKind::Other, e));
+							}
+							if !initialized && request.method.as_str() == Initialize::METHOD {
+								debug!("Intialized successfully");
+								initialized = true;
+							}
+						} else {
+							warn!("Could not find handler for request {:?}", request.method.as_str());
+							let response = Response::Err(
+								request.id.clone(),
+								ErrorCode::MethodNotFound,
+								format!("MethodNotFound: {:?}", request.method.as_str()),
+								Value::Null,
+							);
+							if let Err(e) = handler_sender.send(Message::Response(response)) {
+								warn!("Handler failed to send response {:?}", &e);
+								return Err(io::Error::new(io::ErrorKind::Other, e));
+							}
+						}
+					} else if let Message::Notification(notification) = &message {
+						if let Some(handler) = handler_notification_handlers.get(notification.method.as_str()) {
+							debug!("Found NotificationHandler for {:?}", notification.method.as_str());
+							let response = (handler.handle)(notification);
+							debug!("NotificationHandler <- {:#?}", &response);
+						} else {
+							warn!("Could not find handler for notification {:?}", notification.method.as_str());
+						}
+					}
+				}
+				warn!("LspMessageHandler closing, channel closed");
+				Ok(())
+			})
+			.expect("Failed to create Reader");
+		Server {
+			write_sender,
+			write_receiver,
+			read_sender,
+			read_receiver,
+			request_handlers,
+			notification_handlers,
+			handler,
+		}
+	}
+}
+
+impl Server {
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	pub fn listen_stdio(&self) -> Result<ThreadConnection, io::Error> {
+		let write_receiver = self.write_receiver.clone();
+		let writer = Builder::new().name("LspWriter".into()).spawn(move || {
+			trace!("LSPWRITER");
+			let mut stdout = io::stdout().lock();
+			while let Ok(message) = write_receiver.recv() {
+				trace!("{:?}", message);
+				message.write(&mut stdout)?;
+			}
+			Ok(())
+		})?;
+		let read_sender = self.read_sender.clone();
+		let reader = Builder::new().name("LspReader".into()).spawn(move || {
+			trace!("LSPREADER");
+			let mut stdin = io::stdin().lock();
+			while let Some(message) = Message::read(&mut stdin)? {
+				if let Err(e) = read_sender.send(message) {
+					return Err(io::Error::new(io::ErrorKind::Other, e));
+				}
+			}
+			Ok(())
+		})?;
+		Ok(ThreadConnection { sender: reader, receiver: writer })
+	}
+
+	pub fn tracer(&self) -> TracingLayer {
+		TracingLayer::new(self.write_sender.clone())
+	}
+
+	#[cfg(test)]
+	pub fn raw_channels(&self) -> (Sender<Message>, Receiver<Message>) {
+		(self.read_sender.clone(), self.write_receiver.clone())
+	}
+
+	pub fn handle<T: lsp_types::request::Request>(
+		self,
+		handler: impl Fn(T::Params) -> Result<T::Result, io::Error> + Send + Sync + 'static,
+	) -> Self {
+		self.request_handlers.insert(T::METHOD, RequestHandler::new::<T, _>(handler));
+		self
+	}
+
+	pub fn on<T: lsp_types::notification::Notification>(
+		self,
+		handler: impl Fn(T::Params) -> Result<(), io::Error> + Send + Sync + 'static,
+	) -> Self {
+		self.notification_handlers.insert(T::METHOD, NotificationHandler::new::<T, _>(handler));
+		self
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use lsp_types::{
+		request::{GotoDeclaration, GotoDeclarationResponse, Request as RequestTrait},
+		InitializeParams, InitializeResult,
+	};
+	use serde_json::json;
+	use tracing::level_filters::LevelFilter;
+	use tracing_subscriber::{fmt, registry, Layer};
+
+	#[test]
+	fn smoke_test() {
+		let stderr_log = fmt::layer().with_writer(io::stderr).with_filter(LevelFilter::TRACE);
+		let server = Server::new()
+			.handle::<Initialize>(move |_| -> Result<InitializeResult, io::Error> {
+				Ok(InitializeResult { ..Default::default() })
+			})
+			.handle::<GotoDeclaration>(move |_| -> Result<Option<GotoDeclarationResponse>, io::Error> { Ok(None) });
+		registry().with(stderr_log).with(server.tracer()).init();
+		let (sender, receiver) = server.raw_channels();
+		sender
+			.send(Message::Request(Request {
+				id: 1.into(),
+				method: Initialize::METHOD.into(),
+				params: to_value(InitializeParams { ..Default::default() }).unwrap(),
+			}))
+			.unwrap();
+		assert_eq!(receiver.recv(), Ok(Message::Response(Response::Ok(1.into(), json!({"capabilities": {}})))));
+		sender
+			.send(Message::Request(Request {
+				id: 1.into(),
+				method: GotoDeclaration::METHOD.into(),
+				params: json!({
+					"textDocument": {
+						"uri": "foo/bar",
+					},
+					"position": {
+						"line": 1,
+						"character": 1
+					}
+				}),
+			}))
+			.unwrap();
+		assert_eq!(receiver.recv(), Ok(Message::Response(Response::Ok(1.into(), Value::Null))));
+	}
+}

--- a/crates/hdx_lsp/src/server.rs
+++ b/crates/hdx_lsp/src/server.rs
@@ -257,7 +257,7 @@ mod tests {
 	};
 	use serde_json::json;
 	use tracing::level_filters::LevelFilter;
-	use tracing_subscriber::{fmt, registry, Layer};
+	use tracing_subscriber::{fmt, registry, Layer, layer::SubscriberExt};
 
 	#[test]
 	fn smoke_test() {

--- a/crates/hdx_lsp/src/server.rs
+++ b/crates/hdx_lsp/src/server.rs
@@ -257,7 +257,7 @@ mod tests {
 	};
 	use serde_json::json;
 	use tracing::level_filters::LevelFilter;
-	use tracing_subscriber::{fmt, registry, Layer, layer::SubscriberExt};
+	use tracing_subscriber::{fmt, layer::SubscriberExt, registry, util::SubscriberInitExt, Layer};
 
 	#[test]
 	fn smoke_test() {

--- a/crates/hdx_parser/Cargo.toml
+++ b/crates/hdx_parser/Cargo.toml
@@ -18,8 +18,6 @@ hdx_lexer = { workspace = true }
 hdx_syntax = { workspace = true }
 hdx_atom = { workspace = true }
 
-closestmatch = { workspace = true }
-
 bumpalo = { workspace = true }
 smallvec = { workspace = true }
 

--- a/crates/hdx_parser/src/token_macros.rs
+++ b/crates/hdx_parser/src/token_macros.rs
@@ -79,27 +79,25 @@ macro_rules! kind_ident {
 
 		impl From<$ident> for ::hdx_lexer::Token {
 			fn from(value: $ident) -> Self {
-				value.0.into()
+				value.0.token()
 			}
 		}
 
 		impl From<&$ident> for ::hdx_lexer::Token {
 			fn from(value: &$ident) -> Self {
-				let t: ::hdx_lexer::Token = value.into();
-				t
+				value.0.token()
 			}
 		}
 
 		impl From<$ident> for ::hdx_lexer::Span {
 			fn from(value: $ident) -> Self {
-				value.0.into()
+				value.0.span()
 			}
 		}
 
 		impl From<&$ident> for ::hdx_lexer::Span {
 			fn from(value: &$ident) -> Self {
-				let t: ::hdx_lexer::Span = value.into();
-				t
+				value.0.span()
 			}
 		}
 
@@ -143,6 +141,18 @@ macro_rules! custom_delim {
 		}
 
 		impl From<&$ident> for ::hdx_lexer::Token {
+			fn from(value: &$ident) -> Self {
+				value.0.into()
+			}
+		}
+
+		impl From<$ident> for ::hdx_lexer::Span {
+			fn from(value: $ident) -> Self {
+				value.0.into()
+			}
+		}
+
+		impl From<&$ident> for ::hdx_lexer::Span {
 			fn from(value: &$ident) -> Self {
 				value.0.into()
 			}

--- a/packages/hdx_vscode/.oxlintrc.json
+++ b/packages/hdx_vscode/.oxlintrc.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "./node_modules/oxlint/configuration_schema.json",
+	"plugins": ["import", "typescript", "unicorn", "oxc"],
+	"env": {
+		"browser": true
+	},
+	"settings": {},
+	"rules": {
+		"import/no-cycle": "error"
+	},
+	"ignorePatterns": [".vscode-test/**/*", "node_modules/**/*"],
+	"overrides": [
+		{
+			"files": ["./tests/"],
+			"rules": {
+				"@typescript-eslint/no-explicit-any": "off"
+			}
+		}
+	]
+}

--- a/packages/hdx_vscode/.prettierignore
+++ b/packages/hdx_vscode/.prettierignore
@@ -1,0 +1,1 @@
+.vscode-test/

--- a/packages/hdx_vscode/.vscode-test.cjs
+++ b/packages/hdx_vscode/.vscode-test.cjs
@@ -1,0 +1,2 @@
+const { defineConfig } = require("@vscode/test-cli");
+module.exports = defineConfig({ files: "tests/**.ts" });

--- a/packages/hdx_vscode/.vscode/launch.json
+++ b/packages/hdx_vscode/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Run Extension (DEBUG)",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"env": {
+				"HDX_SERVER_PATH": "${workspaceFolder}/../../target/debug/hdx"
+			},
+			"skipFiles": ["<node_internals>/**/*.js", "/opt/visual-studio-code/**/*.js"],
+			"args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+			"outFiles": ["${workspaceFolder}/src/main.js"]
+		},
+		{
+			"name": "Run Extension Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--disable-extensions",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/tests/run-tests.mjs"
+			],
+			"outFiles": ["${workspaceFolder}/out/tests/**/*.js"]
+		}
+	]
+}

--- a/packages/hdx_vscode/.vscode/tasks.json
+++ b/packages/hdx_vscode/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"type": "npm",
+			"script": "watch-tests",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/packages/hdx_vscode/package-lock.json
+++ b/packages/hdx_vscode/package-lock.json
@@ -1,0 +1,4651 @@
+{
+	"name": "hdx_vscode",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "hdx_vscode",
+			"version": "1.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"@vscode/test-cli": "^0.0.10",
+				"vscode-languageclient": "^9.0.1"
+			},
+			"devDependencies": {
+				"@types/mocha": "^10.0.10",
+				"@types/node": "^22.10.1",
+				"@types/vscode": "^1.95.0",
+				"@typescript-eslint/eslint-plugin": "^8.16.0",
+				"@typescript-eslint/parser": "^8.16.0",
+				"@vscode/test-electron": "^2.4.1",
+				"esbuild": "^0.24.0",
+				"mocha": "^10.8.2",
+				"oxlint": "^0.13.2",
+				"prettier": "^3.4.1",
+				"tinyglobby": "^0.2.10",
+				"typescript": "^5.7.2",
+				"vscode": "^1.1.34"
+			},
+			"engines": {
+				"vscode": "^1.95.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/keithamus"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"license": "MIT"
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
+			"integrity": "sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
+			"integrity": "sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
+			"integrity": "sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
+			"integrity": "sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
+			"integrity": "sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
+			"integrity": "sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
+			"integrity": "sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
+			"integrity": "sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
+			"integrity": "sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
+			"integrity": "sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
+			"integrity": "sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
+			"integrity": "sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
+			"integrity": "sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
+			"integrity": "sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
+			"integrity": "sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
+			"integrity": "sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
+			"integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
+			"integrity": "sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz",
+			"integrity": "sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
+			"integrity": "sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
+			"integrity": "sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
+			"integrity": "sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
+			"integrity": "sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
+			"integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+			"integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-visitor-keys": "^3.4.3"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.12.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/config-array": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+			"integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@eslint/object-schema": "^2.1.4",
+				"debug": "^4.3.1",
+				"minimatch": "^3.1.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+			"integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/eslintrc": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+			"integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ajv": "^6.12.4",
+				"debug": "^4.3.2",
+				"espree": "^10.0.1",
+				"globals": "^14.0.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.0",
+				"minimatch": "^3.1.2",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "9.15.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+			"integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/object-schema": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+			"integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+			"integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@humanfs/core": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/node": {
+			"version": "0.16.6",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+			"integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@humanfs/core": "^0.19.1",
+				"@humanwhocodes/retry": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+			"integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/retry": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+			"integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"license": "MIT"
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@oxlint/darwin-arm64": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.13.2.tgz",
+			"integrity": "sha512-Jbi2UX1xTFTpH/D6n15RzDSG/44oJ0FwrHWl96TsdD3PAOGxmm8LgcrsCU4d22TSN7ShDFB8y34MYplduRzhfA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxlint/darwin-x64": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.13.2.tgz",
+			"integrity": "sha512-ulA2vpNIM14VWJua6BjgX6l8nrjY8Un0uLqBLgELyDHMfpnC0HfrB2mR9PC9tRhb7+BEbgDLWTRs2aTV64eprw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@oxlint/linux-arm64-gnu": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.13.2.tgz",
+			"integrity": "sha512-iwguvPnIx/yIMc2IrwLeRflEFwyn+gcsNR8le5aX5DvQfHiB3/3x5JxOVl7Nd93lLsOg8RyVr2E11CxV10rKWw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxlint/linux-arm64-musl": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.13.2.tgz",
+			"integrity": "sha512-YJVvVyuvUobgCmiE47kBwN6dymLcQBG5/NsEaCbVyYw5HQJN7Ywp/x4suaF4c6M9ItPCnLxEZ4Lwu5TkrkU3vQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxlint/linux-x64-gnu": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.13.2.tgz",
+			"integrity": "sha512-w78gjd3ZJ+ahByS5gmN0jxFn/+G3W/oBJbyGFOuteXYcJwLj6JIyS0VhpMKxuAdFNCnsjJeDHSbdWaCV6VkA3A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxlint/linux-x64-musl": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.13.2.tgz",
+			"integrity": "sha512-yedk6KQT3jtBzpzExo3Ib7NwfuugaaFKvk/EzXEojMQ5aYh6CNhmVmm+adzwBp4YyOeXQZxSPHQ1LcNwDCUJIA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@oxlint/win32-arm64": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.13.2.tgz",
+			"integrity": "sha512-KZvJ3uMWSCwkZtvOcO+K4mLmYU/jIcHUb00s8aPasG1taflbjINsq9ZUUj5LNigcDwJRZGUwNcvY5KuQ+E9WtQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@oxlint/win32-x64": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.13.2.tgz",
+			"integrity": "sha512-G8FM8RTJRMt2dPRJ/TXhqIEu9k00vRAoh3DSV2r3o+jD8FZDBZXOgoDn2D0F9HqgFLEOVTxpfalmWntyk2hmyw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"license": "MIT"
+		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/mocha": {
+			"version": "10.0.10",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+			"integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "22.10.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+			"integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.20.0"
+			}
+		},
+		"node_modules/@types/vscode": {
+			"version": "1.95.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.95.0.tgz",
+			"integrity": "sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.16.0.tgz",
+			"integrity": "sha512-5YTHKV8MYlyMI6BaEG7crQ9BhSc8RxzshOReKwZwRWN0+XvvTOm+L/UYLCYxFpfwYuAAqhxiq4yae0CMFwbL7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "8.16.0",
+				"@typescript-eslint/type-utils": "8.16.0",
+				"@typescript-eslint/utils": "8.16.0",
+				"@typescript-eslint/visitor-keys": "8.16.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.3.1",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.16.0.tgz",
+			"integrity": "sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.16.0",
+				"@typescript-eslint/types": "8.16.0",
+				"@typescript-eslint/typescript-estree": "8.16.0",
+				"@typescript-eslint/visitor-keys": "8.16.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.16.0.tgz",
+			"integrity": "sha512-mwsZWubQvBki2t5565uxF0EYvG+FwdFb8bMtDuGQLdCCnGPrDEDvm1gtfynuKlnpzeBRqdFCkMf9jg1fnAK8sg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.16.0",
+				"@typescript-eslint/visitor-keys": "8.16.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.16.0.tgz",
+			"integrity": "sha512-IqZHGG+g1XCWX9NyqnI/0CX5LL8/18awQqmkZSl2ynn8F76j579dByc0jhfVSnSnhf7zv76mKBQv9HQFKvDCgg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "8.16.0",
+				"@typescript-eslint/utils": "8.16.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.16.0.tgz",
+			"integrity": "sha512-NzrHj6thBAOSE4d9bsuRNMvk+BvaQvmY4dDglgkgGC0EW/tB3Kelnp3tAKH87GEwzoxgeQn9fNGRyFJM/xd+GQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.16.0.tgz",
+			"integrity": "sha512-E2+9IzzXMc1iaBy9zmo+UYvluE3TW7bCGWSF41hVWUE01o8nzr1rvOQYSxelxr6StUvRcTMe633eY8mXASMaNw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/types": "8.16.0",
+				"@typescript-eslint/visitor-keys": "8.16.0",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"ts-api-utils": "^1.3.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.16.0.tgz",
+			"integrity": "sha512-C1zRy/mOL8Pj157GiX4kaw7iyRLKfJXBR3L82hk5kS/GyHcOFmy4YUq/zfZti72I9wnuQtA/+xzft4wCC8PJdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@typescript-eslint/scope-manager": "8.16.0",
+				"@typescript-eslint/types": "8.16.0",
+				"@typescript-eslint/typescript-estree": "8.16.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.16.0.tgz",
+			"integrity": "sha512-pq19gbaMOmFE3CbL0ZB8J8BFCo2ckfHBfaIsaOZgBIF4EoISJIdLX5xRhd0FGB0LlHReNRuzoJoMGpTjq8F2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.16.0",
+				"eslint-visitor-keys": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@vscode/test-cli": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/@vscode/test-cli/-/test-cli-0.0.10.tgz",
+			"integrity": "sha512-B0mMH4ia+MOOtwNiLi79XhA+MLmUItIC8FckEuKrVAVriIuSWjt7vv4+bF8qVFiNFe4QRfzPaIZk39FZGWEwHA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mocha": "^10.0.2",
+				"c8": "^9.1.0",
+				"chokidar": "^3.5.3",
+				"enhanced-resolve": "^5.15.0",
+				"glob": "^10.3.10",
+				"minimatch": "^9.0.3",
+				"mocha": "^10.2.0",
+				"supports-color": "^9.4.0",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"vscode-test": "out/bin.mjs"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@vscode/test-cli/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@vscode/test-cli/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@vscode/test-cli/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vscode/test-cli/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/@vscode/test-cli/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@vscode/test-cli/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@vscode/test-cli/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@vscode/test-cli/node_modules/supports-color": {
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+			"integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/@vscode/test-cli/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vscode/test-cli/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@vscode/test-electron": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.1.tgz",
+			"integrity": "sha512-Gc6EdaLANdktQ1t+zozoBVRynfIsMKMc94Svu1QreOBC8y76x4tvaK32TljrLi1LI2+PK58sDVbL7ALdqf3VRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.5",
+				"jszip": "^3.10.1",
+				"ora": "^7.0.1",
+				"semver": "^7.6.2"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@vscode/test-electron/node_modules/agent-base": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@vscode/test-electron/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+			"integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@vscode/test-electron/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-colors": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"license": "ISC",
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"license": "Python-2.0"
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/bl": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+			"integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^6.0.3",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/bl/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"license": "ISC"
+		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/c8": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
+			"integrity": "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==",
+			"license": "ISC",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@istanbuljs/schema": "^0.1.3",
+				"find-up": "^5.0.0",
+				"foreground-child": "^3.1.1",
+				"istanbul-lib-coverage": "^3.2.0",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.1.6",
+				"test-exclude": "^6.0.0",
+				"v8-to-istanbul": "^9.0.0",
+				"yargs": "^17.7.2",
+				"yargs-parser": "^21.1.1"
+			},
+			"bin": {
+				"c8": "bin/c8.js"
+			},
+			"engines": {
+				"node": ">=14.14.0"
+			}
+		},
+		"node_modules/c8/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/c8/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/c8/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/c8/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/c8/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/c8/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/c8/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chalk/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"license": "MIT",
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/cli-cursor": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+			"integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-spinners": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
+		},
+		"node_modules/commander": {
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"license": "MIT"
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"license": "MIT"
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/diff": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/enhanced-resolve": {
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+			"integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
+			"integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.24.0",
+				"@esbuild/android-arm": "0.24.0",
+				"@esbuild/android-arm64": "0.24.0",
+				"@esbuild/android-x64": "0.24.0",
+				"@esbuild/darwin-arm64": "0.24.0",
+				"@esbuild/darwin-x64": "0.24.0",
+				"@esbuild/freebsd-arm64": "0.24.0",
+				"@esbuild/freebsd-x64": "0.24.0",
+				"@esbuild/linux-arm": "0.24.0",
+				"@esbuild/linux-arm64": "0.24.0",
+				"@esbuild/linux-ia32": "0.24.0",
+				"@esbuild/linux-loong64": "0.24.0",
+				"@esbuild/linux-mips64el": "0.24.0",
+				"@esbuild/linux-ppc64": "0.24.0",
+				"@esbuild/linux-riscv64": "0.24.0",
+				"@esbuild/linux-s390x": "0.24.0",
+				"@esbuild/linux-x64": "0.24.0",
+				"@esbuild/netbsd-x64": "0.24.0",
+				"@esbuild/openbsd-arm64": "0.24.0",
+				"@esbuild/openbsd-x64": "0.24.0",
+				"@esbuild/sunos-x64": "0.24.0",
+				"@esbuild/win32-arm64": "0.24.0",
+				"@esbuild/win32-ia32": "0.24.0",
+				"@esbuild/win32-x64": "0.24.0"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint": {
+			"version": "9.15.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
+			"integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.12.1",
+				"@eslint/config-array": "^0.19.0",
+				"@eslint/core": "^0.9.0",
+				"@eslint/eslintrc": "^3.2.0",
+				"@eslint/js": "9.15.0",
+				"@eslint/plugin-kit": "^0.2.3",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.1",
+				"@types/estree": "^1.0.6",
+				"@types/json-schema": "^7.0.15",
+				"ajv": "^6.12.4",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.5",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^8.2.0",
+				"eslint-visitor-keys": "^4.2.0",
+				"espree": "^10.3.0",
+				"esquery": "^1.5.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.2",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+			"integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-visitor-keys": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/espree": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+			"integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"acorn": "^8.14.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/esquery": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"estraverse": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-glob": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fastq": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/file-entry-cache": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"flat-cache": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"license": "MIT",
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"license": "BSD-3-Clause",
+			"bin": {
+				"flat": "cli.js"
+			}
+		},
+		"node_modules/flat-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.4"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/flatted": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+			"integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"license": "ISC"
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/globals": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC"
+		},
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.x"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"license": "MIT",
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"license": "MIT"
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/import-fresh": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"license": "MIT",
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-interactive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-unicode-supported": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+			"integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC"
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-report/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"dev": true,
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"dependencies": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
+			}
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"immediate": "~3.0.5"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/log-symbols": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+			"integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.0.0",
+				"is-unicode-supported": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC"
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/make-dir/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+			"deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "0.0.8"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/mocha": {
+			"version": "10.8.2",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+			"integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-colors": "^4.1.3",
+				"browser-stdout": "^1.3.1",
+				"chokidar": "^3.5.3",
+				"debug": "^4.3.5",
+				"diff": "^5.2.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-up": "^5.0.0",
+				"glob": "^8.1.0",
+				"he": "^1.2.0",
+				"js-yaml": "^4.1.0",
+				"log-symbols": "^4.1.0",
+				"minimatch": "^5.1.6",
+				"ms": "^2.1.3",
+				"serialize-javascript": "^6.0.2",
+				"strip-json-comments": "^3.1.1",
+				"supports-color": "^8.1.1",
+				"workerpool": "^6.5.1",
+				"yargs": "^16.2.0",
+				"yargs-parser": "^20.2.9",
+				"yargs-unparser": "^2.0.0"
+			},
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha.js"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/mocha/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/mocha/node_modules/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/mocha/node_modules/is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mocha/node_modules/log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mocha/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/optionator": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/ora": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
+			"integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.3.0",
+				"cli-cursor": "^4.0.0",
+				"cli-spinners": "^2.9.0",
+				"is-interactive": "^2.0.0",
+				"is-unicode-supported": "^1.3.0",
+				"log-symbols": "^5.1.0",
+				"stdin-discarder": "^0.1.0",
+				"string-width": "^6.1.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ora/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/oxlint": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.13.2.tgz",
+			"integrity": "sha512-R7wXUspM75TeEXaAFLmuPH0W3h5B5r6BNtOvkcnVddD3BWbBiEOWe9bCqt4+te0l8wQ4a0/XLCGrJroxFFeajg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"oxc_language_server": "bin/oxc_language_server",
+				"oxlint": "bin/oxlint"
+			},
+			"engines": {
+				"node": ">=14.*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			},
+			"optionalDependencies": {
+				"@oxlint/darwin-arm64": "0.13.2",
+				"@oxlint/darwin-x64": "0.13.2",
+				"@oxlint/linux-arm64-gnu": "0.13.2",
+				"@oxlint/linux-arm64-musl": "0.13.2",
+				"@oxlint/linux-x64-gnu": "0.13.2",
+				"@oxlint/linux-x64-musl": "0.13.2",
+				"@oxlint/win32-arm64": "0.13.2",
+				"@oxlint/win32-x64": "0.13.2"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true,
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+			"integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/restore-cursor": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+			"integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"license": "MIT"
+		},
+		"node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/serialize-javascript": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"randombytes": "^2.1.0"
+			}
+		},
+		"node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/stdin-discarder": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
+			"integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^5.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
+			"integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^10.2.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"license": "ISC",
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/test-exclude/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+			"integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.4.2",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+			"integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+			"integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
+		"node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+			"integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/v8-to-istanbul": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+			"license": "ISC",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.12",
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.12.0"
+			}
+		},
+		"node_modules/vscode": {
+			"version": "1.1.37",
+			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+			"integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
+			"deprecated": "This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"glob": "^7.1.2",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"mocha": "^5.2.0",
+				"semver": "^5.4.1",
+				"source-map-support": "^0.5.0",
+				"vscode-test": "^0.4.1"
+			},
+			"bin": {
+				"vscode-install": "bin/install"
+			},
+			"engines": {
+				"node": ">=8.9.3"
+			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageclient": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+			"integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+			"license": "MIT",
+			"dependencies": {
+				"minimatch": "^5.1.0",
+				"semver": "^7.3.7",
+				"vscode-languageserver-protocol": "3.17.5"
+			},
+			"engines": {
+				"vscode": "^1.82.0"
+			}
+		},
+		"node_modules/vscode-languageclient/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/vscode-languageclient/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/vscode-languageclient/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"license": "MIT"
+		},
+		"node_modules/vscode-test": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+			"integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+			"deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.9.3"
+			}
+		},
+		"node_modules/vscode-test/node_modules/agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es6-promisify": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/vscode-test/node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/vscode-test/node_modules/http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "4",
+				"debug": "3.1.0"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/vscode-test/node_modules/https-proxy-agent": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			},
+			"engines": {
+				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/vscode-test/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vscode/node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/vscode/node_modules/diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/vscode/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/vscode/node_modules/glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/vscode/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/vscode/node_modules/he": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+			"integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/vscode/node_modules/minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/vscode/node_modules/mocha": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"browser-stdout": "1.3.1",
+				"commander": "2.15.1",
+				"debug": "3.1.0",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"glob": "7.1.2",
+				"growl": "1.10.5",
+				"he": "1.1.1",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"supports-color": "5.4.0"
+			},
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha"
+			},
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/vscode/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/vscode/node_modules/supports-color": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/workerpool": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+			"integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-unparser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"license": "MIT",
+			"dependencies": {
+				"camelcase": "^6.0.0",
+				"decamelize": "^4.0.0",
+				"flat": "^5.0.2",
+				"is-plain-obj": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	}
+}

--- a/packages/hdx_vscode/package.json
+++ b/packages/hdx_vscode/package.json
@@ -44,6 +44,7 @@
           "Tag.Experimental": ["entity.name.tag.css"],
           "Property": ["support.type.property-name.css"],
           "Property.Unknown": ["meta.property-name.css"],
+          "PseudoClass": ["entity.other.attribute-name.pseudo-class.css"],
           "Punctuation": ["source.css"]
         }
       }

--- a/packages/hdx_vscode/package.json
+++ b/packages/hdx_vscode/package.json
@@ -1,0 +1,84 @@
+{
+	"name": "hdx_vscode",
+	"displayName": "hdx",
+	"version": "1.0.0",
+	"description": "Refreshing CSS",
+	"keywords": [],
+	"repository": "https://github.com/keithamus/hdx",
+	"funding": {
+		"url": "https://github.com/sponsors/keithamus"
+	},
+	"license": "MIT",
+	"author": "Keith Cirkel (https://keithcirke.co.uk)",
+	"type": "commonjs",
+	"main": "./src/main.js",
+	"files": [
+		"./dist"
+	],
+	"scripts": {
+		"check": "prettier --check . && npm run lint && npm run typecheck",
+		"fmt": "prettier --write .",
+		"lint": "oxlint",
+		"typecheck": "tsc",
+		"watch": "npm run build -- --watch",
+		"watch-test": "vscode-test"
+	},
+	"contributes": {
+		"commands": [
+			{
+				"command": "extension.helloWorld",
+				"title": "Hello World"
+			}
+		],
+		"configuration": [],
+		"configurationDefaults": {},
+		"keybindings": [],
+		"problemMatchers": [],
+		"problemPatterns": [],
+		"semanticTokenModifiers": [],
+		"semanticTokenScopes": [
+      {
+        "scopes": {
+          "Tag": ["entity.name.tag.css"],
+          "Tag.Unknown": ["meta.selector.css"],
+          "Tag.Experimental": ["entity.name.tag.css"],
+          "Property": ["support.type.property-name.css"],
+          "Property.Unknown": ["meta.property-name.css"],
+          "Punctuation": ["source.css"]
+        }
+      }
+		],
+		"semanticTokenTypes": [],
+		"snippets": [],
+		"taskDefinitions": [],
+		"views": [],
+		"walkthroughs": []
+	},
+	"activationEvents": ["onLanguage:css"],
+	"dependencies": {
+		"@vscode/test-cli": "^0.0.10",
+		"vscode-languageclient": "^9.0.1"
+	},
+	"devDependencies": {
+		"@types/mocha": "^10.0.10",
+		"@types/node": "^22.10.1",
+		"@types/vscode": "^1.95.0",
+		"@typescript-eslint/eslint-plugin": "^8.16.0",
+		"@typescript-eslint/parser": "^8.16.0",
+		"@vscode/test-electron": "^2.4.1",
+		"esbuild": "^0.24.0",
+		"mocha": "^10.8.2",
+		"oxlint": "^0.13.2",
+		"prettier": "^3.4.1",
+		"tinyglobby": "^0.2.10",
+		"typescript": "^5.7.2",
+		"vscode": "^1.1.34"
+	},
+	"engines": {
+		"vscode": "^1.95.0"
+	},
+	"prettierConfig": {
+		"useTabs": true,
+		"printWidth": 120
+	}
+}

--- a/packages/hdx_vscode/src/main.js
+++ b/packages/hdx_vscode/src/main.js
@@ -1,0 +1,74 @@
+const vscode = require("vscode");
+const lc = require("vscode-languageclient/node");
+
+module.exports = { activate, deactivate };
+
+async function deactivate() {}
+
+/**
+ * @param {vscode.ExtensionContext} context
+ * @returns Promise<HdxExtensionContext>
+ */
+async function activate(context) {
+	console.error("Extension active");
+	const hdxContext = new HdxExtensionContext(context);
+	await hdxContext.activate();
+	return hdxContext;
+}
+
+class HdxExtensionContext {
+	/**
+	 * @public
+	 * @readonly
+	 * @type lc.LanguageClient
+	 */
+	client;
+
+	/**
+	 * @public
+	 * @readonly
+	 * @type vscode.ExtensionContext
+	 */
+	context;
+
+	constructor(context) {
+		this.context = context;
+	}
+
+	async activate() {
+		this.client = await this.createClient();
+		this.client.start();
+	}
+
+	async deactivate() {
+		return this.client?.stop();
+	}
+
+	/**
+	 * @returns Promise<lc.LanguageClient>
+	 */
+	async createClient() {
+		const traceOutputChannel = vscode.window.createOutputChannel("hdx Language Server Trace");
+		const env = Object.assign({}, process.env);
+		const serverOptions = {
+			run: {
+				command: env.HDX_SERVER_PATH || "hdx",
+				args: ["lsp"],
+				options: { env },
+			},
+			debug: {
+				command: env.HDX_SERVER_PATH || "hdx",
+				args: ["--debug", "lsp"],
+				options: { env },
+			},
+		};
+		const clientOptions = {
+			documentSelector: [{ scheme: "file", language: "css" }],
+			diagnosticCollectionName: "hdx",
+			traceOutputChannel,
+		};
+
+		console.log({ serverOptions, clientOptions });
+		return new lc.LanguageClient("hdx", "hdx Language Server", serverOptions, clientOptions);
+	}
+}

--- a/packages/hdx_vscode/tests/basic.test.ts
+++ b/packages/hdx_vscode/tests/basic.test.ts
@@ -1,0 +1,9 @@
+const assert = require("assert");
+const vscode = require("vscode");
+
+suite("Extension Test Suite", () => {
+	test("Sample test", () => {
+		assert.strictEqual([1, 2, 3].indexOf(5), -1);
+		assert.strictEqual([1, 2, 3].indexOf(0), -1);
+	});
+});

--- a/packages/hdx_vscode/tests/run-tests.mjs
+++ b/packages/hdx_vscode/tests/run-tests.mjs
@@ -1,0 +1,36 @@
+import Mocha from "mocha";
+import * as path from "path";
+import { glob } from "tinyglobby";
+
+import { runTests } from "@vscode/test-electron";
+
+async function main() {
+	try {
+		const extensionDevelopmentPath = path.resolve(__dirname, "../");
+		const extensionTestsPath = __filename;
+		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+	} catch {
+		console.error("Failed to run tests");
+		process.exit(1);
+	}
+}
+
+export async function run() {
+	const mocha = new Mocha({ ui: "bdd" });
+	const testsRoot = path.resolve(__dirname, "../out/tests/");
+	const files = await glob("*.test.js", { cwd: testsRoot });
+	for (const file of files) {
+		mocha.addFile(path.resolve(testsRoot, file));
+	}
+	await new Promise((resolve, reject) => {
+		mocha.run((failures) => {
+			if (failures > 0) {
+				reject(new Error(`${failures} tests failed.`));
+			} else {
+				resolve();
+			}
+		});
+	});
+}
+
+main();

--- a/packages/hdx_vscode/tsconfig.json
+++ b/packages/hdx_vscode/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"module": "nodenext",
+		"target": "es2022",
+		"noEmit": true,
+		"lib": ["ES2023"],
+		"rootDir": ".",
+		"strict": true
+	},
+	"exclude": ["node_modules/", ".vscode-test"],
+	"include": ["src", "tests"]
+}

--- a/website/css/index.css
+++ b/website/css/index.css
@@ -1,4 +1,4 @@
-body {
+body, portal {
 	font-family: sans-serif;
 	display: flex;
 	max-width: 700px;


### PR DESCRIPTION
This creates a basic LSP server and cobbles together a VSCode extension based on some of the guides available, in order to get semantic highlighting just about working.

Some notes:

 - `hdx_lsp` offers the main functionality of the LSP. Theres a server core which is more of a library, it uses `Crossbeam` to do threaded handling of requests and responses, routing is very simple and uses `DashMap<&'static str, RequestHandler>` to map requests to their relative handlers. I looked into Tower LSP but I wanted to get to grips with the protocol a little more, so this simple handler pattern made more sense to me. A lot of heavy lifting is done via `lsp_types` which saved a ton of time getting stuff working.
 - This also uses `tracing` which is a really neat library and I am kind of tempted to shove it everywhere - maybe it would be good for perf tracing in the parser itself?
 - The `hdx` binary now offers an `lsp` command. The VSCode extension then can call out to `hdx lsp` to delegate all the work to that. There's sadly still some stuff that needs defining in the extension - mostly fallback styles for semantic tokens. Largely though it all communicates through the LSP, which is great because this means it can eventually scan for local copies of hdx or download the latest version without any updates to the extension.
 - Right now the LSP logic is pretty ropey; highlighting requires reparsing each time and we're storing a `DashMap` of file URIs to Strings. We should be more advanced here and do stuff like:
  - Threaded parsing/highlighting in something like a deque.
  - Storing files in a virtual file system.
  - Actually updated files in edits, so we can re-parse on each edit.

Next up we need a lot of work on Visitor traits, and to implement more token highlighting. Also the test suite needs some improvements. Overall though I am happy with this as a first step!