### PR TITLE
(css_proc_macro): Do not fallthrough when unreachable

### DIFF
--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
-snapshot_kind: text
 ---
 ::css_parse::keyword_set!(FooKeywords { None : "none", });
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -31,8 +30,6 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         } else {
             return Ok(Self::CustomIdent(p.parse::<::css_parse::T![Ident]>()?));
         }
-        let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
-        Err(::css_parse::diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
     }
 }
 #[automatically_derived]


### PR DESCRIPTION
Fallthrough will cause errors if we `deny(warnings)` in css_ast.