### PR TITLE
css_parse: fix doc warnings

### DIFF
--- a/crates/css_parse/src/feature.rs
+++ b/crates/css_parse/src/feature.rs
@@ -14,7 +14,7 @@ use bitmask_enum::bitmask;
 /// ```
 #[bitmask(u8)]
 pub enum Feature {
-	/// This flag is forwarded to the [Lexer][crate::Lexer] which, when enabled, will treat single line comments as valid
+	/// This flag is forwarded to the [Lexer][css_lexer::Lexer] which, when enabled, will treat single line comments as valid
 	/// Comment tokens. If it encounters two consecutative SOLIDUS characters (`//`), it will return a
 	/// [Token][css_lexer::Token] with [Kind::Comment][css_lexer::Kind::Comment]. For more information about exactly what
 	/// happens here at the lexer level, consult the [css_lexer::Feature::SingleLineComments] feature.
@@ -23,12 +23,12 @@ pub enum Feature {
 	/// trivia tokens Vec as normal.
 	SingleLineComments,
 
-	/// This flag is forwarded to the [Lexer][crate::Lexer] which, when enabled, will treat diffetent whitespace kinds as
+	/// This flag is forwarded to the [Lexer][css_lexer::Lexer] which, when enabled, will treat diffetent whitespace kinds as
 	/// descrete. For more information about exactly what happens here at the lexer level, consult the
 	/// [css_lexer::Feature::SeparateWhitespace] feature.
 	///
 	/// This flag doesn't cause any changes in logic on the [Parser][crate::Parser]; whitespace is typically collected in
-	/// the trivia Vec. AST nodes which call [Parser::set_skip()][Parser::set_skip] to parse whitespace sensitive nodes
+	/// the trivia Vec. AST nodes which call [Parser::set_skip()][crate::Parser::set_skip] to parse whitespace sensitive nodes
 	/// should be cognizant that this feature could be enabled, meaning that adjacent whitespace tokens are possible. To
 	/// counter adjacent tokens, simply parse any whitespace in a loop.
 	SeparateWhitespace,

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -171,7 +171,7 @@
 //!   until it enounters the start of a block (<{-token> or <;-token>).
 //! - [CommaSeparatedPreludeList] - AST nodes representing a rule's prelude should use this. It parses a comma separated
 //!   list of preludes. A bit like [PreludeList] but it'll also parse the comma tokens after each item.
-//! - [ConditionPreludeList] - AST nodes representing a prelude "condition list" should use this. It parses the complex
+//! - [FeatureConditionList] - AST nodes representing a prelude "condition list" should use this. It parses the complex
 //!   condition logic in rules like `@media`, `@supports` or `@container`.
 //! - [DeclarationList] - AST nodes representing a block which can only accept "Declarations" should use this. This is
 //!   an implementation of [`<declaration-list>`][8].
@@ -187,7 +187,7 @@
 //!   this. This will likely be used for the prelude of "Style Rules".
 //!
 //! The `*Feature` traits are also available to more easily parse "features conditions", these are the conditions
-//! supports in a [ConditionPreludeList], e.g. the conditions inside of `@media`, `@container` or `@supports` rules.
+//! supports in a [FeatureConditionList], e.g. the conditions inside of `@media`, `@container` or `@supports` rules.
 //!
 //!  - [RangedFeature] - AST nodes representing a feature condition in the "ranged" context.
 //!  - [BooleanFeature] - AST nodes representing a feature condition in the "boolean" context.
@@ -218,9 +218,7 @@
 //!  - [syntax::FunctionBlock] provides the generic [`<function-block>` grammar][19].
 //!  - [syntax::ComponentValues] provides a list of `<component-value>` nodes, [per "parse a list of component
 //!    values"][20].
-//!  - [syntax::CommaSeparatedComponentValues] provides a list of `<component-value>` nodes separated by commas, [per
-//!    "parse a comma-separated list of component values][21].
-//!  - [syntax::BadDeclaration] provides a struct to capture the [bad declaration steps][22].
+//!  - [syntax::BadDeclaration] provides a struct to capture the [bad declaration steps][21].
 //!
 //! [13]: https://drafts.csswg.org/css-syntax-3/#at-rule-diagram
 //! [14]: https://drafts.csswg.org/css-syntax-3/#qualified-rule-diagram
@@ -230,8 +228,7 @@
 //! [18]: https://drafts.csswg.org/css-syntax-3/#simple-block-diagram
 //! [19]: https://drafts.csswg.org/css-syntax-3/#function-block-diagram
 //! [20]: https://drafts.csswg.org/css-syntax-3/#parse-list-of-component-values
-//! [21]: https://drafts.csswg.org/css-syntax-3/#parse-comma-separated-list-of-component-values
-//! [22]: https://drafts.csswg.org/css-syntax-3/#consume-the-remnants-of-a-bad-declaration
+//! [21]: https://drafts.csswg.org/css-syntax-3/#consume-the-remnants-of-a-bad-declaration
 //!
 //! # Test Helpers
 //!
@@ -299,7 +296,7 @@ pub mod syntax;
 /// Test macros available if built with `features = ["testing"]`
 #[cfg(any(feature = "testing", test))]
 pub mod test_helpers;
-/// Various macros that expand to AST nodes that wrap [Tokens][Token].
+/// Various macros that expand to AST nodes that wrap [Tokens][css_lexer::Token].
 pub mod token_macros;
 mod traits;
 

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -1,6 +1,6 @@
 /// (Requires feature "testing") Given a Node, and a string, this will expand to code that sets up a parser, and parses the given string against the
 /// given node. If the parse failed this macro will [panic] with a readable failure. It then writes the result out using
-/// [CursorFmtSink], writing the parsed Node back out to a string. If resulting string from the given string, then the
+/// [crate::CursorFmtSink], writing the parsed Node back out to a string. If resulting string from the given string, then the
 /// macro will [panic] with a readable failure.
 ///
 /// In rare cases it might be necessary to ensure the resulting string _differs_ from the input, for example if a

--- a/crates/css_parse/src/traits/lists/comma_separated_prelude_list.rs
+++ b/crates/css_parse/src/traits/lists/comma_separated_prelude_list.rs
@@ -7,7 +7,7 @@ use css_lexer::KindSet;
 ///
 /// The [CommaSeparatedPreludeList::PreludeItem] must be defined (representing the `<prelude-item>`), which will be the
 /// item that is parsed between the commas. Error tolerance is provided for the commas, and so the return [Vec] will
-/// have [Options][Option] of [T![,]][crate::token_macros::comma]. Parsing will stop once
+/// have [Options][Option] of [T![,]][crate::token_macros::Comma]. Parsing will stop once
 /// [CommaSeparatedPreludeList::STOP_TOKENS] is reached.
 ///
 /// The effective grammar for this trait is:

--- a/crates/css_parse/src/traits/lists/declaration_rule_list.rs
+++ b/crates/css_parse/src/traits/lists/declaration_rule_list.rs
@@ -7,7 +7,7 @@ use bumpalo::collections::Vec;
 /// token may or may not be present on declarations.
 ///
 /// [DeclarationRuleList::Declaration] refers to the `<declataion>` grammar and is required to implement the
-/// [Declaration][crate::Declaration] trait. [DeclarationRuleList::AtRule] refers to the <at-rule> grammar and is
+/// [Declaration][crate::Declaration] trait. [DeclarationRuleList::AtRule] refers to the `<at-rule>` grammar and is
 /// required to impement the [AtRule][crate::AtRule] trait.
 ///
 /// ```md

--- a/crates/css_parse/src/traits/lists/feature_condition_list.rs
+++ b/crates/css_parse/src/traits/lists/feature_condition_list.rs
@@ -7,7 +7,7 @@ keyword_set!(ConditionKeyword { And: "and", Not: "not", Or: "or" });
 /// [Supports Conditions][1], [Media Conditions][2], and [Container Queries][3]
 /// This is an implementation of [`<at-rule-list>`][1].
 ///
-/// Looking at `<supports-condition> and `<container-query>` we can se almost identical grammars (eliding some tokens
+/// Looking at `<supports-condition>` and `<container-query>` we can se almost identical grammars (eliding some tokens
 /// for brevity):
 ///
 /// ```md
@@ -18,7 +18,7 @@ keyword_set!(ConditionKeyword { And: "and", Not: "not", Or: "or" });
 ///                              ├─╭─ <ident-token "or"> ─ <supports-in-parens> ─╮──┤
 ///                              │ ╰─────────────────────────────────────────────╯  │
 ///                              ╰──────────────────────────────────────────────────╯
-///                               
+///
 /// <container-query>
 ///  │├─╮─ <ident-token "not"> ─ <query-in-parens> ───────────────────────────╭──┤│
 ///     ╰─ <supports-in-parens> ─╮─╭─ <ident-token "and"> ─ <supports-in-parens> ─╮─┤

--- a/crates/css_parse/src/traits/parse.rs
+++ b/crates/css_parse/src/traits/parse.rs
@@ -7,7 +7,7 @@ use crate::{diagnostics, Build, Parser, Peek, Result};
 /// need to try and reset the [Parser] state on failure ([Parser::try_parse()] exists for this reason).
 ///
 /// When wanting to parse child nodes, implementations should _not_ call [Parse::parse()] directly. Instead - call
-/// [Parser::parse<T>()]. Other convenience methods such as [Parser::parse_if_peek<T>()] and [Parser::try_parse<T>()]
+/// [`Parser::parse<T>()`]. Other convenience methods such as [`Parser::parse_if_peek<T>()`] and [`Parser::try_parse<T>()`]
 /// exist.
 ///
 /// Any node implementing [Parse::parse()] gets [Parse::try_parse()] for free. It's unlikely that nodes can come up with

--- a/crates/css_parse/src/traits/peek.rs
+++ b/crates/css_parse/src/traits/peek.rs
@@ -24,8 +24,8 @@ use crate::Parser;
 /// underlying string to reason about. When comparing lots of strings, consider implementing a [phf::Map]. If comparing
 /// just one string, consider [Parser::eq_ignore_ascii_case()] which can fail-fast, rather than parsing a whole string.
 ///
-/// When peeking child nodes, implementations should _not_ call [Peek::Peek()] directly. Instead - call
-/// [Parser::peek<T>()]. [Parser::parse_if_peek<T>()] also exists to conveniently parse a Node if it passes the peek
+/// When peeking child nodes, implementations should _not_ call [Peek::peek()] directly. Instead - call
+/// [`Parser::peek<T>()`]. [`Parser::parse_if_peek<T>()`] also exists to conveniently parse a Node if it passes the peek
 /// test.
 ///
 /// If a Node can construct itself from a single [Cursor][css_lexer::Cursor] it should also implement

--- a/crates/css_parse/src/traits/rules/at_rule.rs
+++ b/crates/css_parse/src/traits/rules/at_rule.rs
@@ -35,11 +35,11 @@ use css_lexer::{Cursor, KindSet};
 /// AtRules can have an optional prelude (e.g. @supoports requires one, @starting-style must not have one, and in @page
 /// it is optional). Consequently `parse_at_rule` returns an [Self::Prelude] as an [Option], and rules that either
 /// require should run the neccessary checks in their [Parse::parse()] implementation (or use something like
-/// [NoPreludeAllowed][crate::syntax::NoPreludeAllowed] to ban a prelude).
+/// [NoPreludeAllowed][crate::NoPreludeAllowed] to ban a prelude).
 ///
 /// The block is always parsed. For some rules a block is either optional or disallowed. For optional blocks, it's
 /// advised to provide an `enum` for the block, which can conditionally parse the underyling block. For disallowed
-/// blocks [NoBlockAllowed][crate::syntax::NoBlockAllowed] can be used to ensure that the rule only ends in `;`.
+/// blocks [NoBlockAllowed][crate::NoBlockAllowed] can be used to ensure that the rule only ends in `;`.
 ///
 /// # Example
 ///

--- a/crates/css_parse/src/traits/rules/no_block_allowed.rs
+++ b/crates/css_parse/src/traits/rules/no_block_allowed.rs
@@ -2,8 +2,8 @@ use crate::{diagnostics, CursorSink, Parse, Parser, Peek, Result, ToCursors, T};
 
 /// A struct to provide to [AtRule][crate::AtRule] to disallow blocks.
 ///
-/// Sometimes [AtRules][crate::AtRule] do not have a block - for example `@charset`, `@import`. In those case, assigning
-/// this struct to the [AtRule::Block] can be useful to ensure that the [AtRule] appropriately errors if it enters the
+/// Sometimes [AtRules][crate::syntax::AtRule] do not have a block - for example `@charset`, `@import`. In those case, assigning
+/// this struct to the `Block` can be useful to ensure that the [AtRule][crate::syntax::AtRule] appropriately errors if it enters the
 /// Block parsing context. This captures the `;` token that may optionally end a "statement-style" at-rule.
 pub struct NoBlockAllowed(Option<T![;]>);
 impl<'a> Parse<'a> for NoBlockAllowed {

--- a/crates/css_parse/src/traits/rules/no_prelude_allowed.rs
+++ b/crates/css_parse/src/traits/rules/no_prelude_allowed.rs
@@ -2,8 +2,8 @@ use crate::{diagnostics, CursorSink, Parse, Parser, Peek, Result, ToCursors, T};
 
 /// A struct to provide to [AtRule][crate::AtRule] to disallow preludes.
 ///
-/// Sometimes [AtRules][crate::AtRule] do not have a prelude. In those case, assigning this struct to the
-/// [AtRule::Prelude] can be useful to ensure that the [AtRule][crate::AtRule] appropriately errors if it enters the
+/// Sometimes [AtRules][crate::syntax::AtRule] do not have a prelude. In those case, assigning this struct to the
+/// `Prelude` can be useful to ensure that the [AtRule][crate::syntax::AtRule] appropriately errors if it enters the
 /// Prelude parsing context.
 pub struct NoPreludeAllowed;
 impl<'a> Parse<'a> for NoPreludeAllowed {


### PR DESCRIPTION
Some docs were issuing warnings that failed the build. This fixes those.