### PR TITLE
Update regions

### DIFF
--- a/crates/css_ast/src/values/regions/mod.rs
+++ b/crates/css_ast/src/values/regions/mod.rs
@@ -7,7 +7,7 @@ use impls::*;
  */
 
 // // https://drafts.csswg.org/css-regions-1/#flow-into
-// #[value(" none | <ident> [element | content]? ")]
+// #[value(" none | <custom-ident> [element | content]? ")]
 // #[initial("none")]
 // #[applies_to("All elements, but not pseudo-elements such as ::first-line, ::first-letter, ::before or ::after.")]
 // #[inherited("no")]
@@ -16,15 +16,17 @@ use impls::*;
 // #[animation_type("not animatable")]
 // pub enum FlowIntoStyleValue {}
 
-// // https://drafts.csswg.org/css-regions-1/#flow-from
-// #[value(" <ident> | none ")]
-// #[initial("none")]
-// #[applies_to("Non-replaced block containers.  This might be expanded in future versions of the specification to allow other types of containers to receive flow content.")]
-// #[inherited("no")]
-// #[percentages("n/a")]
-// #[canonical_order("per grammar")]
-// #[animation_type("not animatable")]
-// pub enum FlowFromStyleValue {}
+// https://drafts.csswg.org/css-regions-1/#flow-from
+#[value(" <custom-ident> | none ")]
+#[initial("none")]
+#[applies_to(
+	"Non-replaced block containers.  This might be expanded in future versions of the specification to allow other types of containers to receive flow content."
+)]
+#[inherited("no")]
+#[percentages("n/a")]
+#[canonical_order("per grammar")]
+#[animation_type("not animatable")]
+pub enum FlowFromStyleValue {}
 
 // https://drafts.csswg.org/css-regions-1/#region-fragment
 #[value(" auto | break ")]


### PR DESCRIPTION
I noticed that `flow-from` and `flow-into` were using `<ident>` which is wrong, so I fixed upstream in https://github.com/w3c/csswg-drafts/pull/12445.

That merged, so running `mise run generate-values regions` updated the `mod.rs` to this, which means we can uncomment `flow-from` at least!