### PR TITLE
Sync rust's toolchain with mises'

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.88.0"
 profile = "default"


### PR DESCRIPTION
We use Rust 1.88 with mise, but rusts' toolchain has 1.83. Those should be kept in sync.