### PR TITLE
fix repository org name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.workflow_run.conclusion == 'success' &&
-          github.repository_owner == 'keithamus' &&
+          github.repository_owner == 'csskit' &&
           github.ref_name == 'main'
         )
       }}

--- a/packages/csskit_zed/src/lib.rs
+++ b/packages/csskit_zed/src/lib.rs
@@ -29,7 +29,7 @@ impl CsskitExtension {
 			&zed::LanguageServerInstallationStatus::CheckingForUpdate,
 		);
 
-		let release = zed::github_release_by_tag_name("keithamus/csskit", "canary")?;
+		let release = zed::github_release_by_tag_name("csskit/csskit", "canary")?;
 
 		let (platform, arch) = zed::current_platform();
 		let asset_name = format!(


### PR DESCRIPTION
A couple of places still mention `keithamus` as the repository owner, but this is under the `csskit` org now.