### PR TITLE
Refactor def.rs for better codegen

### DIFF
--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
@@ -2,18 +2,18 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(FooKeywords { None : "none", });
+::css_parse::keyword_set!(FooKeywords { Auto : "auto", });
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 enum Foo {
-    None(::css_parse::T![Ident]),
-    LengthPercentage(crate::LengthPercentage),
+    Length(crate::Length, Option<crate::Length>),
+    Auto(::css_parse::T![Ident]),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
         use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::LengthPercentage>::peek(p, c)
+        <crate::Length>::peek(p, c) || <::css_parse::T![Ident]>::peek(p, c)
     }
 }
 #[automatically_derived]
@@ -23,33 +23,27 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
             use ::css_parse::Build;
             match keyword {
-                FooKeywords::None(c) => {
-                    return Ok(Self::None(<::css_parse::T![Ident]>::build(p, c)));
+                FooKeywords::Auto(c) => {
+                    return Ok(Self::Auto(<::css_parse::T![Ident]>::build(p, c)));
                 }
             }
         }
-        let start = p.offset();
-        let ty = p.parse::<crate::LengthPercentage>()?;
-        let valf32: f32 = ty.into();
-        if 0f32 > valf32 {
-            return Err(
-                ::css_parse::diagnostics::NumberTooSmall(
-                    0f32,
-                    ::css_lexer::Span::new(start, p.offset()),
-                ),
-            )?;
-        }
-        Ok(Self::LengthPercentage(ty))
+        let combo0 = p.parse::<crate::Length>()?;
+        let combo1 = p.parse_if_peek::<crate::Length>()?;
+        Ok(Self::Length(combo0, combo1))
     }
 }
 #[automatically_derived]
 impl ::css_parse::ToCursors for Foo {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
         match self {
-            Self::None(inner) => {
-                ::css_parse::ToCursors::to_cursors(inner, s);
+            Self::Length(c0, c1) => {
+                ::css_parse::ToCursors::to_cursors(c0, s);
+                if let Some(inner) = c1 {
+                    ::css_parse::ToCursors::to_cursors(inner, s);
+                }
             }
-            Self::LengthPercentage(inner) => {
+            Self::Auto(inner) => {
                 ::css_parse::ToCursors::to_cursors(inner, s);
             }
         }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
@@ -21,18 +21,8 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
         let val0 = p.parse::<crate::AnimateableFeature>()?;
-        let val1 = if p.peek::<crate::AnimateableFeature>() {
-            let val = p.parse::<crate::AnimateableFeature>()?;
-            Some(val)
-        } else {
-            None
-        };
-        let val2 = if p.peek::<crate::AnimateableFeature>() {
-            let val = p.parse::<crate::AnimateableFeature>()?;
-            Some(val)
-        } else {
-            None
-        };
+        let val1 = p.parse_if_peek::<crate::AnimateableFeature>()?;
+        let val2 = p.parse_if_peek::<crate::AnimateableFeature>()?;
         Ok(Self(val0, val1, val2))
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
@@ -20,12 +20,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
         let val0 = p.parse::<crate::BorderTopColorStyleValue>()?;
-        let val1 = if p.peek::<crate::BorderTopColorStyleValue>() {
-            let val = p.parse::<crate::BorderTopColorStyleValue>()?;
-            Some(val)
-        } else {
-            None
-        };
+        let val1 = p.parse_if_peek::<crate::BorderTopColorStyleValue>()?;
         Ok(Self(val0, val1))
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
@@ -7,7 +7,7 @@ expression: pretty
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 enum Foo {
     Foo(::css_parse::T![Ident]),
-    Bar((Option<crate::Color>, Option<crate::Color>, ::css_parse::T![Ident])),
+    Bar(Option<crate::Color>, Option<crate::Color>, ::css_parse::T![Ident]),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
@@ -29,30 +29,22 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 }
             }
         }
-        let val0 = if p.peek::<crate::Color>() {
-            let val = p.parse::<crate::Color>()?;
-            Some(val)
-        } else {
-            None
+        let combo0 = p.parse_if_peek::<crate::Color>()?;
+        let combo1 = p.parse_if_peek::<crate::Color>()?;
+        let combo2 = {
+            let ident = p.parse::<::css_parse::T![Ident]>()?;
+            let c: ::css_lexer::Cursor = ident.into();
+            if !p.eq_ignore_ascii_case(c, "bar") {
+                Err(
+                    ::css_parse::diagnostics::UnexpectedIdent(
+                        p.parse_str(c).into(),
+                        c.into(),
+                    ),
+                )?
+            }
+            ident
         };
-        let val1 = if p.peek::<crate::Color>() {
-            let val = p.parse::<crate::Color>()?;
-            Some(val)
-        } else {
-            None
-        };
-        let val2 = p.parse::<::css_parse::T![Ident]>()?;
-        let c: ::css_lexer::Cursor = val2.into();
-        if !p.eq_ignore_ascii_case(c, "bar") {
-            Err(
-                ::css_parse::diagnostics::UnexpectedIdent(
-                    p.parse_str(c).into(),
-                    c.into(),
-                ),
-            )?
-        }
-        let val = (val0, val1, val2);
-        Ok(Self::Bar(val))
+        Ok(Self::Bar(combo0, combo1, combo2))
     }
 }
 #[automatically_derived]
@@ -62,14 +54,14 @@ impl ::css_parse::ToCursors for Foo {
             Self::Foo(inner) => {
                 ::css_parse::ToCursors::to_cursors(inner, s);
             }
-            Self::Bar(inner) => {
-                if let Some(inner) = &inner.0 {
+            Self::Bar(c0, c1, c2) => {
+                if let Some(inner) = c0 {
                     ::css_parse::ToCursors::to_cursors(inner, s);
                 }
-                if let Some(inner) = &inner.1 {
+                if let Some(inner) = c1 {
                     ::css_parse::ToCursors::to_cursors(inner, s);
                 }
-                ::css_parse::ToCursors::to_cursors(&inner.2, s);
+                ::css_parse::ToCursors::to_cursors(c2, s);
             }
         }
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
@@ -7,7 +7,7 @@ expression: pretty
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 enum Foo {
     Foo(::css_parse::T![Ident]),
-    Bar((Option<crate::Color>, ::css_parse::T![Ident])),
+    Bar(Option<crate::Color>, ::css_parse::T![Ident]),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
@@ -29,24 +29,21 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 }
             }
         }
-        let val0 = if p.peek::<crate::Color>() {
-            let val = p.parse::<crate::Color>()?;
-            Some(val)
-        } else {
-            None
+        let combo0 = p.parse_if_peek::<crate::Color>()?;
+        let combo1 = {
+            let ident = p.parse::<::css_parse::T![Ident]>()?;
+            let c: ::css_lexer::Cursor = ident.into();
+            if !p.eq_ignore_ascii_case(c, "bar") {
+                Err(
+                    ::css_parse::diagnostics::UnexpectedIdent(
+                        p.parse_str(c).into(),
+                        c.into(),
+                    ),
+                )?
+            }
+            ident
         };
-        let val1 = p.parse::<::css_parse::T![Ident]>()?;
-        let c: ::css_lexer::Cursor = val1.into();
-        if !p.eq_ignore_ascii_case(c, "bar") {
-            Err(
-                ::css_parse::diagnostics::UnexpectedIdent(
-                    p.parse_str(c).into(),
-                    c.into(),
-                ),
-            )?
-        }
-        let val = (val0, val1);
-        Ok(Self::Bar(val))
+        Ok(Self::Bar(combo0, combo1))
     }
 }
 #[automatically_derived]
@@ -56,11 +53,11 @@ impl ::css_parse::ToCursors for Foo {
             Self::Foo(inner) => {
                 ::css_parse::ToCursors::to_cursors(inner, s);
             }
-            Self::Bar(inner) => {
-                if let Some(inner) = &inner.0 {
+            Self::Bar(c0, c1) => {
+                if let Some(inner) = c0 {
                     ::css_parse::ToCursors::to_cursors(inner, s);
                 }
-                ::css_parse::ToCursors::to_cursors(&inner.1, s);
+                ::css_parse::ToCursors::to_cursors(c1, s);
             }
         }
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
@@ -7,7 +7,7 @@ expression: pretty
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 enum Foo {
     Foo(::css_parse::T![Ident]),
-    Bar((::css_parse::T![Ident], Option<crate::Color>)),
+    Bar(::css_parse::T![Ident], Option<crate::Color>),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
@@ -28,24 +28,21 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 }
             }
         }
-        let val0 = p.parse::<::css_parse::T![Ident]>()?;
-        let c: ::css_lexer::Cursor = val0.into();
-        if !p.eq_ignore_ascii_case(c, "bar") {
-            Err(
-                ::css_parse::diagnostics::UnexpectedIdent(
-                    p.parse_str(c).into(),
-                    c.into(),
-                ),
-            )?
-        }
-        let val1 = if p.peek::<crate::Color>() {
-            let val = p.parse::<crate::Color>()?;
-            Some(val)
-        } else {
-            None
+        let combo0 = {
+            let ident = p.parse::<::css_parse::T![Ident]>()?;
+            let c: ::css_lexer::Cursor = ident.into();
+            if !p.eq_ignore_ascii_case(c, "bar") {
+                Err(
+                    ::css_parse::diagnostics::UnexpectedIdent(
+                        p.parse_str(c).into(),
+                        c.into(),
+                    ),
+                )?
+            }
+            ident
         };
-        let val = (val0, val1);
-        Ok(Self::Bar(val))
+        let combo1 = p.parse_if_peek::<crate::Color>()?;
+        Ok(Self::Bar(combo0, combo1))
     }
 }
 #[automatically_derived]
@@ -55,9 +52,9 @@ impl ::css_parse::ToCursors for Foo {
             Self::Foo(inner) => {
                 ::css_parse::ToCursors::to_cursors(inner, s);
             }
-            Self::Bar(inner) => {
-                ::css_parse::ToCursors::to_cursors(&inner.0, s);
-                if let Some(inner) = &inner.1 {
+            Self::Bar(c0, c1) => {
+                ::css_parse::ToCursors::to_cursors(c0, s);
+                if let Some(inner) = c1 {
                     ::css_parse::ToCursors::to_cursors(inner, s);
                 }
             }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -28,8 +28,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 }
             }
         }
-        let val = p.parse::<crate::CalcSize>()?;
-        Ok(Self::CalcSizeFunction(val))
+        Ok(Self::CalcSizeFunction(p.parse::<crate::CalcSize>()?))
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -43,8 +43,8 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             )?;
         }
         let start = p.offset();
-        let val = p.parse::<crate::LengthPercentage>()?;
-        let valf32: f32 = val.into();
+        let ty = p.parse::<crate::LengthPercentage>()?;
+        let valf32: f32 = ty.into();
         if 0f32 > valf32 {
             return Err(
                 ::css_parse::diagnostics::NumberTooSmall(
@@ -53,8 +53,9 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 ),
             )?;
         }
+        let inner = ty;
         let close = p.parse_if_peek::<::css_parse::T![')']>()?;
-        Ok(Self::FitContentFunction(function, val, close))
+        Ok(Self::FitContentFunction(function, inner, close))
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -45,17 +45,18 @@ impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
                 ),
             )?;
         }
-        let mut val = ::bumpalo::collections::Vec::new_in(p.bump());
+        let mut items = ::bumpalo::collections::Vec::new_in(p.bump());
         loop {
             let item = p.parse::<crate::FeatureValueName>()?;
             let comma = p.parse_if_peek::<::css_parse::T![,]>()?;
-            val.push((item, comma));
+            items.push((item, comma));
             if comma.is_none() {
                 break;
             }
         }
+        let inner = items;
         let close = p.parse_if_peek::<::css_parse::T![')']>()?;
-        Ok(Self::StylesetFunction(function, val, close))
+        Ok(Self::StylesetFunction(function, inner, close))
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
@@ -21,13 +21,11 @@ impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
         use ::css_parse::{Parse, Peek};
         let c = p.peek_n(1);
         if <crate::Color>::peek(p, c) {
-            let val = p.parse::<crate::Color>()?;
-            return Ok(Self::Color(val));
+            return Ok(Self::Color(p.parse::<crate::Color>()?));
         }
         let c = p.peek_n(1);
         if <crate::Image1D>::peek(p, c) {
-            let val = p.parse::<crate::Image1D>()?;
-            return Ok(Self::Image(val));
+            return Ok(Self::Image(p.parse::<crate::Image1D>()?));
         }
         let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
         Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
@@ -33,16 +33,16 @@ impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
                 }
             }
         }
-        let mut val = ::bumpalo::collections::Vec::new_in(p.bump());
+        let mut items = ::bumpalo::collections::Vec::new_in(p.bump());
         loop {
             let item = p.parse::<crate::AnimateableFeature>()?;
             let comma = p.parse_if_peek::<::css_parse::T![,]>()?;
-            val.push((item, comma));
+            items.push((item, comma));
             if comma.is_none() {
                 break;
             }
         };
-        Ok(Self::AnimateableFeatures(val))
+        Ok(Self::AnimateableFeatures(items))
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
@@ -16,18 +16,8 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        let val0 = if p.peek::<crate::Color>() {
-            let val = p.parse::<crate::Color>()?;
-            Some(val)
-        } else {
-            None
-        };
-        let val1 = if p.peek::<crate::Color>() {
-            let val = p.parse::<crate::Color>()?;
-            Some(val)
-        } else {
-            None
-        };
+        let val0 = p.parse_if_peek::<crate::Color>()?;
+        let val1 = p.parse_if_peek::<crate::Color>()?;
         Ok(Self(val0, val1))
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -7,7 +7,7 @@ expression: pretty
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 enum Foo {
     Foo(::css_parse::T![Ident]),
-    Oblique((::css_parse::T![Ident], Option<crate::Angle>)),
+    Oblique(::css_parse::T![Ident], Option<crate::Angle>),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
@@ -28,20 +28,23 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 }
             }
         }
-        let val0 = p.parse::<::css_parse::T![Ident]>()?;
-        let c: ::css_lexer::Cursor = val0.into();
-        if !p.eq_ignore_ascii_case(c, "oblique") {
-            Err(
-                ::css_parse::diagnostics::UnexpectedIdent(
-                    p.parse_str(c).into(),
-                    c.into(),
-                ),
-            )?
-        }
-        let val1 = if p.peek::<crate::Angle>() {
+        let combo0 = {
+            let ident = p.parse::<::css_parse::T![Ident]>()?;
+            let c: ::css_lexer::Cursor = ident.into();
+            if !p.eq_ignore_ascii_case(c, "oblique") {
+                Err(
+                    ::css_parse::diagnostics::UnexpectedIdent(
+                        p.parse_str(c).into(),
+                        c.into(),
+                    ),
+                )?
+            }
+            ident
+        };
+        let combo1 = if p.peek::<crate::Angle>() {
             let start = p.offset();
-            let val = p.parse::<crate::Angle>()?;
-            let valf32: f32 = val.into();
+            let ty = p.parse::<crate::Angle>()?;
+            let valf32: f32 = ty.into();
             if !(-90f32..90f32).contains(&valf32) {
                 return Err(
                     ::css_parse::diagnostics::NumberOutOfBounds(
@@ -51,12 +54,11 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                     ),
                 )?;
             }
-            Some(val)
+            Some(ty)
         } else {
             None
         };
-        let val = (val0, val1);
-        Ok(Self::Oblique(val))
+        Ok(Self::Oblique(combo0, combo1))
     }
 }
 #[automatically_derived]
@@ -66,9 +68,9 @@ impl ::css_parse::ToCursors for Foo {
             Self::Foo(inner) => {
                 ::css_parse::ToCursors::to_cursors(inner, s);
             }
-            Self::Oblique(inner) => {
-                ::css_parse::ToCursors::to_cursors(&inner.0, s);
-                if let Some(inner) = &inner.1 {
+            Self::Oblique(c0, c1) => {
+                ::css_parse::ToCursors::to_cursors(c0, s);
+                if let Some(inner) = c1 {
                     ::css_parse::ToCursors::to_cursors(inner, s);
                 }
             }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
@@ -17,12 +17,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
         let val0 = p.parse::<crate::CaretColorStyleValue>()?;
-        let val1 = if p.peek::<crate::CaretAnimationStyleValue>() {
-            let val = p.parse::<crate::CaretAnimationStyleValue>()?;
-            Some(val)
-        } else {
-            None
-        };
+        let val1 = p.parse_if_peek::<crate::CaretAnimationStyleValue>()?;
         Ok(Self(val0, val1))
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
@@ -7,7 +7,7 @@ expression: pretty
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 enum Foo {
     Auto(::css_parse::T![Ident]),
-    Colors(crate::Color, crate::Color),
+    Color(crate::Color, crate::Color),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
@@ -28,9 +28,9 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 }
             }
         }
-        let val1 = p.parse::<crate::Color>()?;
-        let val2 = p.parse::<crate::Color>()?;
-        Ok(Self::Colors(val1, val2))
+        let combo0 = p.parse::<crate::Color>()?;
+        let combo1 = p.parse::<crate::Color>()?;
+        Ok(Self::Color(combo0, combo1))
     }
 }
 #[automatically_derived]
@@ -40,9 +40,9 @@ impl ::css_parse::ToCursors for Foo {
             Self::Auto(inner) => {
                 ::css_parse::ToCursors::to_cursors(inner, s);
             }
-            Self::Colors(inner1, inner2) => {
-                ::css_parse::ToCursors::to_cursors(inner1, s);
-                ::css_parse::ToCursors::to_cursors(inner2, s);
+            Self::Color(c0, c1) => {
+                ::css_parse::ToCursors::to_cursors(c0, s);
+                ::css_parse::ToCursors::to_cursors(c1, s);
             }
         }
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
@@ -29,8 +29,8 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             }
         }
         let start = p.offset();
-        let val = p.parse::<crate::Length>()?;
-        let valf32: f32 = val.into();
+        let ty = p.parse::<crate::Length>()?;
+        let valf32: f32 = ty.into();
         if 1f32 > valf32 {
             return Err(
                 ::css_parse::diagnostics::NumberTooSmall(
@@ -39,7 +39,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 ),
             )?;
         }
-        Ok(Self::Length(val))
+        Ok(Self::Length(ty))
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
@@ -16,8 +16,7 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        let val = p.parse::<::css_parse::T![Ident]>()?;
-        Ok(Self(val))
+        Ok(Self(p.parse::<::css_parse::T![Ident]>()?))
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
@@ -16,8 +16,7 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        let val = p.parse::<crate::CSSInt>()?;
-        Ok(Self(val))
+        Ok(Self(p.parse::<crate::CSSInt>()?))
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
@@ -16,8 +16,7 @@ impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        let val = p.parse::<crate::Image>()?;
-        Ok(Self(val))
+        Ok(Self(p.parse::<crate::Image>()?))
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
@@ -28,15 +28,14 @@ impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
                 }
             }
         }
-        let mut val = ::bumpalo::collections::Vec::new_in(p.bump());
+        let mut items = ::bumpalo::collections::Vec::new_in(p.bump());
         loop {
-            let item = p.parse::<crate::Length>()?;
-            val.push(item);
+            items.push(p.parse::<crate::Length>()?);
             if !p.peek::<crate::Length>() {
                 break;
             }
         };
-        Ok(Self::Lengths(val))
+        Ok(Self::Lengths(items))
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
@@ -23,18 +23,8 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         use ::css_parse::{Parse, Peek};
         let val0 = p.parse::<crate::Length>()?;
         let val1 = p.parse::<crate::Length>()?;
-        let val2 = if p.peek::<crate::Length>() {
-            let val = p.parse::<crate::Length>()?;
-            Some(val)
-        } else {
-            None
-        };
-        let val3 = if p.peek::<crate::Length>() {
-            let val = p.parse::<crate::Length>()?;
-            Some(val)
-        } else {
-            None
-        };
+        let val2 = p.parse_if_peek::<crate::Length>()?;
+        let val3 = p.parse_if_peek::<crate::Length>()?;
         Ok(Self(val0, val1, val2, val3))
     }
 }


### PR DESCRIPTION
This PR attempts to clean up def.rs a little, with a few key techniques that result in tidier codegen on the other side:

# Optimization 1

`GenerateParseImpl::parse_steps` used to take a `capture: Option<TokenStream>` which could be used as a binding to store the parsed values. Instead we now _return_ a tuple of 2 `TokenStream`s - the first is the parse "steps" and the second is the parse "result"; an expression that can be captured as a binding or enum variant.

The capture binding was overly restrictive on what parsing could do because it could only store a single binding, meaning some values ended up being stored as units, for example `<color>{1,2} | auto` would result in `enum Foo { Color((Color, Option<Color>)), Auto(T![Ident]) }`. With this change the same syntax can now produce `enum Foo { Color(Color, Option<Color>), Auto(T![Ident]) }` - the difference being that the `Color` enum variant is no longer a single tuple of 2 Colors, but instead 2 values! This is important because it enables simpler struct types.

The other benefit to this is that parse steps which are a single expression can be packed into the "result" `TokenStream` (the second entry in the tuple). This means single expression tokens no longer creating a binding, only to return use that binding in the next line, so for e.g. a step like:

```rs
let val = p.parse::<crate::CalcSize>()?;
Ok(Self::CalcSizeFunction(val))
```

Can be simplified to:

```rs
Ok(Self::CalcSizeFunction(p.parse::<crate::CalcSize>()?))
```

# Optimization 2

We used to check for `Def::Multiplier` and try to optimize away fixed or bounded ranges. So for example `<bar>{1,2}` would optimize away to an ordered combinator - so instead of `struct Foo<'a>(Vec<'a, Bar>)` you'd end up with `struct Foo(Bar, Option<Bar>)`.

This is a very useful optimisation, not just for the cleanliness of generated output but it also potentially avoids allocations.

The issue with the way we handled this optimisation is that it was done on the code generation phase, meaning we had lots of repetative branches to deal with it, and not all were covered - for example `<bar>{1,2} | auto` would break the optimisation (because the code inside of Combinator didn't include this optimisation case) and so while `<bar>{1,2}` would optimise to `struct Foo<'a>(Vec<'a, Bar>)`, `<bar>{1,2} | auto` would still be `enum Foo<'a> { Bar(Vec<'a, Bar>), Auto(T![Ident]) }`. No good.

So, rather than putting this optimisation into the _code generation_ phase, it has been lifted to the _def parsing_ phase. When the parser encounters a fixed or bounded range instead of outputting a `Def::Multiplier`, it'll output a `Def::Combinator(_, Ordered)`. This means that the code generation can forget about branching for these cases and we have the added benefit of handling this at any depth level.

I think the snapshot tests speak to the improvements here.
