### PR TITLE
fix: we cannot pprof in windows

### DIFF
--- a/crates/hdx_lsp/Cargo.toml
+++ b/crates/hdx_lsp/Cargo.toml
@@ -38,10 +38,12 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 glob = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
-pprof = { workspace = true, features = ["flamegraph", "criterion"] }
 insta = { workspace = true, features = ["json"] }
 similar = { workspace = true }
 console = { workspace = true }
+
+[target.'cfg(target_family = "unix")'.dev-dependencies]
+pprof = { workspace = true, features = ["flamegraph", "criterion"] }
 
 [features]
 default = []


### PR DESCRIPTION
`pprof` is a "unix" only dependency. Even though we do not "use" it anywhere not protected by `cfg!`, it seems as though `cargo test` builds all dependencies, which `pprof` fails. 

Fix is simple, simply only include that dep on `unix` systems. Confirmed testing/building on my Windows machine.

closes: https://github.com/keithamus/hdx/issues/66