### PR TITLE
(csskit_derives): clean up derive code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
 name = "csskit_derives"
 version = "0.0.0"
 dependencies = [
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	AtRule, Build, CommaSeparatedPreludeList, DeclarationList, Parse, Parser, Peek, QualifiedRule, QualifiedRuleList,
 	Result as ParserResult, T, diagnostics, keyword_set, syntax::BadDeclaration,
 };
-use csskit_derives::{IntoCursor, ToCursors};
+use csskit_derives::{IntoCursor, Peek, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, properties::Property};
@@ -39,7 +39,7 @@ impl<'a> Visitable<'a> for KeyframesRule<'a> {
 	}
 }
 
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum KeyframesName {
 	Ident(T![Ident]),
@@ -49,12 +49,6 @@ pub enum KeyframesName {
 impl KeyframesName {
 	fn valid_ident(str: &str) -> bool {
 		!matches!(str, "default" | "initial" | "inherit" | "unset" | "none")
-	}
-}
-
-impl<'a> Peek<'a> for KeyframesName {
-	fn peek(p: &Parser<'a>, c: css_lexer::Cursor) -> bool {
-		<T![Ident]>::peek(p, c) || <T![String]>::peek(p, c)
 	}
 }
 

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -1,6 +1,6 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, ToCursors};
+use csskit_derives::{IntoCursor, Peek, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -50,7 +50,7 @@ impl<'a> Visitable<'a> for Attribute {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value"))]
 pub enum AttributeOperator {
 	Exact(T![=]),
@@ -59,17 +59,6 @@ pub enum AttributeOperator {
 	Prefix(T![^=]),
 	Suffix(T!["$="]),
 	Contains(T![*=]),
-}
-
-impl<'a> Peek<'a> for AttributeOperator {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![=]>::peek(p, c)
-			|| <T![~=]>::peek(p, c)
-			|| <T![|=]>::peek(p, c)
-			|| <T![^=]>::peek(p, c)
-			|| <T!["$="]>::peek(p, c)
-			|| <T![*=]>::peek(p, c)
-	}
 }
 
 impl<'a> Parse<'a> for AttributeOperator {
@@ -91,17 +80,11 @@ impl<'a> Parse<'a> for AttributeOperator {
 	}
 }
 
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value"))]
 pub enum AttributeValue {
 	String(T![String]),
 	Ident(T![Ident]),
-}
-
-impl<'a> Peek<'a> for AttributeValue {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![Ident]>::peek(p, c) || <T![String]>::peek(p, c)
-	}
 }
 
 impl<'a> Build<'a> for AttributeValue {

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -1,10 +1,10 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{
-	Build, CompoundSelector as CompoundSelectorTrait, Parse, Parser, Peek, Result as ParserResult,
+	Build, CompoundSelector as CompoundSelectorTrait, Parse, Parser, Result as ParserResult,
 	SelectorComponent as SelectorComponentTrait, SelectorList as SelectorListTrait, T,
 };
-use csskit_derives::{IntoCursor, ToCursors};
+use csskit_derives::{IntoCursor, Peek, ToCursors};
 use csskit_proc_macro::visit;
 
 mod attribute;
@@ -99,16 +99,10 @@ pub type ComplexSelector<'a> = SelectorList<'a>;
 pub type ForgivingSelector<'a> = SelectorList<'a>;
 pub type RelativeSelector<'a> = SelectorList<'a>;
 
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct Id(T![Hash]);
-
-impl<'a> Peek<'a> for Id {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![Hash]>::peek(p, c)
-	}
-}
 
 impl<'a> Build<'a> for Id {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
@@ -122,16 +116,10 @@ impl<'a> Visitable<'a> for Id {
 	}
 }
 
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct Wildcard(T![*]);
-
-impl<'a> Peek<'a> for Wildcard {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![*]>::peek(p, c)
-	}
-}
 
 impl<'a> Build<'a> for Wildcard {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,6 +1,6 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, ToCursors};
+use csskit_derives::{IntoCursor, Peek, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -80,17 +80,11 @@ impl<'a> Parse<'a> for NamespacePrefix {
 	}
 }
 
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NamespaceTag {
-	Tag(Tag),
 	Wildcard(T![*]),
-}
-
-impl<'a> Peek<'a> for NamespaceTag {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![*]>::peek(p, c) || Tag::peek(p, c)
-	}
+	Tag(Tag),
 }
 
 impl<'a> Build<'a> for NamespaceTag {

--- a/crates/css_ast/src/types/animateable_feature.rs
+++ b/crates/css_ast/src/types/animateable_feature.rs
@@ -1,10 +1,10 @@
 use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::{IntoCursor, ToCursors};
+use css_parse::{Build, Parser, T};
+use csskit_derives::{IntoCursor, Peek, ToCursors};
 
 // https://drafts.csswg.org/css-will-change-1/#typedef-animateable-feature
 // <animateable-feature> = scroll-position | contents | <custom-ident>
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum AnimateableFeature {
 	ScrollPosition(T![Ident]),
@@ -90,12 +90,6 @@ impl AnimateableFeature {
 			"view-transition-name" => Self::ViewTransitionName(<T![Ident]>::dummy()),
 			"z-index" => Self::ZIndex(<T![Ident]>::dummy()),
 	};
-}
-
-impl<'a> Peek<'a> for AnimateableFeature {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![Ident]>::peek(p, c)
-	}
 }
 
 impl<'a> Build<'a> for AnimateableFeature {

--- a/crates/css_ast/src/types/ratio.rs
+++ b/crates/css_ast/src/types/ratio.rs
@@ -1,21 +1,14 @@
 use crate::units::CSSInt;
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::ToCursors;
+use css_parse::{Parse, Parser, Result as ParserResult, T};
+use csskit_derives::{Peek, ToCursors};
 
 // https://drafts.csswg.org/css-values-4/#ratios
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Ratio {
 	pub numerator: CSSInt,
 	pub slash: Option<T![/]>,
 	pub denominator: Option<CSSInt>,
-}
-
-impl<'a> Peek<'a> for Ratio {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		CSSInt::peek(p, c)
-	}
 }
 
 impl<'a> Parse<'a> for Ratio {

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -1,20 +1,14 @@
 use bumpalo::collections::Vec;
-use css_lexer::Cursor;
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors};
+use css_parse::{Parse, Parser, Result as ParserResult};
+use csskit_derives::{Peek, ToCursors};
 
 use crate::TransformFunction;
 
 // https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
 // <transform-list> = <transform-function>+
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct TransformList<'a>(Vec<'a, TransformFunction>);
-
-impl<'a> Peek<'a> for TransformList<'a> {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		TransformFunction::peek(p, c)
-	}
-}
 
 impl<'a> Parse<'a> for TransformList<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
@@ -23,14 +17,6 @@ impl<'a> Parse<'a> for TransformList<'a> {
 			list.push(transform);
 		}
 		Ok(TransformList(list))
-	}
-}
-
-impl<'a> ToCursors for TransformList<'a> {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		for transform in &self.0 {
-			ToCursors::to_cursors(transform, s);
-		}
 	}
 }
 

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -1,13 +1,13 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::{IntoCursor, ToCursors};
+use css_lexer::{Cursor, DimensionUnit};
+use css_parse::{Build, Parser, T};
+use csskit_derives::{IntoCursor, Peek, ToCursors};
 
 // const DEG_GRAD: f32 = 0.9;
 // const DEG_RAD: f32 = 57.295_78;
 // const DEG_TURN: f32 = 360.0;
 
 // https://drafts.csswg.org/css-values/#angles
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Angle {
 	Grad(T![Dimension::Grad]),
@@ -27,19 +27,13 @@ impl From<Angle> for f32 {
 	}
 }
 
-impl<'a> Peek<'a> for Angle {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![Dimension]>::peek(p, c) && matches!(p.parse_str_lower(c), "grad" | "rad" | "turn" | "deg")
-	}
-}
-
 impl<'a> Build<'a> for Angle {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
-		match p.parse_str_lower(c) {
-			"grad" => Self::Grad(<T![Dimension::Grad]>::build(p, c)),
-			"rad" => Self::Rad(<T![Dimension::Rad]>::build(p, c)),
-			"turn" => Self::Turn(<T![Dimension::Turn]>::build(p, c)),
-			"deg" => Self::Deg(<T![Dimension::Deg]>::build(p, c)),
+		match c.token().dimension_unit() {
+			DimensionUnit::Grad => Self::Grad(<T![Dimension::Grad]>::build(p, c)),
+			DimensionUnit::Rad => Self::Rad(<T![Dimension::Rad]>::build(p, c)),
+			DimensionUnit::Turn => Self::Turn(<T![Dimension::Turn]>::build(p, c)),
+			DimensionUnit::Deg => Self::Deg(<T![Dimension::Deg]>::build(p, c)),
 			_ => unreachable!(),
 		}
 	}

--- a/crates/css_ast/src/units/frequency.rs
+++ b/crates/css_ast/src/units/frequency.rs
@@ -1,9 +1,9 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::{IntoCursor, ToCursors};
+use css_lexer::{Cursor, DimensionUnit};
+use css_parse::{Build, Parser, T};
+use csskit_derives::{IntoCursor, Peek, ToCursors};
 
 // https://drafts.csswg.org/css-values/#resolution
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Frequency {
 	Hz(T![Dimension::Hz]),
@@ -19,17 +19,11 @@ impl From<Frequency> for f32 {
 	}
 }
 
-impl<'a> Peek<'a> for Frequency {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![Dimension]>::peek(p, c) && matches!(p.parse_str_lower(c), "hz" | "khz")
-	}
-}
-
 impl<'a> Build<'a> for Frequency {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
-		match p.parse_str_lower(c) {
-			"hz" => Self::Hz(<T![Dimension::Hz]>::build(p, c)),
-			"khz" => Self::Khz(<T![Dimension::Khz]>::build(p, c)),
+		match c.token().dimension_unit() {
+			DimensionUnit::Hz => Self::Hz(<T![Dimension::Hz]>::build(p, c)),
+			DimensionUnit::Khz => Self::Khz(<T![Dimension::Khz]>::build(p, c)),
 			_ => unreachable!(),
 		}
 	}

--- a/crates/css_parse/src/traits/peek.rs
+++ b/crates/css_parse/src/traits/peek.rs
@@ -37,3 +37,14 @@ pub trait Peek<'a>: Sized {
 		c == Self::PEEK_KINDSET
 	}
 }
+
+impl<'a, T> Peek<'a> for ::bumpalo::collections::Vec<'a, T>
+where
+	T: Peek<'a>,
+{
+	const PEEK_KINDSET: KindSet = T::PEEK_KINDSET;
+
+	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
+		T::peek(p, c)
+	}
+}

--- a/crates/csskit_derives/Cargo.toml
+++ b/crates/csskit_derives/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 syn = { workspace = true, features = ["extra-traits"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
+itertools = { workspace = true }
 
 [features]
 default = []

--- a/crates/csskit_derives/src/into_cursor.rs
+++ b/crates/csskit_derives/src/into_cursor.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields};
+use syn::{Data, DataEnum, DataStruct, DeriveInput};
 
 use crate::err;
 
@@ -9,38 +9,32 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	let generics = &mut input.generics.clone();
 	let (impl_generics, _, _) = generics.split_for_impl();
 	let body = match input.data {
-		Data::Struct(DataStruct { fields: Fields::Unnamed(fields), .. }) => {
-			if fields.unnamed.len() != 1 {
+		Data::Union(_) => err(ident.span(), "Cannot derive Into<Cursor> on a Union"),
+
+		Data::Struct(DataStruct { fields, .. }) => {
+			if fields.len() != 1 {
 				return err(ident.span(), "Cannot derive Into<Cursor> for a struct with many fields");
 			} else {
-				quote! { value.0.into() }
+				let member = fields.members().next().unwrap();
+				quote! { value.#member.into() }
 			}
 		}
-		Data::Struct(DataStruct { fields: Fields::Named(fields), .. }) => {
-			if fields.named.len() != 1 {
-				err(ident.span(), "Cannot derive Into<Cursor> for a struct with many fields")
-			} else {
-				let ident = fields.named.first().unwrap().ident.clone().unwrap();
-				quote! { value.#ident.into() }
-			}
-		}
-		Data::Struct(_) => err(ident.span(), "Cannot derive Into<Cursor> on this struct"),
-		Data::Union(_) => err(ident.span(), "Cannot derive Into<Cursor> on a Union"),
+
 		Data::Enum(DataEnum { variants, .. }) => {
-			let steps: Vec<_> = variants
+			let steps: TokenStream = variants
 				.iter()
 				.map(|variant| {
 					if variant.fields.len() != 1 {
-						err(ident.span(), "Cannot derive Into<Cursor> for an enum variant with many fields")
+						err(ident.span(), "Cannot derive Into<Cursor> for an enum variant with none or many fields")
 					} else {
 						let variant = &variant.ident;
-						quote! { #ident::#variant(value) => { value.into() } }
+						quote! { #ident::#variant(c) => c.into(), }
 					}
 				})
 				.collect();
 			quote! {
 				match value {
-					#(#steps)*
+					#steps
 				}
 			}
 		}

--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -1,6 +1,7 @@
+use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, FieldsUnnamed, spanned::Spanned};
+use syn::{Data, DataEnum, DataStruct, DeriveInput};
 
 use crate::err;
 
@@ -9,53 +10,21 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	let generics = &mut input.generics.clone();
 	let (impl_generics, _, _) = generics.split_for_impl();
 	let body = match input.data {
-		Data::Struct(DataStruct { fields: Fields::Unnamed(fields), .. }) => {
-			let ty = &fields.unnamed.first().unwrap().ty;
+		Data::Union(_) => err(ident.span(), "Cannot derive Peek on a Union"),
+
+		Data::Struct(DataStruct { fields, .. }) => {
+			let ty = &fields.iter().next().unwrap().ty;
 			quote! { <#ty>::peek(p, c) }
 		}
 
-		Data::Struct(_) => err(ident.span(), "Cannot derive Peek on a struct with named fields"),
-
-		Data::Union(_) => err(ident.span(), "Cannot derive Peek on a Union"),
-
 		Data::Enum(DataEnum { variants, .. }) => {
-			let mut steps = vec![];
-			let mut first = true;
-			for var in variants {
-				match var.fields {
-					Fields::Unit => {
-						steps.push(err(ident.span(), "Cannot derive Parse on a Field Unit Variant"));
-					}
-					Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
-						if unnamed.len() != 1 {
-							steps
-								.push(err(ident.span(), "Cannot derive Parse on a struct with multiple unnamed fields"))
-						} else {
-							let field = unnamed.first().unwrap();
-							let field_ty = &field.ty;
-							if first {
-								steps.push(quote! {
-									<#field_ty>::peek(p, c)
-								});
-							} else {
-								steps.push(quote! {
-									|| <#field_ty>::peek(p, c)
-								});
-							}
-						}
-					}
-					Fields::Named(_) => {
-						steps.push(err(var.fields.span(), "Cannot derive on Parse on a Named Field Variant"));
-					}
-				}
-				first = false;
-			}
-			quote! { #(#steps)* }
+			let ty: Vec<_> = variants.iter().map(|variant| variant.fields.iter().next()).dedup().collect();
+			quote! { #(<#ty>::peek(p, c))||* }
 		}
 	};
 	quote! {
 		#[automatically_derived]
-		impl<'a> #impl_generics ::css_parse::Peek<'a> for #ident #impl_generics {
+		impl<'a> ::css_parse::Peek<'a> for #ident #impl_generics {
 			fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
 				use ::css_parse::{Peek};
 				#body


### PR DESCRIPTION
Some of the csskit_derives code was very hastily/sloppily written. I took a bit of time to clean it up, tighten some of the code, make it less brittle and a bit more generic. Some nice benefits of this is that now it can apply to more structs, so I went through and added `derive(Peek)` in a few more places that it could be added.