### PR TITLE
Removes the `dependencyDashboard` for now

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": false,
   "extends": [
     "config:recommended"
   ],


### PR DESCRIPTION
Cleans up our one open issue, for arguably maybe a useless issue?