### PR TITLE
rename hdx to csskit in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           shared-key: release-${{ matrix.target }}
       - name: Build Binary
         # strip debug symbols from std, see https://github.com/johnthagen/min-sized-rust#remove-panic-string-formatting-with-panic_immediate_abort
-        run: cargo build --release --target ${{ matrix.target }} -p hdx
+        run: cargo build --release --target ${{ matrix.target }} -p csskit
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
@@ -87,23 +87,23 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          BIN_NAME=hdx-${{ matrix.code-target }}
-          mv target/${{ matrix.target }}/release/hdx.exe $BIN_NAME.exe
+          BIN_NAME=csskit-${{ matrix.code-target }}
+          mv target/${{ matrix.target }}/release/csskit.exe $BIN_NAME.exe
 
       - name: Archive Binary
         if: runner.os != 'Windows'
         run: |
-          BIN_NAME=hdx-${{ matrix.code-target }}
-          mv target/${{ matrix.target }}/release/hdx $BIN_NAME
+          BIN_NAME=csskit-${{ matrix.code-target }}
+          mv target/${{ matrix.target }}/release/csskit $BIN_NAME
 
-      - run: chmod +x hdx-*
+      - run: chmod +x csskit-*
 
       - name: Upload Binary
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
           name: binary-${{ matrix.code-target }}
-          path: hdx-*
+          path: csskit-*
 
   deploy:
     env:
@@ -122,14 +122,14 @@ jobs:
           cache: "npm"
       - name: Download Artifacts
         uses: actions/download-artifact@v4
-      - run: cp binary-*/* packages/hdx/bin
+      - run: cp binary-*/* packages/csskit/bin
       - run: tree
       - run: npm i
-        working-directory: ./packages/hdx
+        working-directory: ./packages/csskit
       - run: npm version ${TAG_NAME} --no-git-tag-version
-        working-directory: ./packages/hdx
+        working-directory: ./packages/csskit
       - run: npm whoami; npm pub --provenance --tag $DIST_TAG --access public
-        working-directory: ./packages/hdx
+        working-directory: ./packages/csskit
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
       - name: Update Release
@@ -146,5 +146,5 @@ jobs:
 
             And is currently published to npm:
             ```shell
-            npm i hdx@canary
+            npm i csskit@canary
             ```


### PR DESCRIPTION
Release failed because somehow I missed this in the rename. This should fix it.