### PR TITLE
css_ast: make todo types use the Todo struct

### DIFF
--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -22,7 +22,7 @@ pub use values::*;
 pub use visit::*;
 
 use css_lexer::Span;
-use css_parse::{CursorSink, Parse, Parser, Result as ParserResult, ToCursors, diagnostics};
+use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, diagnostics};
 
 // TODO! - delete this when we're done ;)
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -30,6 +30,12 @@ use css_parse::{CursorSink, Parse, Parser, Result as ParserResult, ToCursors, di
 pub enum Todo {
 	#[default]
 	Todo,
+}
+
+impl<'a> Peek<'a> for Todo {
+	fn peek(_p: &Parser<'a>, _c: css_lexer::Cursor) -> bool {
+		false
+	}
 }
 
 impl<'a> Parse<'a> for Todo {

--- a/crates/css_ast/src/types/auto_line_color_list.rs
+++ b/crates/css_ast/src/types/auto_line_color_list.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-color-list
 // <auto-line-color-list> = [ <line-color-or-repeat> ]* <auto-repeat-line-color> [ <line-color-or-repeat> ]*
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct AutoLineColorList;
-
-impl<'a> Peek<'a> for AutoLineColorList {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for AutoLineColorList {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for AutoLineColorList {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type AutoLineColorList = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/auto_line_style_list.rs
+++ b/crates/css_ast/src/types/auto_line_style_list.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-style-list
 // <auto-line-style-list> = [ <line-style-or-repeat> ]* <auto-repeat-line-style> [ <line-style-or-repeat> ]*
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct AutoLineStyleList;
-
-impl<'a> Peek<'a> for AutoLineStyleList {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for AutoLineStyleList {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for AutoLineStyleList {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type AutoLineStyleList = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/auto_line_width_list.rs
+++ b/crates/css_ast/src/types/auto_line_width_list.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-width-list
 // <auto-line-width-list>     = [ <line-width-or-repeat> ]* <auto-repeat-line-width> [ <line-width-or-repeat> ]*
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct AutoLineWidthList;
-
-impl<'a> Peek<'a> for AutoLineWidthList {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for AutoLineWidthList {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for AutoLineWidthList {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type AutoLineWidthList = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/autospace.rs
+++ b/crates/css_ast/src/types/autospace.rs
@@ -2,30 +2,12 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-text-4/#typedef-autospace
 //
 // <autospace> = no-autospace | [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct Autospace;
-
-impl<'a> Peek<'a> for Autospace {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for Autospace {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for Autospace {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type Autospace = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/basic_shape_rect.rs
+++ b/crates/css_ast/src/types/basic_shape_rect.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape-rect
 // <basic-shape-rect> = <inset()> | <rect()> | <xywh()>
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct BasicShapeRect;
-
-impl<'a> Peek<'a> for BasicShapeRect {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for BasicShapeRect {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for BasicShapeRect {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type BasicShapeRect = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/calc_size.rs
+++ b/crates/css_ast/src/types/calc_size.rs
@@ -1,25 +1,17 @@
+#![allow(warnings)]
 use css_lexer::Cursor;
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct CalcSize;
+use crate::Todo;
 
-impl<'a> Peek<'a> for CalcSize {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![Function]>::peek(p, c) && p.eq_ignore_ascii_case(c, "calc-size")
-	}
-}
+// https://drafts.csswg.org/css-values-5/#calc-size
+// <calc-size()> = calc-size( <calc-size-basis>, <calc-sum> )
+// <calc-size-basis> = [ <size-keyword> | <calc-size()> | any | <calc-sum> ]
+//
+// The <size-keyword> production matches any sizing keywords allowed in the context. For example, in width, it matches auto, min-content, stretch, etc.
+pub type CalcSize = Todo;
 
-impl<'a> Parse<'a> for CalcSize {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		p.parse::<T![Function]>()?;
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for CalcSize {
-	fn to_cursors(&self, _: &mut impl CursorSink) {
-		todo!();
-	}
+#[cfg(test)]
+mod tests {
+	use super::*;
 }

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-content-3/#content-values
 // <content-list> = [ <string> | <image> | <attr()> | contents | <quote> | <leader()> | <target> | <string()> | <content()> | <counter> ]+
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct ContentList;
-
-impl<'a> Peek<'a> for ContentList {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for ContentList {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for ContentList {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type ContentList = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/corner_shape_value.rs
+++ b/crates/css_ast/src/types/corner_shape_value.rs
@@ -2,30 +2,12 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-borders-4/#typedef-corner-shape-value
 // <corner-shape-value> = round | scoop | bevel | notch | square | squircle | <superellipse()>
 // superellipse() = superellipse(<number [-∞,∞]> | infinity | -infinity)
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct CornerShapeValue;
-
-impl<'a> Peek<'a> for CornerShapeValue {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for CornerShapeValue {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for CornerShapeValue {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type CornerShapeValue = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/gap_auto_rule_list.rs
+++ b/crates/css_ast/src/types/gap_auto_rule_list.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-gaps-1/#typedef-gap-auto-rule-list
 // <gap-auto-rule-list> = <gap-rule-or-repeat>#? , <gap-auto-repeat-rule> , <gap-rule-or-repeat>#?
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct GapAutoRuleList;
-
-impl<'a> Peek<'a> for GapAutoRuleList {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for GapAutoRuleList {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for GapAutoRuleList {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type GapAutoRuleList = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/gap_rule_list.rs
+++ b/crates/css_ast/src/types/gap_rule_list.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule-list
 // <gap-rule-list> = <gap-rule-or-repeat>#
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct GapRuleList;
-
-impl<'a> Peek<'a> for GapRuleList {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for GapRuleList {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for GapRuleList {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type GapRuleList = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/grid_line.rs
+++ b/crates/css_ast/src/types/grid_line.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-grid-2/#typedef-grid-row-start-grid-line
 // <grid-line> = auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct GridLine;
-
-impl<'a> Peek<'a> for GridLine {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for GridLine {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for GridLine {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type GridLine = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/line_color_list.rs
+++ b/crates/css_ast/src/types/line_color_list.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-gaps-1/#typedef-line-color-list
 // <line-color-list> = [ <line-color-or-repeat> ]+
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct LineColorList;
-
-impl<'a> Peek<'a> for LineColorList {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for LineColorList {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for LineColorList {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type LineColorList = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/line_style_list.rs
+++ b/crates/css_ast/src/types/line_style_list.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list
 // <line-style-list> = [ <line-style-or-repeat> ]+
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct LineStyleList;
-
-impl<'a> Peek<'a> for LineStyleList {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for LineStyleList {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for LineStyleList {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type LineStyleList = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/line_width_list.rs
+++ b/crates/css_ast/src/types/line_width_list.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-gaps-1/#typedef-line-width-list
 // <line-width-list> = [ <line-width-or-repeat> ]+
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct LineWidthList;
-
-impl<'a> Peek<'a> for LineWidthList {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for LineWidthList {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for LineWidthList {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type LineWidthList = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/single_animation_trigger.rs
+++ b/crates/css_ast/src/types/single_animation_trigger.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-animations-2/#typedef-single-animation-trigger
 // <single-animation-trigger> = <single-animation-trigger-behavior> || [ none | auto | [ [ <dashed-ident> | <scroll()> | <view()> ] [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]{0,4} ] ]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct SingleAnimationTrigger;
-
-impl<'a> Peek<'a> for SingleAnimationTrigger {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for SingleAnimationTrigger {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for SingleAnimationTrigger {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type SingleAnimationTrigger = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/spread_shadow.rs
+++ b/crates/css_ast/src/types/spread_shadow.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-borders-4/#typedef-spread-shadow
 // <spread-shadow> = <'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct SpreadShadow;
-
-impl<'a> Peek<'a> for SpreadShadow {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for SpreadShadow {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for SpreadShadow {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type SpreadShadow = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/text_edge.rs
+++ b/crates/css_ast/src/types/text_edge.rs
@@ -2,29 +2,11 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-inline-3/#typedef-text-edge
 // <text-edge> = [ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct TextEdge;
-
-impl<'a> Peek<'a> for TextEdge {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for TextEdge {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for TextEdge {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type TextEdge = Todo;
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/track_size.rs
+++ b/crates/css_ast/src/types/track_size.rs
@@ -2,31 +2,13 @@
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 
+use crate::Todo;
+
 // https://drafts.csswg.org/css-grid-2/#typedef-track-size
 // <track-size> = <track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage [0,∞]> )
 // <track-breadth> = <length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto
 // <inflexible-breadth>  = <length-percentage [0,∞]> | min-content | max-content | auto
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct TrackSize;
-
-impl<'a> Peek<'a> for TrackSize {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for TrackSize {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for TrackSize {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
+pub type TrackSize = Todo;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
We had a lot of structs which were todo, but they had some copypasta code to get them working. This now uses the Todo type which will help us better track where these are, and also make it easier to apply traits (e.g. Peek) to all todo items.