### PR TITLE
implement IntoCursor derive

### DIFF
--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	AtRule, Build, CommaSeparatedPreludeList, DeclarationList, Parse, Parser, Peek, QualifiedRule, QualifiedRuleList,
 	Result as ParserResult, T, diagnostics, keyword_set, syntax::BadDeclaration,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, properties::Property};
@@ -39,7 +39,7 @@ impl<'a> Visitable<'a> for KeyframesRule<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum KeyframesName {
 	Ident(T![Ident]),
@@ -71,15 +71,6 @@ impl<'a> Parse<'a> for KeyframesName {
 			Err(diagnostics::ReservedKeyframeName(str.into(), c.into()))?
 		}
 		Ok(Self::Ident(ident))
-	}
-}
-
-impl From<KeyframesName> for Cursor {
-	fn from(value: KeyframesName) -> Self {
-		match value {
-			KeyframesName::String(c) => c.into(),
-			KeyframesName::Ident(c) => c.into(),
-		}
 	}
 }
 
@@ -188,7 +179,7 @@ impl<'a> Visitable<'a> for KeyframeBlock<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub enum KeyframeSelector {
@@ -220,16 +211,6 @@ impl<'a> Parse<'a> for KeyframeSelector {
 			Ok(Self::Percent(percent))
 		} else {
 			Err(diagnostics::NumberOutOfBounds(f, format!("{:?}", 0.0..=100.0), c.into()))?
-		}
-	}
-}
-
-impl From<KeyframeSelector> for Cursor {
-	fn from(value: KeyframeSelector) -> Self {
-		match value {
-			KeyframeSelector::From(c) => c.into(),
-			KeyframeSelector::To(c) => c.into(),
-			KeyframeSelector::Percent(c) => c.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	AtRule, Block, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Peek, PreludeList,
 	Result as ParserResult, T, diagnostics, keyword_set,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 use crate::{Property, Visit, Visitable, stylesheet::Rule};
 
@@ -82,7 +82,7 @@ impl<'a> Parse<'a> for MediaQueryList<'a> {
 
 keyword_set!(MediaPreCondition { Not: "not", Only: "only" });
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub enum MediaType {
 	All(T![Ident]),
@@ -122,17 +122,6 @@ impl<'a> Build<'a> for MediaType {
 			Some(Self::Screen(_)) => Self::Screen(<T![Ident]>::build(p, c)),
 			_ if *Self::INVALID.get(str).unwrap_or(&false) => unreachable!(),
 			_ => Self::Custom(<T![Ident]>::build(p, c)),
-		}
-	}
-}
-
-impl From<MediaType> for Cursor {
-	fn from(value: MediaType) -> Cursor {
-		match value {
-			MediaType::All(c) => c.into(),
-			MediaType::Print(c) => c.into(),
-			MediaType::Screen(c) => c.into(),
-			MediaType::Custom(c) => c.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -1,6 +1,6 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -91,7 +91,7 @@ impl<'a> Parse<'a> for AttributeOperator {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value"))]
 pub enum AttributeValue {
 	String(T![String]),
@@ -114,16 +114,7 @@ impl<'a> Build<'a> for AttributeValue {
 	}
 }
 
-impl From<AttributeValue> for Cursor {
-	fn from(value: AttributeValue) -> Cursor {
-		match value {
-			AttributeValue::Ident(c) => c.into(),
-			AttributeValue::String(c) => c.into(),
-		}
-	}
-}
-
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum AttributeModifier {
 	Sensitive(T![Ident]),
@@ -142,15 +133,6 @@ impl<'a> Build<'a> for AttributeModifier {
 			Self::Sensitive(<T![Ident]>::build(p, c))
 		} else {
 			Self::Insensitive(<T![Ident]>::build(p, c))
-		}
-	}
-}
-
-impl From<AttributeModifier> for Cursor {
-	fn from(value: AttributeModifier) -> Self {
-		match value {
-			AttributeModifier::Sensitive(c) => c.into(),
-			AttributeModifier::Insensitive(c) => c.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	Build, CompoundSelector as CompoundSelectorTrait, Parse, Parser, Peek, Result as ParserResult,
 	SelectorComponent as SelectorComponentTrait, SelectorList as SelectorListTrait, T,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 use csskit_proc_macro::visit;
 
 mod attribute;
@@ -99,7 +99,7 @@ pub type ComplexSelector<'a> = SelectorList<'a>;
 pub type ForgivingSelector<'a> = SelectorList<'a>;
 pub type RelativeSelector<'a> = SelectorList<'a>;
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct Id(T![Hash]);
@@ -116,19 +116,13 @@ impl<'a> Build<'a> for Id {
 	}
 }
 
-impl From<Id> for Cursor {
-	fn from(value: Id) -> Self {
-		value.0.into()
-	}
-}
-
 impl<'a> Visitable<'a> for Id {
 	fn accept<V: Visit<'a>>(&self, v: &mut V) {
 		v.visit_id(self);
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct Wildcard(T![*]);
@@ -142,12 +136,6 @@ impl<'a> Peek<'a> for Wildcard {
 impl<'a> Build<'a> for Wildcard {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		Self(<T![*]>::build(p, c))
-	}
-}
-
-impl From<Wildcard> for Cursor {
-	fn from(value: Wildcard) -> Self {
-		value.0.into()
 	}
 }
 

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,6 +1,6 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -80,7 +80,7 @@ impl<'a> Parse<'a> for NamespacePrefix {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NamespaceTag {
 	Tag(Tag),
@@ -96,15 +96,6 @@ impl<'a> Peek<'a> for NamespaceTag {
 impl<'a> Build<'a> for NamespaceTag {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		if <T![*]>::peek(p, c) { Self::Wildcard(<T![*]>::build(p, c)) } else { Self::Tag(Tag::build(p, c)) }
-	}
-}
-
-impl From<NamespaceTag> for Cursor {
-	fn from(value: NamespaceTag) -> Self {
-		match value {
-			NamespaceTag::Tag(c) => c.into(),
-			NamespaceTag::Wildcard(c) => c.into(),
-		}
 	}
 }
 

--- a/crates/css_ast/src/selector/tag.rs
+++ b/crates/css_ast/src/selector/tag.rs
@@ -1,11 +1,11 @@
-use css_lexer::{Cursor, Span};
+use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub enum Tag {
@@ -44,27 +44,6 @@ impl<'a> Build<'a> for Tag {
 	}
 }
 
-impl From<Tag> for Cursor {
-	fn from(value: Tag) -> Self {
-		match value {
-			Tag::Html(c) => c.into(),
-			Tag::HtmlNonConforming(c) => c.into(),
-			Tag::HtmlNonStandard(c) => c.into(),
-			Tag::Svg(c) => c.into(),
-			Tag::Mathml(c) => c.into(),
-			Tag::CustomElement(c) => c.into(),
-			Tag::Unknown(c) => c.into(),
-		}
-	}
-}
-
-impl From<&Tag> for Span {
-	fn from(value: &Tag) -> Self {
-		let c: Cursor = (*value).into();
-		c.into()
-	}
-}
-
 impl<'a> Visitable<'a> for Tag {
 	fn accept<V: Visit<'a>>(&self, v: &mut V) {
 		v.visit_tag(self);
@@ -80,7 +59,7 @@ impl<'a> Visitable<'a> for Tag {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct CustomElementTag(T![Ident]);
@@ -143,19 +122,6 @@ impl<'a> Peek<'a> for CustomElementTag {
 impl<'a> Build<'a> for CustomElementTag {
 	fn build(p: &Parser<'a>, c: css_lexer::Cursor) -> Self {
 		Self(<T![Ident]>::build(p, c))
-	}
-}
-
-impl From<CustomElementTag> for Cursor {
-	fn from(value: CustomElementTag) -> Self {
-		value.0.into()
-	}
-}
-
-impl From<&CustomElementTag> for Span {
-	fn from(value: &CustomElementTag) -> Self {
-		let c: Cursor = (*value).into();
-		c.into()
 	}
 }
 
@@ -608,7 +574,7 @@ impl<'a> Visitable<'a> for MathmlTag {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct UnknownTag(T![Ident]);
@@ -622,19 +588,6 @@ impl<'a> Peek<'a> for UnknownTag {
 impl<'a> Build<'a> for UnknownTag {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		Self(<T![Ident]>::build(p, c))
-	}
-}
-
-impl From<&UnknownTag> for Span {
-	fn from(value: &UnknownTag) -> Self {
-		let c: Cursor = (*value).into();
-		c.into()
-	}
-}
-
-impl From<UnknownTag> for Cursor {
-	fn from(value: UnknownTag) -> Self {
-		value.0.into()
 	}
 }
 

--- a/crates/css_ast/src/types/animateable_feature.rs
+++ b/crates/css_ast/src/types/animateable_feature.rs
@@ -1,10 +1,10 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 // https://drafts.csswg.org/css-will-change-1/#typedef-animateable-feature
 // <animateable-feature> = scroll-position | contents | <custom-ident>
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum AnimateableFeature {
 	ScrollPosition(T![Ident]),
@@ -131,43 +131,6 @@ impl<'a> Build<'a> for AnimateableFeature {
 			Some(Self::ViewTransitionName(_)) => Self::ViewTransitionName(ident),
 			Some(Self::ZIndex(_)) => Self::ZIndex(ident),
 			_ => Self::CustomIdent(ident),
-		}
-	}
-}
-
-impl From<AnimateableFeature> for Cursor {
-	fn from(value: AnimateableFeature) -> Self {
-		match value {
-			AnimateableFeature::ScrollPosition(c) => c.into(),
-			AnimateableFeature::Contents(c) => c.into(),
-			AnimateableFeature::CustomIdent(c) => c.into(),
-			AnimateableFeature::BackdropFilter(c) => c.into(),
-			AnimateableFeature::ClipPath(c) => c.into(),
-			AnimateableFeature::Contain(c) => c.into(),
-			AnimateableFeature::Filter(c) => c.into(),
-			AnimateableFeature::Isolation(c) => c.into(),
-			AnimateableFeature::MixBlendMode(c) => c.into(),
-			AnimateableFeature::OffsetPath(c) => c.into(),
-			AnimateableFeature::Opacity(c) => c.into(),
-			AnimateableFeature::Perspective(c) => c.into(),
-			AnimateableFeature::Position(c) => c.into(),
-			AnimateableFeature::Rotate(c) => c.into(),
-			AnimateableFeature::Scale(c) => c.into(),
-			AnimateableFeature::Transform(c) => c.into(),
-			AnimateableFeature::TransformStyle(c) => c.into(),
-			AnimateableFeature::Translate(c) => c.into(),
-			AnimateableFeature::ZIndex(c) => c.into(),
-			AnimateableFeature::ViewTransitionName(c) => c.into(),
-			AnimateableFeature::Mask(c) => c.into(),
-			AnimateableFeature::OffsetPosition(c) => c.into(),
-			AnimateableFeature::WebkitBoxReflect(c) => c.into(),
-			AnimateableFeature::WebkitMaskBoxImage(c) => c.into(),
-			AnimateableFeature::MaskBorder(c) => c.into(),
-			AnimateableFeature::WebkitMask(c) => c.into(),
-			AnimateableFeature::WebkitPerspective(c) => c.into(),
-			AnimateableFeature::WebkitBackdropFilter(c) => c.into(),
-			AnimateableFeature::WebkitOverflowScrolling(c) => c.into(),
-			AnimateableFeature::MaskImage(c) => c.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/types/color/color_function.rs
+++ b/crates/css_ast/src/types/color/color_function.rs
@@ -1,7 +1,7 @@
 use crate::units::Angle;
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 function_set!(ColorFunctionName {
 	Color: "color",
@@ -16,7 +16,7 @@ function_set!(ColorFunctionName {
 	Oklch: "oklch",
 });
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Hue {
 	None(T![Ident]),
@@ -41,16 +41,8 @@ impl<'a> Build<'a> for Hue {
 		}
 	}
 }
-impl From<Hue> for Cursor {
-	fn from(value: Hue) -> Self {
-		match value {
-			Hue::None(c) => c.into(),
-			Hue::Number(c) => c.into(),
-			Hue::Angle(c) => c.into(),
-		}
-	}
-}
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Channel {
 	None(T![Ident]),
@@ -74,16 +66,6 @@ impl<'a> Build<'a> for Channel {
 			Self::Percent(<T![Dimension::%]>::build(p, c))
 		} else {
 			Self::None(<T![Ident]>::build(p, c))
-		}
-	}
-}
-
-impl From<Channel> for Cursor {
-	fn from(value: Channel) -> Self {
-		match value {
-			Channel::None(c) => c.into(),
-			Channel::Number(c) => c.into(),
-			Channel::Percent(c) => c.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/types/font_weight_absolute.rs
+++ b/crates/css_ast/src/types/font_weight_absolute.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 use crate::CSSInt;
 
 // https://drafts.csswg.org/css-fonts-4/#font-weight-absolute-values
 // <font-weight-absolute> = [normal | bold | <number [1,1000]>]
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value"))]
 pub enum FontWeightAbsolute {
 	Normal(T![Ident]),
@@ -42,16 +42,6 @@ impl<'a> Parse<'a> for FontWeightAbsolute {
 			Err(diagnostics::NumberTooLarge(f, c.into()))?
 		}
 		Ok(Self::Number(int))
-	}
-}
-
-impl From<FontWeightAbsolute> for Cursor {
-	fn from(value: FontWeightAbsolute) -> Self {
-		match value {
-			FontWeightAbsolute::Normal(c) => c.into(),
-			FontWeightAbsolute::Bold(c) => c.into(),
-			FontWeightAbsolute::Number(c) => c.into(),
-		}
 	}
 }
 

--- a/crates/css_ast/src/types/opacity_value.rs
+++ b/crates/css_ast/src/types/opacity_value.rs
@@ -1,8 +1,8 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum OpacityValue {
 	Number(T![Number]),
@@ -45,15 +45,6 @@ impl<'a> Build<'a> for OpacityValue {
 			Self::Number(<T![Number]>::build(p, c))
 		} else {
 			Self::Percent(<T![Dimension::%]>::build(p, c))
-		}
-	}
-}
-
-impl From<OpacityValue> for Cursor {
-	fn from(value: OpacityValue) -> Self {
-		match value {
-			OpacityValue::Number(t) => t.into(),
-			OpacityValue::Percent(t) => t.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -1,6 +1,6 @@
 use css_lexer::{Cursor, Kind, Token};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 use crate::units::LengthPercentage;
 
@@ -94,7 +94,7 @@ impl<'a> Parse<'a> for Position {
 
 keyword_set!(PositionValueKeyword { Left: "left", Right: "right", Center: "center", Top: "top", Bottom: "bottom" });
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionSingleValue {
 	Left(T![Ident]),
@@ -147,32 +147,6 @@ impl PositionSingleValue {
 	}
 }
 
-impl From<PositionSingleValue> for Token {
-	fn from(value: PositionSingleValue) -> Self {
-		match value {
-			PositionSingleValue::Left(v) => v.into(),
-			PositionSingleValue::Right(v) => v.into(),
-			PositionSingleValue::Center(v) => v.into(),
-			PositionSingleValue::Top(v) => v.into(),
-			PositionSingleValue::Bottom(v) => v.into(),
-			PositionSingleValue::LengthPercentage(v) => v.into(),
-		}
-	}
-}
-
-impl From<PositionSingleValue> for Cursor {
-	fn from(value: PositionSingleValue) -> Self {
-		match value {
-			PositionSingleValue::Left(v) => v.into(),
-			PositionSingleValue::Right(v) => v.into(),
-			PositionSingleValue::Center(v) => v.into(),
-			PositionSingleValue::Top(v) => v.into(),
-			PositionSingleValue::Bottom(v) => v.into(),
-			PositionSingleValue::LengthPercentage(v) => v.into(),
-		}
-	}
-}
-
 impl From<PositionSingleValue> for Kind {
 	fn from(value: PositionSingleValue) -> Self {
 		let t: Token = value.into();
@@ -205,7 +179,7 @@ impl<'a> Build<'a> for PositionSingleValue {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionHorizontal {
 	Left(T![Ident]),
@@ -214,57 +188,13 @@ pub enum PositionHorizontal {
 	LengthPercentage(LengthPercentage),
 }
 
-impl From<PositionHorizontal> for Token {
-	fn from(value: PositionHorizontal) -> Self {
-		match value {
-			PositionHorizontal::Left(v) => v.into(),
-			PositionHorizontal::Right(v) => v.into(),
-			PositionHorizontal::Center(v) => v.into(),
-			PositionHorizontal::LengthPercentage(v) => v.into(),
-		}
-	}
-}
-
-impl From<PositionHorizontal> for Cursor {
-	fn from(value: PositionHorizontal) -> Self {
-		match value {
-			PositionHorizontal::Left(v) => v.into(),
-			PositionHorizontal::Right(v) => v.into(),
-			PositionHorizontal::Center(v) => v.into(),
-			PositionHorizontal::LengthPercentage(v) => v.into(),
-		}
-	}
-}
-
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionVertical {
 	Top(T![Ident]),
 	Bottom(T![Ident]),
 	Center(T![Ident]),
 	LengthPercentage(LengthPercentage),
-}
-
-impl From<PositionVertical> for Token {
-	fn from(value: PositionVertical) -> Self {
-		match value {
-			PositionVertical::Top(v) => v.into(),
-			PositionVertical::Bottom(v) => v.into(),
-			PositionVertical::Center(v) => v.into(),
-			PositionVertical::LengthPercentage(v) => v.into(),
-		}
-	}
-}
-
-impl From<PositionVertical> for Cursor {
-	fn from(value: PositionVertical) -> Self {
-		match value {
-			PositionVertical::Top(v) => v.into(),
-			PositionVertical::Bottom(v) => v.into(),
-			PositionVertical::Center(v) => v.into(),
-			PositionVertical::LengthPercentage(v) => v.into(),
-		}
-	}
 }
 
 keyword_set!(PositionHorizontalKeyword { Left: "left", Right: "right" });

--- a/crates/css_ast/src/types/single_animation_iteration_count.rs
+++ b/crates/css_ast/src/types/single_animation_iteration_count.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 use crate::units::CSSFloat;
 
 // https://drafts.csswg.org/css-animations/#typedef-single-animation-iteration-count
 // <single-animation-iteration-count> = infinite | <number [0,∞]>
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(
 	feature = "serde",
 	derive(serde::Serialize),
@@ -35,14 +35,5 @@ impl<'a> Parse<'a> for SingleAnimationIterationCount {
 			Err(diagnostics::NumberTooSmall(f, c.into()))?
 		}
 		Ok(Self::Number(int))
-	}
-}
-
-impl From<SingleAnimationIterationCount> for Cursor {
-	fn from(value: SingleAnimationIterationCount) -> Self {
-		match value {
-			SingleAnimationIterationCount::Infinite(c) => c.into(),
-			SingleAnimationIterationCount::Number(c) => c.into(),
-		}
 	}
 }

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -1,13 +1,13 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 // const DEG_GRAD: f32 = 0.9;
 // const DEG_RAD: f32 = 57.295_78;
 // const DEG_TURN: f32 = 360.0;
 
 // https://drafts.csswg.org/css-values/#angles
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Angle {
 	Grad(T![Dimension::Grad]),
@@ -41,17 +41,6 @@ impl<'a> Build<'a> for Angle {
 			"turn" => Self::Turn(<T![Dimension::Turn]>::build(p, c)),
 			"deg" => Self::Deg(<T![Dimension::Deg]>::build(p, c)),
 			_ => unreachable!(),
-		}
-	}
-}
-
-impl From<Angle> for Cursor {
-	fn from(value: Angle) -> Self {
-		match value {
-			Angle::Grad(t) => t.into(),
-			Angle::Rad(t) => t.into(),
-			Angle::Turn(t) => t.into(),
-			Angle::Deg(t) => t.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/units/custom.rs
+++ b/crates/css_ast/src/units/custom.rs
@@ -1,8 +1,8 @@
 use css_lexer::{Cursor, DimensionUnit};
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct CustomDimension(T![Dimension]);
 
@@ -21,12 +21,6 @@ impl<'a> Peek<'a> for CustomDimension {
 impl<'a> Build<'a> for CustomDimension {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		Self(<T![Dimension]>::build(p, c))
-	}
-}
-
-impl From<CustomDimension> for Cursor {
-	fn from(value: CustomDimension) -> Self {
-		value.0.into()
 	}
 }
 

--- a/crates/css_ast/src/units/flex.rs
+++ b/crates/css_ast/src/units/flex.rs
@@ -1,9 +1,9 @@
-use css_lexer::{Cursor, Token};
+use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 // https://www.w3.org/TR/css-grid-2/#typedef-flex
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Flex(T![Dimension::Fr]);
 
@@ -22,18 +22,6 @@ impl<'a> Peek<'a> for Flex {
 impl<'a> Build<'a> for Flex {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		Self(<T![Dimension::Fr]>::build(p, c))
-	}
-}
-
-impl From<Flex> for Token {
-	fn from(flex: Flex) -> Self {
-		flex.0.into()
-	}
-}
-
-impl From<Flex> for Cursor {
-	fn from(flex: Flex) -> Self {
-		flex.0.into()
 	}
 }
 

--- a/crates/css_ast/src/units/float.rs
+++ b/crates/css_ast/src/units/float.rs
@@ -1,8 +1,8 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
 pub struct CSSFloat(T![Number]);
 
@@ -32,12 +32,6 @@ impl<'a> Peek<'a> for CSSFloat {
 impl<'a> Build<'a> for CSSFloat {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		Self(<T![Number]>::build(p, c))
-	}
-}
-
-impl From<CSSFloat> for Cursor {
-	fn from(value: CSSFloat) -> Self {
-		value.0.into()
 	}
 }
 

--- a/crates/css_ast/src/units/frequency.rs
+++ b/crates/css_ast/src/units/frequency.rs
@@ -1,9 +1,9 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 // https://drafts.csswg.org/css-values/#resolution
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Frequency {
 	Hz(T![Dimension::Hz]),
@@ -31,15 +31,6 @@ impl<'a> Build<'a> for Frequency {
 			"hz" => Self::Hz(<T![Dimension::Hz]>::build(p, c)),
 			"khz" => Self::Khz(<T![Dimension::Khz]>::build(p, c)),
 			_ => unreachable!(),
-		}
-	}
-}
-
-impl From<Frequency> for Cursor {
-	fn from(value: Frequency) -> Self {
-		match value {
-			Frequency::Hz(t) => t.into(),
-			Frequency::Khz(t) => t.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/units/int.rs
+++ b/crates/css_ast/src/units/int.rs
@@ -1,8 +1,8 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
 pub struct CSSInt(T![Number]);
 
@@ -32,12 +32,6 @@ impl<'a> Peek<'a> for CSSInt {
 impl<'a> Build<'a> for CSSInt {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		Self(<T![Number]>::build(p, c))
-	}
-}
-
-impl From<CSSInt> for Cursor {
-	fn from(value: CSSInt) -> Self {
-		value.0.into()
 	}
 }
 

--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -1,6 +1,6 @@
-use css_lexer::{Cursor, Token};
+use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 use super::Flex;
 
@@ -76,7 +76,7 @@ macro_rules! apply_lengths {
 
 macro_rules! define_length {
 	( $($name: ident),+ $(,)* ) => {
-		#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value", rename_all = "kebab-case"))]
 		pub enum Length {
 			Zero(T![Number]),
@@ -96,20 +96,6 @@ impl From<Length> for f32 {
 				}
 			}
 		}
-		apply_lengths!(match_length)
-	}
-}
-
-impl From<Length> for Token {
-	fn from(value: Length) -> Self {
-		macro_rules! match_length {
-				( $($name: ident),+ $(,)* ) => {
-					match value {
-						Length::Zero(l) => l.into(),
-						$(Length::$name(l) => l.into(),)+
-					}
-				}
-			}
 		apply_lengths!(match_length)
 	}
 }
@@ -141,23 +127,9 @@ impl<'a> Build<'a> for Length {
 	}
 }
 
-impl From<Length> for Cursor {
-	fn from(value: Length) -> Self {
-		macro_rules! from_steps {
-			( $($name: ident),+ $(,)* ) => {
-				match value {
-					$(Length::$name(t) => t.into(),)+
-					Length::Zero(t) => t.into(),
-				}
-			}
-		}
-		apply_lengths!(from_steps)
-	}
-}
-
 macro_rules! define_length_percentage {
 	( $($name: ident),+ $(,)* ) => {
-		#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value", rename_all = "kebab-case"))]
 		pub enum LengthPercentage {
 			Zero(T![Number]),
@@ -180,36 +152,6 @@ impl From<LengthPercentage> for f32 {
 			}
 		}
 		apply_lengths!(match_length)
-	}
-}
-
-impl From<LengthPercentage> for Token {
-	fn from(value: LengthPercentage) -> Self {
-		macro_rules! match_length {
-				( $($name: ident),+ $(,)* ) => {
-					match value {
-						LengthPercentage::Zero(l) => l.into(),
-						LengthPercentage::Percent(l) => l.into(),
-						$(LengthPercentage::$name(l) => l.into(),)+
-					}
-				}
-			}
-		apply_lengths!(match_length)
-	}
-}
-
-impl From<LengthPercentage> for Cursor {
-	fn from(value: LengthPercentage) -> Self {
-		macro_rules! from_steps {
-			( $($name: ident),+ $(,)* ) => {
-				match value {
-					$(LengthPercentage::$name(t) => t.into(),)+
-					LengthPercentage::Percent(t) => t.into(),
-					LengthPercentage::Zero(t) => t.into(),
-				}
-			}
-		}
-		apply_lengths!(from_steps)
 	}
 }
 
@@ -243,7 +185,7 @@ impl<'a> Build<'a> for LengthPercentage {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum LengthPercentageOrAuto {
 	Auto(T![Ident]),
@@ -266,25 +208,7 @@ impl<'a> Build<'a> for LengthPercentageOrAuto {
 	}
 }
 
-impl From<LengthPercentageOrAuto> for Token {
-	fn from(value: LengthPercentageOrAuto) -> Self {
-		match value {
-			LengthPercentageOrAuto::Auto(l) => l.into(),
-			LengthPercentageOrAuto::LengthPercentage(l) => l.into(),
-		}
-	}
-}
-
-impl From<LengthPercentageOrAuto> for Cursor {
-	fn from(value: LengthPercentageOrAuto) -> Self {
-		match value {
-			LengthPercentageOrAuto::Auto(t) => t.into(),
-			LengthPercentageOrAuto::LengthPercentage(t) => t.into(),
-		}
-	}
-}
-
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum LengthPercentageOrFlex {
 	Flex(Flex),
@@ -303,24 +227,6 @@ impl<'a> Build<'a> for LengthPercentageOrFlex {
 			Self::Flex(Flex::build(p, c))
 		} else {
 			Self::LengthPercentage(LengthPercentage::build(p, c))
-		}
-	}
-}
-
-impl From<LengthPercentageOrFlex> for Token {
-	fn from(value: LengthPercentageOrFlex) -> Self {
-		match value {
-			LengthPercentageOrFlex::Flex(l) => l.into(),
-			LengthPercentageOrFlex::LengthPercentage(l) => l.into(),
-		}
-	}
-}
-
-impl From<LengthPercentageOrFlex> for Cursor {
-	fn from(value: LengthPercentageOrFlex) -> Self {
-		match value {
-			LengthPercentageOrFlex::Flex(l) => l.into(),
-			LengthPercentageOrFlex::LengthPercentage(l) => l.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/units/line_width.rs
+++ b/crates/css_ast/src/units/line_width.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 use super::Length;
 
 keyword_set!(LineWidthKeyword { Thin: "thin", Medium: "medium", Thick: "thick" });
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum LineWidth {
 	Thin(T![Ident]),
@@ -31,17 +31,6 @@ impl<'a> Build<'a> for LineWidth {
 				LineWidthKeyword::Thin(_) => Self::Thin(<T![Ident]>::build(p, c)),
 				LineWidthKeyword::Thick(_) => Self::Thick(<T![Ident]>::build(p, c)),
 			}
-		}
-	}
-}
-
-impl From<LineWidth> for Cursor {
-	fn from(value: LineWidth) -> Self {
-		match value {
-			LineWidth::Thin(t) => t.into(),
-			LineWidth::Medium(t) => t.into(),
-			LineWidth::Thick(t) => t.into(),
-			LineWidth::Length(t) => t.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/units/resolution.rs
+++ b/crates/css_ast/src/units/resolution.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 // const DPPX_IN: f32 = 96.0;
 // const DPPX_CM: f32 = DPPX_IN / 2.54;
 
 // https://drafts.csswg.org/css-values/#resolution
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Resolution {
 	Dpi(T![Dimension::Dpi]),
@@ -37,16 +37,6 @@ impl<'a> Build<'a> for Resolution {
 			"dpcm" => Self::Dpcm(<T![Dimension::Dpcm]>::build(p, c)),
 			"dppx" => Self::Dppx(<T![Dimension::Dppx]>::build(p, c)),
 			_ => unreachable!(),
-		}
-	}
-}
-
-impl From<Resolution> for Cursor {
-	fn from(value: Resolution) -> Self {
-		match value {
-			Resolution::Dpi(t) => t.into(),
-			Resolution::Dpcm(t) => t.into(),
-			Resolution::Dppx(t) => t.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -1,9 +1,9 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoCursor, ToCursors};
 
 // https://drafts.csswg.org/css-values/#resolution
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Time {
 	Zero(T![Number]),
@@ -38,16 +38,6 @@ impl<'a> Build<'a> for Time {
 				"ms" => Self::Ms(<T![Dimension::Ms]>::build(p, c)),
 				_ => unreachable!(),
 			}
-		}
-	}
-}
-
-impl From<Time> for Cursor {
-	fn from(value: Time) -> Self {
-		match value {
-			Time::Zero(t) => t.into(),
-			Time::Ms(t) => t.into(),
-			Time::S(t) => t.into(),
 		}
 	}
 }

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_pure.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_pure.snap
@@ -5384,6 +5384,7 @@ expression: result.output.unwrap()
             "start": 8704,
             "open": {
               "kind": "LeftParen",
+              "offset": 8704,
               "len": 1
             },
             "values": {
@@ -5412,6 +5413,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 8728,
               "len": 1
             }
           },
@@ -5430,6 +5432,7 @@ expression: result.output.unwrap()
             "start": 8731,
             "open": {
               "kind": "LeftParen",
+              "offset": 8731,
               "len": 1
             },
             "values": {
@@ -5458,6 +5461,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 8757,
               "len": 1
             }
           }

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_brackets.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_brackets.snap
@@ -24,6 +24,7 @@ expression: result.output.unwrap()
             "start": 10,
             "open": {
               "kind": "LeftParen",
+              "offset": 10,
               "len": 1
             },
             "values": {
@@ -56,6 +57,7 @@ expression: result.output.unwrap()
                       "start": 34,
                       "open": {
                         "kind": "LeftCurly",
+                        "offset": 34,
                         "len": 1
                       },
                       "values": {
@@ -89,6 +91,7 @@ expression: result.output.unwrap()
                       },
                       "close": {
                         "kind": "RightCurly",
+                        "offset": 52,
                         "len": 1
                       }
                     }
@@ -103,6 +106,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 54,
               "len": 1
             }
           }
@@ -128,6 +132,7 @@ expression: result.output.unwrap()
                     "start": 60,
                     "open": {
                       "kind": "LeftSquare",
+                      "offset": 60,
                       "len": 1
                     },
                     "values": {
@@ -141,6 +146,7 @@ expression: result.output.unwrap()
                     },
                     "close": {
                       "kind": "RightSquare",
+                      "offset": 67,
                       "len": 1
                     }
                   }
@@ -227,6 +233,7 @@ expression: result.output.unwrap()
             "start": 117,
             "open": {
               "kind": "LeftParen",
+              "offset": 117,
               "len": 1
             },
             "values": {
@@ -236,6 +243,7 @@ expression: result.output.unwrap()
                   "start": 118,
                   "open": {
                     "kind": "LeftCurly",
+                    "offset": 118,
                     "len": 1
                   },
                   "values": {
@@ -264,6 +272,7 @@ expression: result.output.unwrap()
                   },
                   "close": {
                     "kind": "RightCurly",
+                    "offset": 131,
                     "len": 1
                   }
                 }
@@ -271,6 +280,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 132,
               "len": 1
             }
           }
@@ -379,6 +389,7 @@ expression: result.output.unwrap()
             "start": 174,
             "open": {
               "kind": "LeftParen",
+              "offset": 174,
               "len": 1
             },
             "values": {
@@ -388,6 +399,7 @@ expression: result.output.unwrap()
                   "start": 175,
                   "open": {
                     "kind": "LeftParen",
+                    "offset": 175,
                     "len": 1
                   },
                   "values": {
@@ -416,6 +428,7 @@ expression: result.output.unwrap()
                   },
                   "close": {
                     "kind": "RightParen",
+                    "offset": 188,
                     "len": 1
                   }
                 }
@@ -423,6 +436,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 189,
               "len": 1
             }
           }
@@ -531,6 +545,7 @@ expression: result.output.unwrap()
             "start": 231,
             "open": {
               "kind": "LeftParen",
+              "offset": 231,
               "len": 1
             },
             "values": {
@@ -574,6 +589,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 250,
               "len": 1
             }
           }
@@ -682,6 +698,7 @@ expression: result.output.unwrap()
             "start": 292,
             "open": {
               "kind": "LeftParen",
+              "offset": 292,
               "len": 1
             },
             "values": {
@@ -695,6 +712,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 298,
               "len": 1
             }
           }
@@ -803,6 +821,7 @@ expression: result.output.unwrap()
             "start": 340,
             "open": {
               "kind": "LeftParen",
+              "offset": 340,
               "len": 1
             },
             "values": {
@@ -812,6 +831,7 @@ expression: result.output.unwrap()
                   "start": 341,
                   "open": {
                     "kind": "LeftSquare",
+                    "offset": 341,
                     "len": 1
                   },
                   "values": {
@@ -819,6 +839,7 @@ expression: result.output.unwrap()
                   },
                   "close": {
                     "kind": "RightSquare",
+                    "offset": 342,
                     "len": 1
                   }
                 }
@@ -826,6 +847,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 343,
               "len": 1
             }
           }
@@ -934,6 +956,7 @@ expression: result.output.unwrap()
             "start": 385,
             "open": {
               "kind": "LeftParen",
+              "offset": 385,
               "len": 1
             },
             "values": {
@@ -943,6 +966,7 @@ expression: result.output.unwrap()
                   "start": 386,
                   "open": {
                     "kind": "LeftSquare",
+                    "offset": 386,
                     "len": 1
                   },
                   "values": {
@@ -971,6 +995,7 @@ expression: result.output.unwrap()
                   },
                   "close": {
                     "kind": "RightSquare",
+                    "offset": 397,
                     "len": 1
                   }
                 }
@@ -978,6 +1003,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 398,
               "len": 1
             }
           }
@@ -1086,6 +1112,7 @@ expression: result.output.unwrap()
             "start": 440,
             "open": {
               "kind": "LeftParen",
+              "offset": 440,
               "len": 1
             },
             "values": {
@@ -1095,6 +1122,7 @@ expression: result.output.unwrap()
                   "start": 441,
                   "open": {
                     "kind": "LeftSquare",
+                    "offset": 441,
                     "len": 1
                   },
                   "values": {
@@ -1104,6 +1132,7 @@ expression: result.output.unwrap()
                         "start": 442,
                         "open": {
                           "kind": "LeftSquare",
+                          "offset": 442,
                           "len": 1
                         },
                         "values": {
@@ -1113,6 +1142,7 @@ expression: result.output.unwrap()
                               "start": 443,
                               "open": {
                                 "kind": "LeftSquare",
+                                "offset": 443,
                                 "len": 1
                               },
                               "values": {
@@ -1122,6 +1152,7 @@ expression: result.output.unwrap()
                                     "start": 444,
                                     "open": {
                                       "kind": "LeftSquare",
+                                      "offset": 444,
                                       "len": 1
                                     },
                                     "values": {
@@ -1131,6 +1162,7 @@ expression: result.output.unwrap()
                                           "start": 445,
                                           "open": {
                                             "kind": "LeftSquare",
+                                            "offset": 445,
                                             "len": 1
                                           },
                                           "values": {
@@ -1140,6 +1172,7 @@ expression: result.output.unwrap()
                                                 "start": 446,
                                                 "open": {
                                                   "kind": "LeftCurly",
+                                                  "offset": 446,
                                                   "len": 1
                                                 },
                                                 "values": {
@@ -1177,6 +1210,7 @@ expression: result.output.unwrap()
                                                           "start": 462,
                                                           "open": {
                                                             "kind": "LeftCurly",
+                                                            "offset": 462,
                                                             "len": 1
                                                           },
                                                           "values": {
@@ -1195,6 +1229,7 @@ expression: result.output.unwrap()
                                                           },
                                                           "close": {
                                                             "kind": "RightCurly",
+                                                            "offset": 468,
                                                             "len": 1
                                                           }
                                                         }
@@ -1209,6 +1244,7 @@ expression: result.output.unwrap()
                                                 },
                                                 "close": {
                                                   "kind": "RightCurly",
+                                                  "offset": 471,
                                                   "len": 1
                                                 }
                                               }
@@ -1216,6 +1252,7 @@ expression: result.output.unwrap()
                                           },
                                           "close": {
                                             "kind": "RightSquare",
+                                            "offset": 472,
                                             "len": 1
                                           }
                                         }
@@ -1223,6 +1260,7 @@ expression: result.output.unwrap()
                                     },
                                     "close": {
                                       "kind": "RightSquare",
+                                      "offset": 473,
                                       "len": 1
                                     }
                                   }
@@ -1230,6 +1268,7 @@ expression: result.output.unwrap()
                               },
                               "close": {
                                 "kind": "RightSquare",
+                                "offset": 474,
                                 "len": 1
                               }
                             }
@@ -1237,6 +1276,7 @@ expression: result.output.unwrap()
                         },
                         "close": {
                           "kind": "RightSquare",
+                          "offset": 475,
                           "len": 1
                         }
                       }
@@ -1244,6 +1284,7 @@ expression: result.output.unwrap()
                   },
                   "close": {
                     "kind": "RightSquare",
+                    "offset": 476,
                     "len": 1
                   }
                 }
@@ -1251,6 +1292,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightParen",
+              "offset": 477,
               "len": 1
             }
           }

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_comments.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_comments.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
-snapshot_kind: text
 ---
 {
   "type": "stylesheet",
@@ -263,6 +262,7 @@ snapshot_kind: text
                   "start": 212,
                   "open": {
                     "kind": "LeftParen",
+                    "offset": 216,
                     "len": 1
                   },
                   "values": {
@@ -276,6 +276,7 @@ snapshot_kind: text
                   },
                   "close": {
                     "kind": "RightParen",
+                    "offset": 225,
                     "len": 1
                   }
                 }

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_custom_properties.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_custom_properties.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
-snapshot_kind: text
 ---
 {
   "type": "stylesheet",
@@ -360,6 +359,7 @@ snapshot_kind: text
                   "start": 204,
                   "open": {
                     "kind": "LeftSquare",
+                    "offset": 204,
                     "len": 1
                   },
                   "values": {
@@ -403,6 +403,7 @@ snapshot_kind: text
                   },
                   "close": {
                     "kind": "RightSquare",
+                    "offset": 212,
                     "len": 1
                   }
                 }
@@ -441,6 +442,7 @@ snapshot_kind: text
                   "start": 232,
                   "open": {
                     "kind": "LeftParen",
+                    "offset": 232,
                     "len": 1
                   },
                   "values": {
@@ -484,6 +486,7 @@ snapshot_kind: text
                   },
                   "close": {
                     "kind": "RightParen",
+                    "offset": 240,
                     "len": 1
                   }
                 }
@@ -674,6 +677,7 @@ snapshot_kind: text
                   "start": 366,
                   "open": {
                     "kind": "LeftCurly",
+                    "offset": 366,
                     "len": 1
                   },
                   "values": {
@@ -717,6 +721,7 @@ snapshot_kind: text
                   },
                   "close": {
                     "kind": "RightCurly",
+                    "offset": 374,
                     "len": 1
                   }
                 }
@@ -755,6 +760,7 @@ snapshot_kind: text
                   "start": 387,
                   "open": {
                     "kind": "LeftSquare",
+                    "offset": 387,
                     "len": 1
                   },
                   "values": {
@@ -794,6 +800,7 @@ snapshot_kind: text
                         "start": 396,
                         "open": {
                           "kind": "LeftCurly",
+                          "offset": 396,
                           "len": 1
                         },
                         "values": {
@@ -818,6 +825,7 @@ snapshot_kind: text
                               "start": 406,
                               "open": {
                                 "kind": "LeftCurly",
+                                "offset": 406,
                                 "len": 1
                               },
                               "values": {
@@ -841,6 +849,7 @@ snapshot_kind: text
                               },
                               "close": {
                                 "kind": "RightCurly",
+                                "offset": 412,
                                 "len": 1
                               }
                             }
@@ -848,6 +857,7 @@ snapshot_kind: text
                         },
                         "close": {
                           "kind": "RightCurly",
+                          "offset": 413,
                           "len": 1
                         }
                       },
@@ -866,6 +876,7 @@ snapshot_kind: text
                         "start": 416,
                         "open": {
                           "kind": "LeftSquare",
+                          "offset": 416,
                           "len": 1
                         },
                         "values": {
@@ -879,6 +890,7 @@ snapshot_kind: text
                         },
                         "close": {
                           "kind": "RightSquare",
+                          "offset": 418,
                           "len": 1
                         }
                       }
@@ -886,6 +898,7 @@ snapshot_kind: text
                   },
                   "close": {
                     "kind": "RightSquare",
+                    "offset": 419,
                     "len": 1
                   }
                 }
@@ -949,6 +962,7 @@ snapshot_kind: text
                   "start": 453,
                   "open": {
                     "kind": "LeftCurly",
+                    "offset": 453,
                     "len": 1
                   },
                   "values": {
@@ -992,6 +1006,7 @@ snapshot_kind: text
                   },
                   "close": {
                     "kind": "RightCurly",
+                    "offset": 473,
                     "len": 1
                   }
                 }

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_escape.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_escape.snap
@@ -409,6 +409,7 @@ expression: result.output.unwrap()
                     "start": 172,
                     "open": {
                       "kind": "LeftSquare",
+                      "offset": 172,
                       "len": 1
                     },
                     "values": {
@@ -432,6 +433,7 @@ expression: result.output.unwrap()
                     },
                     "close": {
                       "kind": "RightSquare",
+                      "offset": 180,
                       "len": 1
                     }
                   }
@@ -826,6 +828,7 @@ expression: result.output.unwrap()
             "start": 295,
             "open": {
               "kind": "LeftSquare",
+              "offset": 295,
               "len": 1
             },
             "values": {
@@ -849,6 +852,7 @@ expression: result.output.unwrap()
             },
             "close": {
               "kind": "RightSquare",
+              "offset": 302,
               "len": 1
             }
           }

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_extends.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_extends.snap
@@ -109,6 +109,7 @@ expression: result.output.unwrap()
                     "start": 31,
                     "open": {
                       "kind": "LeftCurly",
+                      "offset": 31,
                       "len": 1
                     },
                     "values": {
@@ -152,6 +153,7 @@ expression: result.output.unwrap()
                     },
                     "close": {
                       "kind": "RightCurly",
+                      "offset": 55,
                       "len": 1
                     }
                   },

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_media.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_media.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
-snapshot_kind: text
 ---
 {
   "type": "stylesheet",
@@ -64,6 +63,7 @@ snapshot_kind: text
                   "start": 23,
                   "open": {
                     "kind": "LeftCurly",
+                    "offset": 23,
                     "len": 1
                   },
                   "values": {
@@ -132,6 +132,7 @@ snapshot_kind: text
                   },
                   "close": {
                     "kind": "RightCurly",
+                    "offset": 56,
                     "len": 1
                   }
                 }
@@ -170,6 +171,7 @@ snapshot_kind: text
                   "start": 75,
                   "open": {
                     "kind": "LeftCurly",
+                    "offset": 75,
                     "len": 1
                   },
                   "values": {
@@ -240,6 +242,7 @@ snapshot_kind: text
                   },
                   "close": {
                     "kind": "RightCurly",
+                    "offset": 114,
                     "len": 1
                   }
                 }

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_prop.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_prop.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
-snapshot_kind: text
 ---
 {
   "type": "stylesheet",
@@ -154,6 +153,7 @@ snapshot_kind: text
             "start": 77,
             "open": {
               "kind": "LeftParen",
+              "offset": 77,
               "len": 1
             },
             "values": {
@@ -167,6 +167,7 @@ snapshot_kind: text
             },
             "close": {
               "kind": "RightParen",
+              "offset": 81,
               "len": 1
             }
           },

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -119,7 +119,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<ComponentValue>(), 64);
+		assert_eq!(std::mem::size_of::<ComponentValue>(), 72);
 	}
 
 	#[test]

--- a/crates/css_parse/src/syntax/simple_block.rs
+++ b/crates/css_parse/src/syntax/simple_block.rs
@@ -43,7 +43,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<SimpleBlock>(), 56);
+		assert_eq!(std::mem::size_of::<SimpleBlock>(), 64);
 	}
 
 	#[test]

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -1,4 +1,5 @@
-use css_lexer::{Cursor, DimensionUnit, Kind, KindSet, Span, Token};
+use css_lexer::{Cursor, DimensionUnit, Kind, KindSet, Token};
+use csskit_derives::IntoCursor;
 
 use crate::{Build, CursorSink, Parse, Parser, Peek, Result, ToCursors, diagnostics};
 
@@ -6,7 +7,7 @@ macro_rules! define_kinds {
 	($($(#[$meta:meta])* $ident:ident,)*) => {
 		$(
 		$(#[$meta])*
-		#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::IntoCursor, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		pub struct $ident(::css_lexer::Cursor);
 
@@ -16,27 +17,9 @@ macro_rules! define_kinds {
 			}
 		}
 
-		impl From<$ident> for ::css_lexer::Cursor {
-			fn from(value: $ident) -> Self {
-				value.0
-			}
-		}
-
 		impl $crate::ToCursors for $ident {
 			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
 				s.append((*self).into());
-			}
-		}
-
-		impl From<$ident> for ::css_lexer::Token {
-			fn from(value: $ident) -> Self {
-				value.0.token()
-			}
-		}
-
-		impl From<&$ident> for ::css_lexer::Span {
-			fn from(value: &$ident) -> Self {
-				value.0.span()
 			}
 		}
 
@@ -59,31 +42,13 @@ macro_rules! define_kind_idents {
 	($($(#[$meta:meta])* $ident:ident,)*) => {
 		$(
 		$(#[$meta])*
-		#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::IntoCursor, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		pub struct $ident(::css_lexer::Cursor);
-
-		impl From<$ident> for ::css_lexer::Cursor {
-			fn from(value: $ident) -> Self {
-				value.0
-			}
-		}
 
 		impl $crate::ToCursors for $ident {
 			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
 				s.append((*self).into());
-			}
-		}
-
-		impl From<$ident> for ::css_lexer::Token {
-			fn from(value: $ident) -> Self {
-				value.0.token()
-			}
-		}
-
-		impl From<&$ident> for ::css_lexer::Span {
-			fn from(value: &$ident) -> Self {
-				value.0.span()
 			}
 		}
 
@@ -131,31 +96,13 @@ macro_rules! define_kind_idents {
 macro_rules! custom_delim {
 	($(#[$meta:meta])* $ident:ident, $ch:literal) => {
 		$(#[$meta])*
-		#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::IntoCursor, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		pub struct $ident($crate::T![Delim]);
-
-		impl From<$ident> for ::css_lexer::Cursor {
-			fn from(value: $ident) -> Self {
-				value.0.into()
-			}
-		}
 
 		impl $crate::ToCursors for $ident {
 			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
 				s.append((*self).into());
-			}
-		}
-
-		impl From<$ident> for ::css_lexer::Token {
-			fn from(value: $ident) -> Self {
-				value.0.into()
-			}
-		}
-
-		impl From<&$ident> for ::css_lexer::Span {
-			fn from(value: &$ident) -> Self {
-				(&value.0).into()
 			}
 		}
 
@@ -184,7 +131,7 @@ macro_rules! custom_delim {
 macro_rules! custom_dimension {
 	($(#[$meta:meta])*$ident: ident, $str: tt) => {
 		$(#[$meta])*
-		#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		pub struct $ident(::css_lexer::Cursor);
 
@@ -196,18 +143,6 @@ macro_rules! custom_dimension {
 
 			pub const fn dummy() -> Self {
 				Self(::css_lexer::Cursor::dummy(::css_lexer::Token::dummy(::css_lexer::Kind::Dimension)))
-			}
-		}
-
-		impl From<$ident> for ::css_lexer::Token {
-			fn from(value: $ident) -> Self {
-				value.0.token()
-			}
-		}
-
-		impl From<$ident> for ::css_lexer::Cursor {
-			fn from(value: $ident) -> Self {
-				value.0
 			}
 		}
 
@@ -658,31 +593,13 @@ define_kind_idents! {
 
 /// Represents a token with [Kind::Whitespace]. Use [T![Whitespace]][crate::T] to refer to
 /// this.
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Whitespace(Cursor);
-
-impl From<Whitespace> for Cursor {
-	fn from(value: Whitespace) -> Self {
-		value.0
-	}
-}
 
 impl ToCursors for Whitespace {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		s.append((*self).into());
-	}
-}
-
-impl From<Whitespace> for Token {
-	fn from(value: Whitespace) -> Self {
-		value.0.token()
-	}
-}
-
-impl From<&Whitespace> for Span {
-	fn from(value: &Whitespace) -> Self {
-		value.0.span()
 	}
 }
 
@@ -710,25 +627,13 @@ impl<'a> Parse<'a> for Whitespace {
 
 /// Represents a token with [Kind::Ident] that also begins with two HYPHEN MINUS (`--`)
 /// characters. Use [T![DashedIdent]][crate::T] to refer to this.
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct DashedIdent(Ident);
-
-impl From<DashedIdent> for Cursor {
-	fn from(value: DashedIdent) -> Self {
-		value.0.into()
-	}
-}
 
 impl ToCursors for DashedIdent {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		s.append((*self).into());
-	}
-}
-
-impl From<&DashedIdent> for Span {
-	fn from(value: &DashedIdent) -> Self {
-		(&value.0).into()
 	}
 }
 
@@ -745,15 +650,9 @@ impl<'a> Build<'a> for DashedIdent {
 }
 
 /// Represents a token with [Kind::Dimension]. Use [T![Dimension]][crate::T] to refer to this.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Dimension(Cursor);
-
-impl From<Dimension> for Cursor {
-	fn from(value: Dimension) -> Self {
-		value.0
-	}
-}
 
 impl ToCursors for Dimension {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
@@ -776,12 +675,6 @@ impl<'a> Peek<'a> for Dimension {
 impl<'a> Build<'a> for Dimension {
 	fn build(_: &Parser<'a>, c: Cursor) -> Self {
 		Self(c)
-	}
-}
-
-impl From<&Dimension> for Span {
-	fn from(value: &Dimension) -> Self {
-		value.0.span()
 	}
 }
 
@@ -815,7 +708,7 @@ impl Dimension {
 }
 
 /// Represents a token with [Kind::Number]. Use [T![Number]][crate::T] to refer to this.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Number(Cursor);
 
@@ -837,24 +730,6 @@ impl Number {
 
 	pub fn has_sign(&self) -> bool {
 		self.0.token().has_sign()
-	}
-}
-
-impl From<Number> for Cursor {
-	fn from(value: Number) -> Self {
-		value.0
-	}
-}
-
-impl From<Number> for Token {
-	fn from(value: Number) -> Self {
-		value.0.token()
-	}
-}
-
-impl From<&Number> for Span {
-	fn from(value: &Number) -> Self {
-		value.0.span()
 	}
 }
 
@@ -1442,15 +1317,9 @@ pub mod dimension {
 }
 
 /// Represents any possible single token. Use [T![Any]][crate::T] to refer to this.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Any(Cursor);
-
-impl From<Any> for Cursor {
-	fn from(value: Any) -> Self {
-		value.0
-	}
-}
 
 impl ToCursors for Any {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
@@ -1472,25 +1341,13 @@ impl<'a> Build<'a> for Any {
 
 /// Represents a token with either [Kind::LeftCurly], [Kind::LeftParen] or [Kind::LeftSquare]. Use
 /// [T![PairWiseStart]][crate::T] to refer to this.
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct PairWiseStart(Token);
-
-impl From<PairWiseStart> for Cursor {
-	fn from(value: PairWiseStart) -> Self {
-		Cursor::dummy(value.0)
-	}
-}
-
-impl From<PairWiseStart> for Token {
-	fn from(value: PairWiseStart) -> Self {
-		value.0
-	}
-}
+pub struct PairWiseStart(Cursor);
 
 impl PairWiseStart {
 	pub fn kind(&self) -> Kind {
-		self.0.kind()
+		self.0.token().kind()
 	}
 
 	pub fn end(&self) -> Kind {
@@ -1509,31 +1366,19 @@ impl<'a> Peek<'a> for PairWiseStart {
 
 impl<'a> Build<'a> for PairWiseStart {
 	fn build(_: &Parser<'a>, c: Cursor) -> Self {
-		Self(c.token())
+		Self(c)
 	}
 }
 
 /// Represents a token with either [Kind::RightCurly], [Kind::RightParen] or [Kind::RightSquare]. Use
 /// [T![PairWiseEnd]][crate::T] to refer to this.
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct PairWiseEnd(Token);
-
-impl From<PairWiseEnd> for Cursor {
-	fn from(value: PairWiseEnd) -> Self {
-		Cursor::dummy(value.0)
-	}
-}
-
-impl From<PairWiseEnd> for Token {
-	fn from(value: PairWiseEnd) -> Self {
-		value.0
-	}
-}
+pub struct PairWiseEnd(Cursor);
 
 impl PairWiseEnd {
 	pub fn kind(&self) -> Kind {
-		self.0.kind()
+		self.0.token().kind()
 	}
 
 	pub fn start(&self) -> Kind {
@@ -1552,7 +1397,7 @@ impl<'a> Peek<'a> for PairWiseEnd {
 
 impl<'a> Build<'a> for PairWiseEnd {
 	fn build(_: &Parser<'a>, c: Cursor) -> Self {
-		Self(c.token())
+		Self(c)
 	}
 }
 

--- a/crates/csskit_derives/src/into_cursor.rs
+++ b/crates/csskit_derives/src/into_cursor.rs
@@ -1,0 +1,71 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields};
+
+use crate::err;
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+	let ident = input.ident;
+	let generics = &mut input.generics.clone();
+	let (impl_generics, _, _) = generics.split_for_impl();
+	let body = match input.data {
+		Data::Struct(DataStruct { fields: Fields::Unnamed(fields), .. }) => {
+			if fields.unnamed.len() != 1 {
+				return err(ident.span(), "Cannot derive Into<Cursor> for a struct with many fields");
+			} else {
+				quote! { value.0.into() }
+			}
+		}
+		Data::Struct(DataStruct { fields: Fields::Named(fields), .. }) => {
+			if fields.named.len() != 1 {
+				err(ident.span(), "Cannot derive Into<Cursor> for a struct with many fields")
+			} else {
+				let ident = fields.named.first().unwrap().ident.clone().unwrap();
+				quote! { value.#ident.into() }
+			}
+		}
+		Data::Struct(_) => err(ident.span(), "Cannot derive Into<Cursor> on this struct"),
+		Data::Union(_) => err(ident.span(), "Cannot derive Into<Cursor> on a Union"),
+		Data::Enum(DataEnum { variants, .. }) => {
+			let steps: Vec<_> = variants
+				.iter()
+				.map(|variant| {
+					if variant.fields.len() != 1 {
+						err(ident.span(), "Cannot derive Into<Cursor> for an enum variant with many fields")
+					} else {
+						let variant = &variant.ident;
+						quote! { #ident::#variant(value) => { value.into() } }
+					}
+				})
+				.collect();
+			quote! {
+				match value {
+					#(#steps)*
+				}
+			}
+		}
+	};
+	quote! {
+		#[automatically_derived]
+		impl #impl_generics From<#ident #impl_generics> for ::css_lexer::Cursor {
+			fn from(value: #ident) -> ::css_lexer::Cursor {
+				#body
+			}
+		}
+
+		#[automatically_derived]
+		impl #impl_generics From<#ident #impl_generics> for ::css_lexer::Token {
+			fn from(value: #ident) -> ::css_lexer::Token {
+				Into::<::css_lexer::Cursor>::into(value).token()
+			}
+		}
+
+		#[automatically_derived]
+		impl #impl_generics From<&#ident #impl_generics> for ::css_lexer::Span {
+			fn from(value: &#ident) -> ::css_lexer::Span {
+				Into::<::css_lexer::Cursor>::into(*value).into()
+			}
+		}
+
+	}
+}

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -3,6 +3,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::Error;
 
+mod into_cursor;
 mod parse;
 mod peek;
 mod to_cursors;
@@ -23,6 +24,12 @@ pub fn derive_parse(stream: TokenStream) -> TokenStream {
 pub fn derive_peek(stream: TokenStream) -> TokenStream {
 	let input = syn::parse(stream).unwrap();
 	peek::derive(input).into()
+}
+
+#[proc_macro_derive(IntoCursor)]
+pub fn derive_into_cursor(stream: TokenStream) -> TokenStream {
+	let input = syn::parse(stream).unwrap();
+	into_cursor::derive(input).into()
 }
 
 fn err(span: Span, msg: &str) -> proc_macro2::TokenStream {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_foo.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_foo.snap
@@ -1,0 +1,7 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::core::compile_error! {
+    "wrong structure for this syntax, please redefine as an Enum"
+}


### PR DESCRIPTION
This derive allows us to implement `From<T> for Cursor`, and also get `From<T> for Token` and `From<T> for Span` implementations for close to free. All that's required is a `derive(IntoCursor)` on a struct or enum. This removes a fair amount of code but more importantly consistently implements the three pairs across any implementation that produces these.