### PR TITLE
enable text-emphasis-skip

### DIFF
--- a/crates/css_ast/src/values/text_decor/impls.rs
+++ b/crates/css_ast/src/values/text_decor/impls.rs
@@ -4,7 +4,7 @@ pub(crate) use csskit_proc_macro::*;
 #[cfg(test)]
 mod tests {
 	use super::super::*;
-	use css_parse::assert_parse;
+	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
 	pub fn size_test() {
@@ -26,12 +26,33 @@ mod tests {
 		assert_eq!(std::mem::size_of::<TextDecorationSkipBoxStyleValue>(), 16);
 		// assert_eq!(std::mem::size_of::<TextDecorationSkipSpacesStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<TextDecorationSkipInkStyleValue>(), 16);
-		// assert_eq!(std::mem::size_of::<TextEmphasisSkipStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<TextEmphasisSkipStyleValue>(), 64);
 	}
 
 	#[test]
 	fn test_writes() {
 		assert_parse!(TextDecorationTrimStyleValue, "1px 2px");
 		assert_parse!(TextDecorationTrimStyleValue, "auto");
+
+		assert_parse!(TextEmphasisSkipStyleValue, "spaces");
+		assert_parse!(TextEmphasisSkipStyleValue, "punctuation");
+		assert_parse!(TextEmphasisSkipStyleValue, "symbols");
+		assert_parse!(TextEmphasisSkipStyleValue, "narrow");
+		// Out of order keywords also work
+		assert_parse!(TextEmphasisSkipStyleValue, "narrow symbols", "symbols narrow");
+		assert_parse!(
+			TextEmphasisSkipStyleValue,
+			"punctuation symbols spaces narrow",
+			"spaces punctuation symbols narrow"
+		);
+	}
+
+	#[test]
+	fn test_errors() {
+		assert_parse_error!(TextEmphasisSkipStyleValue, "");
+		assert_parse_error!(TextEmphasisSkipStyleValue, "spaces spaces");
+		assert_parse_error!(TextEmphasisSkipStyleValue, "punctuation punctuation");
+		assert_parse_error!(TextEmphasisSkipStyleValue, "foo");
+		assert_parse_error!(TextEmphasisSkipStyleValue, "punctuation bar narrow");
 	}
 }

--- a/crates/css_ast/src/values/text_decor/mod.rs
+++ b/crates/css_ast/src/values/text_decor/mod.rs
@@ -186,12 +186,12 @@ pub enum TextDecorationSkipBoxStyleValue {}
 #[animation_type("discrete")]
 pub enum TextDecorationSkipInkStyleValue {}
 
-// // https://drafts.csswg.org/css-text-decor-4/#text-emphasis-skip
-// #[value(" spaces || punctuation || symbols || narrow ")]
-// #[initial("spaces punctuation")]
-// #[applies_to("text")]
-// #[inherited("yes")]
-// #[percentages("n/a")]
-// #[canonical_order("per grammar")]
-// #[animation_type("discrete")]
-// pub struct TextEmphasisSkipStyleValue;
+// https://drafts.csswg.org/css-text-decor-4/#text-emphasis-skip
+#[value(" spaces || punctuation || symbols || narrow ")]
+#[initial("spaces punctuation")]
+#[applies_to("text")]
+#[inherited("yes")]
+#[percentages("n/a")]
+#[canonical_order("per grammar")]
+#[animation_type("discrete")]
+pub struct TextEmphasisSkipStyleValue;

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
@@ -1,0 +1,82 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(FooKeywords { Foo : "foo", Bar : "bar", Baz : "baz", });
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+struct Foo {
+    foo: Option<::css_parse::T![Ident]>,
+    bar: Option<::css_parse::T![Ident]>,
+    baz: Option<::css_parse::T![Ident]>,
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for Foo {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+        use ::css_parse::Peek;
+        <::css_parse::T![Ident]>::peek(p, c)
+    }
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Foo {
+    fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
+        use ::css_parse::{Parse, Peek};
+        use ::css_parse::Build;
+        let mut val = Self {
+            foo: None,
+            bar: None,
+            baz: None,
+        };
+        loop {
+            if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
+                match keyword {
+                    FooKeywords::Foo(c) => {
+                        if val.foo.is_some() {
+                            Err(
+                                ::css_parse::diagnostics::Unexpected(c.into(), c.into()),
+                            )?
+                        }
+                        val.foo = Some(<::css_parse::T![Ident]>::build(p, c));
+                    }
+                    FooKeywords::Bar(c) => {
+                        if val.bar.is_some() {
+                            Err(
+                                ::css_parse::diagnostics::Unexpected(c.into(), c.into()),
+                            )?
+                        }
+                        val.bar = Some(<::css_parse::T![Ident]>::build(p, c));
+                    }
+                    FooKeywords::Baz(c) => {
+                        if val.baz.is_some() {
+                            Err(
+                                ::css_parse::diagnostics::Unexpected(c.into(), c.into()),
+                            )?
+                        }
+                        val.baz = Some(<::css_parse::T![Ident]>::build(p, c));
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        if val.foo.is_none() && val.bar.is_none() && val.baz.is_none() {
+            let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+        }
+        Ok(val)
+    }
+}
+#[automatically_derived]
+impl ::css_parse::ToCursors for Foo {
+    fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
+        if let Some(c) = self.foo {
+            s.append(c.into());
+        }
+        if let Some(c) = self.bar {
+            s.append(c.into());
+        }
+        if let Some(c) = self.baz {
+            s.append(c.into());
+        }
+    }
+}

--- a/crates/csskit_proc_macro/src/string_transform.rs
+++ b/crates/csskit_proc_macro/src/string_transform.rs
@@ -9,6 +9,17 @@ pub fn kebab(str: String) -> String {
 	kebab
 }
 
+pub fn snake(str: String) -> String {
+	let mut kebab = String::new();
+	for (i, ch) in str.char_indices() {
+		if i > 0 && ch.is_uppercase() {
+			kebab.push('_');
+		}
+		kebab.push(ch.to_ascii_lowercase());
+	}
+	kebab
+}
+
 pub fn pascal(str: String) -> String {
 	let mut pascal = String::new();
 	let mut make_upper = true;

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -538,3 +538,10 @@ fn just_optional() {
 	let data = to_deriveinput! { struct Foo {} };
 	assert_snapshot!(syntax, data, "just_optional");
 }
+
+#[test]
+fn combinator_optional_all_keywords() {
+	let syntax = to_valuedef! { foo || bar || baz };
+	let data = to_deriveinput! { struct Foo {} };
+	assert_snapshot!(syntax, data, "combinator_optional_all_keywords");
+}


### PR DESCRIPTION
`text-emphasis-skip` is an interesting value:

```
spaces || punctuation || symbols || narrow
```

This effectively says "it can be any of these keywords, in any order. This is quite simple to define as a data-type:

```rs
struct TextEmphasisSkipStyleValue {
  spaces: Option<T![Ident]>,
  punctuation: Option<T![Ident]>,
  symbols: Option<T![Ident]>,
  narrow: Option<T![Ident]>,
}
```

The parsing rules should be farily evident from this struct. 

Sadly the soluton is a little unweildy (at least as I've naively done it). We check especially for a Combinator of Optionals where all the options are Idents, and branch if they are - generating the defintion and code for this exactly. 

Hopefully some more style values will leverage this technique so we don't have all these code branches for one style value.