### PR TITLE
chore(ci): automatically upload binaries to github release's

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 # mostly copied from https://raw.githubusercontent.com/web-infra-dev/oxc/main/.github/workflows/release_cli.yml
 name: release
 on:
-  push:
-    branches: ["main"]
-  release:
-    types: [created]
+  workflow_run:
+    workflows: [test]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 concurrency:
   group: "release"
@@ -13,7 +13,29 @@ permissions:
   contents: read
   id-token: write
 jobs:
+  tag:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa canary -m "Latest Continuous Release" ${GITHUB_SHA}
+          git push --force origin canary
+
   build:
+    if: |
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          github.repository_owner == 'keithamus' &&
+          github.ref_name == 'main'
+        )
+      }}
+
     strategy:
       matrix:
         include:
@@ -84,11 +106,10 @@ jobs:
 
   deploy:
     env:
-      TAG_NAME: ${{ github.event.release.tag_name || format('0.0.0-canary.{0}', github.SHA) }}
-      DIST_TAG: ${{ github.event.release.tag_name && 'latest' || 'canary' }}
+      TAG_NAME: ${{ format('0.0.0-canary.{0}', github.SHA) }}
+      DIST_TAG: canary
     runs-on: ubuntu-latest
-    needs:
-      - build
+    needs: [build]
     steps:
       - run: echo "TAG_NAME=$TAG_NAME"; echo "DIST_TAG=$DIST_TAG"
       - uses: actions/checkout@v4
@@ -100,8 +121,7 @@ jobs:
           cache: "npm"
       - name: Download Artifacts
         uses: actions/download-artifact@v4
-      - name: Move
-        run: mv binary-*/* packages/hdx/bin && chmod +x packages/hdx/bin/*
+      - run: cp binary-*/* packages/hdx/bin && chmod +x packages/hdx/bin/*
       - run: tree
       - run: npm i
         working-directory: ./packages/hdx
@@ -111,3 +131,19 @@ jobs:
         working-directory: ./packages/hdx
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - name: Update Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Canary
+          prerelease: true
+          tag_name: canary
+          target_commitish: ${{ github.sha }}
+          files: binary-*/*
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            This release is automatically built and generated on every commit to main that passes tests.
+
+            And is currently published to npm:
+            ```shell
+            npm add hdx@$DIST_TAG
+            ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -fa canary -m "Latest Continuous Release" ${GITHUB_SHA}
-          git push --force origin canary
+          git push --force-with-lease origin canary
 
   build:
     if: |


### PR DESCRIPTION
What this pull request does is publish the latest binaries to the `canary` git tag release. GitHub can house release assets per tag, or per release issue.

Until we hit something stable, we should publish the latest binaries to the `canary` tag. 

There is an additional change, in that the release action will only run if the `test` workflow succeeded. I also got rid of the "release tag" or issue creation flows, probably we can explore that closer to when we wanna start tagging properly. I've found that using [git tags to "trigger" releases](https://github.com/maraisr/dldr/blob/614317540d4982b779a3756a560a96b74ec2060f/.github/workflows/ci.yml#L31), work really well. But given we embed the css spec in the binary, id probably like to see us split the "db" from the cli, such that we do not need a new NPM/extension release just to capture new specs. And instead do something like caniuse, in that the db is a separate binary. But lets discuss this some other time, there are pros in a self contained NPM too.

For now, this will publish the binaries to a canary release, we can then use to power things like a Zed extension.
