### PR TITLE
css_ast: derive IntoSpan for all AST Nodes

### DIFF
--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -48,6 +48,12 @@ impl ToCursors for Todo {
 	fn to_cursors(&self, _: &mut impl CursorSink) {}
 }
 
+impl From<&Todo> for Span {
+	fn from(_: &Todo) -> Self {
+		Self::DUMMY
+	}
+}
+
 impl<'a> Visitable<'a> for Todo {
 	fn accept<V: Visit<'a>>(&self, _: &mut V) {}
 }

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	Build, Declaration, DeclarationValue, Parse, Parser, Peek, Result as ParserResult, State, T, keyword_set,
 	syntax::BangImportant, syntax::ComponentValues,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 use std::{fmt::Debug, hash::Hash};
 
@@ -13,7 +13,7 @@ use super::{Visit, Visitable};
 // The build.rs generates a list of CSS properties from the value mods
 include!(concat!(env!("OUT_DIR"), "/css_apply_properties.rs"));
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Custom<'a>(pub ComponentValues<'a>);
 
@@ -28,7 +28,7 @@ impl<'a> Parse<'a> for Custom<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Computed<'a>(pub ComponentValues<'a>);
 
@@ -62,7 +62,7 @@ impl<'a> Parse<'a> for Computed<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Unknown<'a>(pub ComponentValues<'a>);
 
@@ -77,7 +77,7 @@ impl<'a> Parse<'a> for Unknown<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "property"))]
 #[visit]
 pub struct Property<'a> {
@@ -113,7 +113,7 @@ impl<'a> Visitable<'a> for Property<'a> {
 
 macro_rules! style_value {
 	( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $str: tt,)+ ) => {
-		#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename_all = "kebab-case"))]
 		#[visit]
 		pub enum StyleValue<'a> {

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 // https://drafts.csswg.org/css-syntax-3/#charset-rule
-#[derive(ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct CharsetRule {

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	AtRule, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Peek, PreludeList, Result as ParserResult,
 	RuleList, T, diagnostics, keyword_set,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, stylesheet::Rule};
@@ -13,7 +13,7 @@ mod features;
 pub use features::*;
 
 // https://drafts.csswg.org/css-contain-3/#container-rule
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct ContainerRule<'a> {
@@ -53,7 +53,7 @@ impl<'a> Visitable<'a> for ContainerRule<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct ContainerRules<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -4,13 +4,13 @@ use css_parse::{
 	AtRule, Build, CommaSeparatedPreludeList, Parse, Parser, Result as ParserResult, RuleList, T, diagnostics,
 	function_set,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, stylesheet::Rule};
 
 // https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct DocumentRule<'a> {
@@ -132,7 +132,7 @@ impl<'a> Visitable<'a> for DocumentMatcher {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct DocumentRuleBlock<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -4,13 +4,13 @@ use css_parse::{
 	AtRule, Declaration, NoPreludeAllowed, Parse, Parser, Peek, Result as ParserResult, RuleList, T, keyword_set,
 	syntax::BangImportant,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, properties::StyleValue};
 
 // https://drafts.csswg.org/css-fonts/#font-face-rule
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct FontFaceRule<'a> {
@@ -38,7 +38,7 @@ impl<'a> Visitable<'a> for FontFaceRule<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct FontFaceRuleBlock<'a> {
 	pub open: T!['{'],
@@ -65,7 +65,7 @@ impl<'a> Visitable<'a> for FontFaceRuleBlock<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "property"))]
 #[visit]
 pub struct FontFaceRuleProperty<'a> {

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -4,13 +4,13 @@ use css_parse::{
 	AtRule, Build, CommaSeparatedPreludeList, DeclarationList, Parse, Parser, Peek, QualifiedRule, QualifiedRuleList,
 	Result as ParserResult, T, diagnostics, keyword_set, syntax::BadDeclaration,
 };
-use csskit_derives::{IntoCursor, Peek, ToCursors};
+use csskit_derives::{IntoCursor, IntoSpan, Peek, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, properties::Property};
 
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct KeyframesRule<'a> {
@@ -68,7 +68,7 @@ impl<'a> Parse<'a> for KeyframesName {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct KeyframesBlock<'a> {
 	pub open: T!['{'],
@@ -95,7 +95,7 @@ impl<'a> Visitable<'a> for KeyframesBlock<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct Keyframe<'a> {
@@ -124,7 +124,7 @@ impl<'a> Visitable<'a> for Keyframe<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct KeyframeSelectors<'a>(pub Vec<'a, (KeyframeSelector, Option<T![,]>)>);
 
@@ -146,7 +146,7 @@ impl<'a> Visitable<'a> for KeyframeSelectors<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct KeyframeBlock<'a> {
 	open: T!['{'],

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -1,13 +1,13 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{AtRule, CommaSeparatedPreludeList, Parse, Parser, Result as ParserResult, RuleList, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, stylesheet::Rule};
 
 // https://drafts.csswg.org/css-cascade-5/#layering
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct LayerRule<'a> {
@@ -95,7 +95,7 @@ impl<'a> Visitable<'a> for LayerName<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum OptionalLayerRuleBlock<'a> {
 	None(T![;]),
@@ -120,7 +120,7 @@ impl<'a> Visitable<'a> for OptionalLayerRuleBlock<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct LayerRuleBlock<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	AtRule, Block, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Peek, PreludeList,
 	Result as ParserResult, T, diagnostics, keyword_set,
 };
-use csskit_derives::{IntoCursor, ToCursors};
+use csskit_derives::{IntoCursor, IntoSpan, ToCursors};
 
 use crate::{Property, Visit, Visitable, stylesheet::Rule};
 
@@ -12,7 +12,7 @@ mod features;
 use features::*;
 
 // https://drafts.csswg.org/mediaqueries-4/
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct MediaRule<'a> {
 	pub at_keyword: T![AtKeyword],
@@ -45,7 +45,7 @@ impl<'a> Visitable<'a> for MediaRule<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct MediaRules<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -1,13 +1,13 @@
 use css_lexer::Cursor;
 use css_parse::{AtRule, Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 use super::{DocumentMatcherList, DocumentRuleBlock};
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct MozDocumentRule<'a> {

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	AtRule, Build, CommaSeparatedPreludeList, DeclarationList, DeclarationRuleList, NoPreludeAllowed, Parse, Parser,
 	Peek, Result as ParserResult, T, atkeyword_set, diagnostics, keyword_set,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
 
 // https://drafts.csswg.org/cssom-1/#csspagerule
 // https://drafts.csswg.org/css-page-3/#at-page-rule
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct PageRule<'a> {
@@ -145,7 +145,7 @@ impl ToSpecificity for PagePseudoClass {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct PageRuleBlock<'a> {
 	pub open: T!['{'],
@@ -186,7 +186,7 @@ impl<'a> Visitable<'a> for PageRuleBlock<'a> {
 }
 
 // https://drafts.csswg.org/cssom-1/#cssmarginrule
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct MarginRule<'a> {
@@ -236,7 +236,7 @@ impl<'a> Visitable<'a> for MarginRule<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct MarginRuleBlock<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -5,12 +5,12 @@ use css_parse::{
 	AtRule, Build, Declaration, DeclarationList, DeclarationValue, Parse, Parser, Peek, Result as ParserResult, T,
 	diagnostics, keyword_set, syntax::ComponentValues,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 // https://drafts.csswg.org/cssom-1/#csspagerule
 // https://drafts.csswg.org/css-page-3/#at-page-rule
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct PropertyRule<'a> {
@@ -47,7 +47,7 @@ impl<'a> Visitable<'a> for PropertyRule<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct PropertyRuleBlock<'a> {
 	pub open: T!['{'],
@@ -67,7 +67,7 @@ impl<'a> DeclarationList<'a> for PropertyRuleBlock<'a> {
 	type Declaration = PropertyRuleProperty<'a>;
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct PropertyRuleProperty<'a> {
@@ -97,7 +97,7 @@ impl<'a> Visitable<'a> for PropertyRuleProperty<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PropertyRuleStyleValue<'a> {
 	InitialValue(ComponentValues<'a>),

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -5,11 +5,11 @@ use css_parse::{
 	AtRule, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Result as ParserResult, RuleList, T,
 	diagnostics, function_set, syntax::ComponentValues,
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 // https://drafts.csswg.org/css-conditional-3/#at-supports
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct SupportsRule<'a> {
@@ -73,7 +73,7 @@ impl<'a> Visitable<'a> for SupportsRule<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SupportsRuleBlock<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -1,6 +1,6 @@
 use css_lexer::Span;
 use css_parse::{AtRule, Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -8,7 +8,7 @@ use crate::{Visit, Visitable};
 use super::{KeyframesBlock, KeyframesName};
 
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct WebkitKeyframesRule<'a> {

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -1,13 +1,13 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, Peek, ToCursors};
+use csskit_derives::{IntoCursor, IntoSpan, Peek, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 use super::NamespacePrefix;
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct Attribute {
@@ -50,7 +50,7 @@ impl<'a> Visitable<'a> for Attribute {
 	}
 }
 
-#[derive(Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value"))]
 pub enum AttributeOperator {
 	Exact(T![=]),

--- a/crates/css_ast/src/selector/class.rs
+++ b/crates/css_ast/src/selector/class.rs
@@ -1,11 +1,11 @@
 use css_lexer::{Cursor, Kind};
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct Class {

--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -1,11 +1,11 @@
 use css_parse::{Parse, Parser, Result as ParserResult, T};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 // https://drafts.csswg.org/selectors/#combinators
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit]
 pub enum Combinator {

--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Result as ParserResult, T, function_set, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 use crate::{Visit, Visitable};
 
@@ -31,7 +31,7 @@ macro_rules! apply_functional_pseudo_class {
 
 macro_rules! define_functional_pseudo_class {
 	( $($ident: ident: $str: tt: $ty: ty: $val_ty: ty $(,)*)+ ) => {
-		#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(
 			feature = "serde",
 			derive(serde::Serialize),
@@ -91,7 +91,7 @@ impl<'a> Visitable<'a> for FunctionalPseudoClass<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct DirPseudoFunction {
 	pub colon: T![:],
@@ -102,7 +102,7 @@ pub struct DirPseudoFunction {
 
 keyword_set!(DirValue { Rtl: "rtl", Ltr: "ltr" });
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct HasPseudoFunction<'a> {
 	pub colon: T![:],
@@ -111,7 +111,7 @@ pub struct HasPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct HostPseudoFunction<'a> {
 	pub colon: T![:],
@@ -120,7 +120,7 @@ pub struct HostPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct HostContextPseudoFunction<'a> {
 	pub colon: T![:],
@@ -129,7 +129,7 @@ pub struct HostContextPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct IsPseudoFunction<'a> {
 	pub colon: T![:],
@@ -138,7 +138,7 @@ pub struct IsPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LangPseudoFunction<'a> {
 	pub colon: T![:],
@@ -147,7 +147,7 @@ pub struct LangPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LangValues<'a>(Vec<'a, LangValue>);
 
@@ -164,7 +164,7 @@ impl<'a> Parse<'a> for LangValues<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum LangValue {
 	Ident(T![Ident], Option<T![,]>),
@@ -185,7 +185,7 @@ impl<'a> Parse<'a> for LangValue {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NotPseudoFunction<'a> {
 	pub colon: T![:],
@@ -194,7 +194,7 @@ pub struct NotPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthChildPseudoFunction<'a> {
 	pub colon: T![:],
@@ -203,7 +203,7 @@ pub struct NthChildPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthColPseudoFunction<'a> {
 	pub colon: T![:],
@@ -212,7 +212,7 @@ pub struct NthColPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthLastChildPseudoFunction<'a> {
 	pub colon: T![:],
@@ -221,7 +221,7 @@ pub struct NthLastChildPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthLastColPseudoFunction<'a> {
 	pub colon: T![:],
@@ -230,7 +230,7 @@ pub struct NthLastColPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthLastOfTypePseudoFunction<'a> {
 	pub colon: T![:],
@@ -239,7 +239,7 @@ pub struct NthLastOfTypePseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthOfTypePseudoFunction<'a> {
 	pub colon: T![:],
@@ -248,7 +248,7 @@ pub struct NthOfTypePseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct WherePseudoFunction<'a> {
 	pub colon: T![:],
@@ -257,7 +257,7 @@ pub struct WherePseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct StatePseudoFunction {
 	pub colon: T![:],

--- a/crates/css_ast/src/selector/functional_pseudo_element.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_element.rs
@@ -1,14 +1,14 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 use super::CompoundSelector;
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename_all = "kebab-case"))]
 #[visit]
 pub enum FunctionalPseudoElement<'a> {
@@ -60,7 +60,7 @@ impl<'a> Visitable<'a> for FunctionalPseudoElement<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct HighlightPseudoElement {
 	pub colons: T![::],
@@ -69,7 +69,7 @@ pub struct HighlightPseudoElement {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SlottedPseudoElement<'a> {
 	pub colons: T![::],
@@ -78,7 +78,7 @@ pub struct SlottedPseudoElement<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct PartPseudoElement<'a> {
 	pub colons: T![::],

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	Build, CompoundSelector as CompoundSelectorTrait, Parse, Parser, Result as ParserResult,
 	SelectorComponent as SelectorComponentTrait, SelectorList as SelectorListTrait, T,
 };
-use csskit_derives::{IntoCursor, Peek, ToCursors};
+use csskit_derives::{IntoCursor, IntoSpan, Peek, ToCursors};
 use csskit_proc_macro::visit;
 
 mod attribute;
@@ -47,7 +47,7 @@ use super::{Visit, Visitable};
 ///     │                       ╰───────╯ │
 ///     ╰─────────────────────────────────╯
 /// ```
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct SelectorList<'a>(pub Vec<'a, (CompoundSelector<'a>, Option<T![,]>)>);
@@ -71,7 +71,7 @@ impl<'a> Visitable<'a> for SelectorList<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct CompoundSelector<'a>(pub Vec<'a, SelectorComponent<'a>>);
@@ -136,7 +136,7 @@ impl<'a> Visitable<'a> for Wildcard {
 // This encapsulates all `simple-selector` subtypes (e.g. `wq-name`,
 // `id-selector`) into one enum, as it makes parsing and visiting much more
 // practical.
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(
 	feature = "serde",
 	derive(serde::Serialize),

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,6 +1,6 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, Peek, ToCursors};
+use csskit_derives::{IntoCursor, IntoSpan, Peek, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -8,7 +8,7 @@ use crate::{Visit, Visitable};
 use super::Tag;
 
 // https://drafts.csswg.org/selectors/#combinators
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit]
 pub struct Namespace {
@@ -49,7 +49,7 @@ impl<'a> Visitable<'a> for Namespace {
 	}
 }
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NamespacePrefix {
 	None(T![|]),

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -1,5 +1,5 @@
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, Kind, KindSet};
+use css_lexer::{Cursor, Kind, KindSet, Span};
 use css_parse::{CursorSink, Parse, Parser, Result as ParserResult, T, ToCursors, diagnostics};
 
 use crate::units::CSSInt;
@@ -121,6 +121,17 @@ impl<'a> ToCursors for Nth<'a> {
 					s.append(*c);
 				}
 			}
+		}
+	}
+}
+
+impl<'a> From<&Nth<'a>> for Span {
+	fn from(value: &Nth<'a>) -> Self {
+		match value {
+			Nth::Odd(c) => c.into(),
+			Nth::Even(c) => c.into(),
+			Nth::Integer(c) => c.into(),
+			Nth::Anb(_, _, c) => c.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/selector/pseudo_class.rs
+++ b/crates/css_ast/src/selector/pseudo_class.rs
@@ -1,6 +1,5 @@
-use css_lexer::Span;
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -66,7 +65,7 @@ macro_rules! apply_pseudo_class {
 
 macro_rules! define_pseudo_class {
 	( $($ident: ident: $str: tt $(,)*)+ ) => {
-		#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToCursors, IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 		#[visit]
 		pub enum PseudoClass {
@@ -119,23 +118,6 @@ impl<'a> Parse<'a> for PseudoClass {
 					}
 				}
 			};
-		}
-		apply_pseudo_class!(match_keyword)
-	}
-}
-
-impl From<&PseudoClass> for Span {
-	fn from(value: &PseudoClass) -> Self {
-		macro_rules! match_keyword {
-			( $($ident: ident: $str: tt $(,)*)+ ) => {
-				match value {
-					$(PseudoClass::$ident(colon, ident))|+ => Into::<Span>::into(colon) + ident.into(),
-					PseudoClass::Webkit(c) => c.into(),
-					PseudoClass::Moz(c) => c.into(),
-					PseudoClass::Ms(c) => c.into(),
-					PseudoClass::O(c) => c.into(),
-				}
-			}
 		}
 		apply_pseudo_class!(match_keyword)
 	}

--- a/crates/css_ast/src/selector/pseudo_element.rs
+++ b/crates/css_ast/src/selector/pseudo_element.rs
@@ -1,6 +1,6 @@
 use css_lexer::KindSet;
 use css_parse::{Build, Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set, pseudo_class};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -31,7 +31,7 @@ macro_rules! apply_pseudo_element {
 
 macro_rules! define_pseudo_element {
 	( $($ident: ident: $str: tt $(,)*)+ ) => {
-		#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 		#[visit]
 		pub enum PseudoElement {

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -2,7 +2,7 @@ use crate::{properties::Property, selector::SelectorList};
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Block, Parse, Parser, QualifiedRule, Result as ParserResult, State, T, syntax::BadDeclaration};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use super::{UnknownAtRule, UnknownQualifiedRule, Visit, Visitable, rules};
@@ -19,7 +19,7 @@ use super::{UnknownAtRule, UnknownQualifiedRule, Visit, Visitable, rules};
 /// ```
 ///
 /// [1]: https://drafts.csswg.org/cssom-1/#the-cssstylerule-interface
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "stylerule"))]
 #[visit]
 pub struct StyleRule<'a> {
@@ -52,7 +52,7 @@ impl<'a> Visitable<'a> for StyleRule<'a> {
 }
 
 // https://drafts.csswg.org/cssom-1/#the-cssstylerule-interface
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "style-declaration"))]
 #[visit]
 pub struct StyleDeclaration<'a> {
@@ -104,7 +104,7 @@ macro_rules! nested_group_rule {
         $name: ident$(<$a: lifetime>)?: $str: pat,
     )+ ) => {
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
-		#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 		pub enum NestedGroupRule<'a> {
 			$(

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -4,13 +4,13 @@ use css_parse::{
 	Parse, Parser, Result as ParserResult, StyleSheet as StyleSheetTrait, T,
 	syntax::{AtRule, QualifiedRule},
 };
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, rules, stylerule::StyleRule};
 
 // https://drafts.csswg.org/cssom-1/#the-cssstylesheet-interface
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "stylesheet"))]
 #[visit]
 pub struct StyleSheet<'a> {
@@ -73,7 +73,7 @@ macro_rules! apply_rules {
 	};
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct UnknownAtRule<'a>(AtRule<'a>);
@@ -90,7 +90,7 @@ impl<'a> Visitable<'a> for UnknownAtRule<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct UnknownQualifiedRule<'a>(QualifiedRule<'a>);
@@ -112,7 +112,7 @@ macro_rules! rule {
         $name: ident$(<$a: lifetime>)?: $str: pat,
     )+ ) => {
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
-		#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 		pub enum Rule<'a> {
 			$(

--- a/crates/css_ast/src/types/anchor_name.rs
+++ b/crates/css_ast/src/types/anchor_name.rs
@@ -1,7 +1,7 @@
 use css_parse::T;
-use csskit_derives::{Parse, Peek, ToCursors};
+use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
 
 // https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-name
-#[derive(Parse, Peek, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Parse, Peek, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct AnchorName(T![DashedIdent]);

--- a/crates/css_ast/src/types/autospace.rs
+++ b/crates/css_ast/src/types/autospace.rs
@@ -5,7 +5,6 @@ use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCu
 use crate::Todo;
 
 // https://drafts.csswg.org/css-text-4/#typedef-autospace
-//
 // <autospace> = no-autospace | [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]
 pub type Autospace = Todo;
 

--- a/crates/css_ast/src/types/calc_size.rs
+++ b/crates/css_ast/src/types/calc_size.rs
@@ -1,6 +1,6 @@
 #![allow(warnings)]
 use css_lexer::Cursor;
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{CursorSink, Parser, Peek, Result as ParserResult, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/color/color_function.rs
+++ b/crates/css_ast/src/types/color/color_function.rs
@@ -1,7 +1,7 @@
 use crate::units::Angle;
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
-use csskit_derives::{IntoCursor, ToCursors};
+use csskit_derives::{IntoCursor, IntoSpan, ToCursors};
 
 function_set!(ColorFunctionName {
 	Color: "color",
@@ -83,7 +83,7 @@ keyword_set!(ColorSpace {
 });
 
 // https://drafts.csswg.org/css-color/#typedef-color-function
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum ColorFunction {
 	// https://drafts.csswg.org/css-color/#funcdef-color

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -4,13 +4,13 @@ mod system;
 
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 pub use color_function::*;
 pub use named::*;
 pub use system::*;
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Color {
 	Currentcolor(T![Ident]),

--- a/crates/css_ast/src/types/counter_style.rs
+++ b/crates/css_ast/src/types/counter_style.rs
@@ -1,10 +1,10 @@
 use css_lexer::Cursor;
 use css_parse::{Parser, Peek, T, keyword_set};
-use csskit_derives::{Parse, ToCursors};
+use csskit_derives::{IntoSpan, Parse, ToCursors};
 
 use super::Symbols;
 
-#[derive(Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum CounterStyle<'a> {
 	Predefined(PredefinedCounter),

--- a/crates/css_ast/src/types/dynamic_range_limit_mix.rs
+++ b/crates/css_ast/src/types/dynamic_range_limit_mix.rs
@@ -1,9 +1,9 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct DynamicRangeLimitMix<'a> {
 	function: T![Function],

--- a/crates/css_ast/src/types/easing_function.rs
+++ b/crates/css_ast/src/types/easing_function.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 use crate::CSSInt;
 
@@ -45,7 +45,7 @@ keyword_set!(StepPosition {
 // steps() = steps( <integer>, <step-position>?)
 //
 // <step-position> = jump-start | jump-end | jump-none | jump-both | start | end
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum EasingFunction<'a> {
 	Linear(T![Ident]),

--- a/crates/css_ast/src/types/gradient.rs
+++ b/crates/css_ast/src/types/gradient.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::{Cursor, Kind};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 use crate::{
 	types::Position,
@@ -18,7 +18,7 @@ function_set!(GradientFunctionName {
 });
 
 // https://drafts.csswg.org/css-images-3/#typedef-gradient
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Gradient<'a> {
 	Linear(T![Function], Option<LinearDirection>, Option<T![,]>, Vec<'a, ColorStopOrHint>, Option<T![')']>),
@@ -235,7 +235,7 @@ impl<'a> Parse<'a> for RadialSize {
 // https://drafts.csswg.org/css-images-3/#typedef-radial-shape
 keyword_set!(RadialShape { Circle: "circle", Ellipse: "ellipse" });
 
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum ColorStopOrHint {
 	Stop(Color, Option<LengthPercentage>, Option<T![,]>),

--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -1,11 +1,11 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 use super::Gradient;
 
 // https://drafts.csswg.org/css-images-3/#typedef-image
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Image<'a> {
 	Url(T![Url]),

--- a/crates/css_ast/src/types/image_1d.rs
+++ b/crates/css_ast/src/types/image_1d.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 use crate::{types::Color, units::LengthPercentageOrFlex};
 
@@ -9,7 +9,7 @@ use crate::{types::Color, units::LengthPercentageOrFlex};
 // <image-1D> = <stripes()>
 // <stripes()> = stripes( <color-stripe># )
 // <color-stripe> = <color> && [ <length-percentage> | <flex> ]?
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Image1D<'a> {
 	pub function: T![Function],

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -1,6 +1,6 @@
 use css_lexer::{Cursor, Kind, Token};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoCursor, ToCursors};
+use csskit_derives::{IntoCursor, IntoSpan, ToCursors};
 
 use crate::units::LengthPercentage;
 
@@ -16,7 +16,7 @@ use crate::units::LengthPercentage;
 //   [ [ left | right ] <length-percentage> ] &&
 //   [ [ top | bottom ] <length-percentage> ]
 // ]
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Position {
 	SingleValue(PositionSingleValue),

--- a/crates/css_ast/src/types/position_area.rs
+++ b/crates/css_ast/src/types/position_area.rs
@@ -1,6 +1,6 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 // https://drafts.csswg.org/css-anchor-position-1/#typedef-position-area
 // <position-area> = [
@@ -29,7 +29,7 @@ use csskit_derives::ToCursors;
 // |
 //   [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}
 // ]
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum PositionArea {
 	Physical(Option<PositionAreaPhsyicalHorizontal>, Option<PositionAreaPhsyicalVertical>),

--- a/crates/css_ast/src/types/ratio.rs
+++ b/crates/css_ast/src/types/ratio.rs
@@ -1,9 +1,9 @@
 use crate::units::CSSInt;
 use css_parse::{Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{Peek, ToCursors};
+use csskit_derives::{IntoSpan, Peek, ToCursors};
 
 // https://drafts.csswg.org/css-values-4/#ratios
-#[derive(Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Ratio {
 	pub numerator: CSSInt,

--- a/crates/css_ast/src/types/repeat_style.rs
+++ b/crates/css_ast/src/types/repeat_style.rs
@@ -1,10 +1,10 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 // https://drafts.csswg.org/css-backgrounds-4/#background-repeat
 // <repeat-style> = repeat-x | repeat-y | <repetition>{1,2}
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum RepeatStyle {
 	RepeatX(T![Ident]),

--- a/crates/css_ast/src/types/single_transition.rs
+++ b/crates/css_ast/src/types/single_transition.rs
@@ -1,14 +1,14 @@
 #![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset, Span};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics, keyword_set};
-use csskit_derives::{Parse, Peek, ToCursors};
+use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
 
 use crate::types::{EasingFunction, SingleTransitionProperty, TransitionBehaviorValue};
 use crate::units::Time;
 
 // https://drafts.csswg.org/css-transitions-2/#single-transition
 // <single-transition> = [ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SingleTransition<'a> {
 	pub property: Option<SingleTransitionPropertyOrNone>,
@@ -21,7 +21,7 @@ pub struct SingleTransition<'a> {
 keyword_set!(NoneKeyword, "none");
 
 // [ none | <single-transition-property> ]
-#[derive(ToCursors, Parse, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Parse, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum SingleTransitionPropertyOrNone {
 	None(NoneKeyword),

--- a/crates/css_ast/src/types/single_transition_property.rs
+++ b/crates/css_ast/src/types/single_transition_property.rs
@@ -1,11 +1,11 @@
 #![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
-use csskit_derives::{Peek, ToCursors};
+use csskit_derives::{IntoSpan, Peek, ToCursors};
 
 // https://drafts.csswg.org/css-transitions-1/#single-transition-property
 // <single-transition-property> = all | <custom-ident>
-#[derive(ToCursors, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum SingleTransitionProperty {
 	All(T![Ident]),

--- a/crates/css_ast/src/types/snap_block.rs
+++ b/crates/css_ast/src/types/snap_block.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 use crate::units::LengthPercentage;
 
 // https://drafts.csswg.org/css-page-floats-3/#funcdef-float-snap-block
 // snap-block() = snap-block( <length> , [ start | end | near ]? )
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub struct SnapBlock {
 	pub function: T![Function],

--- a/crates/css_ast/src/types/snap_inline.rs
+++ b/crates/css_ast/src/types/snap_inline.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 use crate::units::LengthPercentage;
 
 // https://drafts.csswg.org/css-page-floats-3/#funcdef-float-snap-inline
 // snap-inline() = snap-inline( <length> , [ left | right | near ]? )
-#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub struct SnapInline {
 	pub function: T![Function],

--- a/crates/css_ast/src/types/symbols.rs
+++ b/crates/css_ast/src/types/symbols.rs
@@ -1,12 +1,12 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::ToCursors;
+use csskit_derives::{IntoSpan, ToCursors};
 
 use crate::types::Image;
 
 // https://drafts.csswg.org/css-counter-styles-3/#funcdef-symbols
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Symbols<'a> {
 	pub function: T![Function],
@@ -50,7 +50,7 @@ impl<'a> Parse<'a> for Symbols<'a> {
 }
 
 // https://drafts.csswg.org/css-counter-styles-3/#funcdef-symbols
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Symbol<'a> {
 	String(T![String]),

--- a/crates/css_ast/src/types/transform_function.rs
+++ b/crates/css_ast/src/types/transform_function.rs
@@ -5,7 +5,7 @@ use css_lexer::Cursor;
 use css_parse::{
 	Build, CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics, function_set,
 };
-use csskit_derives::{Parse, Peek, ToCursors};
+use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
 
 #[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -29,7 +29,7 @@ function_set!(TransformFunctionName {
 });
 
 // https://drafts.csswg.org/css-transforms-1/#two-d-transform-functions
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum TransformFunction {
 	// https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -1,12 +1,12 @@
 use bumpalo::collections::Vec;
 use css_parse::{Parse, Parser, Result as ParserResult};
-use csskit_derives::{Peek, ToCursors};
+use csskit_derives::{IntoSpan, Peek, ToCursors};
 
 use crate::TransformFunction;
 
 // https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
 // <transform-list> = <transform-function>+
-#[derive(Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct TransformList<'a>(Vec<'a, TransformFunction>);
 

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_pure.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_pure.snap
@@ -5381,7 +5381,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 8704,
             "open": {
               "kind": "LeftParen",
               "offset": 8704,
@@ -5429,7 +5428,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 8731,
             "open": {
               "kind": "LeftParen",
               "offset": 8731,

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_brackets.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_brackets.snap
@@ -21,7 +21,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 10,
             "open": {
               "kind": "LeftParen",
               "offset": 10,
@@ -54,7 +53,6 @@ expression: result.output.unwrap()
                     },
                     {
                       "type": "SimpleBlock",
-                      "start": 34,
                       "open": {
                         "kind": "LeftCurly",
                         "offset": 34,
@@ -129,7 +127,6 @@ expression: result.output.unwrap()
                 "values": [
                   {
                     "type": "SimpleBlock",
-                    "start": 60,
                     "open": {
                       "kind": "LeftSquare",
                       "offset": 60,
@@ -230,7 +227,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 117,
             "open": {
               "kind": "LeftParen",
               "offset": 117,
@@ -240,7 +236,6 @@ expression: result.output.unwrap()
               "values": [
                 {
                   "type": "SimpleBlock",
-                  "start": 118,
                   "open": {
                     "kind": "LeftCurly",
                     "offset": 118,
@@ -386,7 +381,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 174,
             "open": {
               "kind": "LeftParen",
               "offset": 174,
@@ -396,7 +390,6 @@ expression: result.output.unwrap()
               "values": [
                 {
                   "type": "SimpleBlock",
-                  "start": 175,
                   "open": {
                     "kind": "LeftParen",
                     "offset": 175,
@@ -542,7 +535,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 231,
             "open": {
               "kind": "LeftParen",
               "offset": 231,
@@ -695,7 +687,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 292,
             "open": {
               "kind": "LeftParen",
               "offset": 292,
@@ -818,7 +809,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 340,
             "open": {
               "kind": "LeftParen",
               "offset": 340,
@@ -828,7 +818,6 @@ expression: result.output.unwrap()
               "values": [
                 {
                   "type": "SimpleBlock",
-                  "start": 341,
                   "open": {
                     "kind": "LeftSquare",
                     "offset": 341,
@@ -953,7 +942,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 385,
             "open": {
               "kind": "LeftParen",
               "offset": 385,
@@ -963,7 +951,6 @@ expression: result.output.unwrap()
               "values": [
                 {
                   "type": "SimpleBlock",
-                  "start": 386,
                   "open": {
                     "kind": "LeftSquare",
                     "offset": 386,
@@ -1109,7 +1096,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 440,
             "open": {
               "kind": "LeftParen",
               "offset": 440,
@@ -1119,7 +1105,6 @@ expression: result.output.unwrap()
               "values": [
                 {
                   "type": "SimpleBlock",
-                  "start": 441,
                   "open": {
                     "kind": "LeftSquare",
                     "offset": 441,
@@ -1129,7 +1114,6 @@ expression: result.output.unwrap()
                     "values": [
                       {
                         "type": "SimpleBlock",
-                        "start": 442,
                         "open": {
                           "kind": "LeftSquare",
                           "offset": 442,
@@ -1139,7 +1123,6 @@ expression: result.output.unwrap()
                           "values": [
                             {
                               "type": "SimpleBlock",
-                              "start": 443,
                               "open": {
                                 "kind": "LeftSquare",
                                 "offset": 443,
@@ -1149,7 +1132,6 @@ expression: result.output.unwrap()
                                 "values": [
                                   {
                                     "type": "SimpleBlock",
-                                    "start": 444,
                                     "open": {
                                       "kind": "LeftSquare",
                                       "offset": 444,
@@ -1159,7 +1141,6 @@ expression: result.output.unwrap()
                                       "values": [
                                         {
                                           "type": "SimpleBlock",
-                                          "start": 445,
                                           "open": {
                                             "kind": "LeftSquare",
                                             "offset": 445,
@@ -1169,7 +1150,6 @@ expression: result.output.unwrap()
                                             "values": [
                                               {
                                                 "type": "SimpleBlock",
-                                                "start": 446,
                                                 "open": {
                                                   "kind": "LeftCurly",
                                                   "offset": 446,
@@ -1207,7 +1187,6 @@ expression: result.output.unwrap()
                                                         },
                                                         {
                                                           "type": "SimpleBlock",
-                                                          "start": 462,
                                                           "open": {
                                                             "kind": "LeftCurly",
                                                             "offset": 462,

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_comments.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_comments.snap
@@ -259,7 +259,6 @@ expression: result.output.unwrap()
                 },
                 {
                   "type": "SimpleBlock",
-                  "start": 212,
                   "open": {
                     "kind": "LeftParen",
                     "offset": 216,

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_custom_properties.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_custom_properties.snap
@@ -356,7 +356,6 @@ expression: result.output.unwrap()
                 },
                 {
                   "type": "SimpleBlock",
-                  "start": 204,
                   "open": {
                     "kind": "LeftSquare",
                     "offset": 204,
@@ -439,7 +438,6 @@ expression: result.output.unwrap()
                 },
                 {
                   "type": "SimpleBlock",
-                  "start": 232,
                   "open": {
                     "kind": "LeftParen",
                     "offset": 232,
@@ -674,7 +672,6 @@ expression: result.output.unwrap()
                 },
                 {
                   "type": "SimpleBlock",
-                  "start": 366,
                   "open": {
                     "kind": "LeftCurly",
                     "offset": 366,
@@ -757,7 +754,6 @@ expression: result.output.unwrap()
                 },
                 {
                   "type": "SimpleBlock",
-                  "start": 387,
                   "open": {
                     "kind": "LeftSquare",
                     "offset": 387,
@@ -797,7 +793,6 @@ expression: result.output.unwrap()
                       },
                       {
                         "type": "SimpleBlock",
-                        "start": 396,
                         "open": {
                           "kind": "LeftCurly",
                           "offset": 396,
@@ -822,7 +817,6 @@ expression: result.output.unwrap()
                             },
                             {
                               "type": "SimpleBlock",
-                              "start": 406,
                               "open": {
                                 "kind": "LeftCurly",
                                 "offset": 406,
@@ -873,7 +867,6 @@ expression: result.output.unwrap()
                       },
                       {
                         "type": "SimpleBlock",
-                        "start": 416,
                         "open": {
                           "kind": "LeftSquare",
                           "offset": 416,
@@ -959,7 +952,6 @@ expression: result.output.unwrap()
                 },
                 {
                   "type": "SimpleBlock",
-                  "start": 453,
                   "open": {
                     "kind": "LeftCurly",
                     "offset": 453,

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_escape.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_escape.snap
@@ -406,7 +406,6 @@ expression: result.output.unwrap()
                   },
                   {
                     "type": "SimpleBlock",
-                    "start": 172,
                     "open": {
                       "kind": "LeftSquare",
                       "offset": 172,
@@ -825,7 +824,6 @@ expression: result.output.unwrap()
         "values": [
           {
             "type": "SimpleBlock",
-            "start": 295,
             "open": {
               "kind": "LeftSquare",
               "offset": 295,

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_extends.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_extends.snap
@@ -106,7 +106,6 @@ expression: result.output.unwrap()
                   },
                   {
                     "type": "SimpleBlock",
-                    "start": 31,
                     "open": {
                       "kind": "LeftCurly",
                       "offset": 31,

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_media.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_media.snap
@@ -60,7 +60,6 @@ expression: result.output.unwrap()
                 },
                 {
                   "type": "SimpleBlock",
-                  "start": 23,
                   "open": {
                     "kind": "LeftCurly",
                     "offset": 23,
@@ -168,7 +167,6 @@ expression: result.output.unwrap()
                 },
                 {
                   "type": "SimpleBlock",
-                  "start": 75,
                   "open": {
                     "kind": "LeftCurly",
                     "offset": 75,

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_prop.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_prop.snap
@@ -150,7 +150,6 @@ expression: result.output.unwrap()
           },
           {
             "type": "SimpleBlock",
-            "start": 77,
             "open": {
               "kind": "LeftParen",
               "offset": 77,

--- a/crates/css_lexer/src/span.rs
+++ b/crates/css_lexer/src/span.rs
@@ -144,6 +144,48 @@ impl From<Span> for miette::SourceSpan {
 	}
 }
 
+impl<'a, T> From<&'a bumpalo::collections::Vec<'a, T>> for Span
+where
+	&'a T: Into<Span>,
+{
+	fn from(value: &'a bumpalo::collections::Vec<'a, T>) -> Self {
+		let mut span = Span::DUMMY;
+		for item in value {
+			span = span + item.into();
+		}
+		span
+	}
+}
+
+impl<T, U> From<&(T, U)> for Span
+where
+	for<'a> &'a T: Into<Span>,
+	for<'a> &'a U: Into<Span>,
+{
+	fn from(value: &(T, U)) -> Self {
+		Into::<Span>::into(&value.0) + (&value.1).into()
+	}
+}
+
+impl<T, U, V> From<&(T, U, V)> for Span
+where
+	for<'a> &'a T: Into<Span>,
+	for<'a> &'a V: Into<Span>,
+{
+	fn from(value: &(T, U, V)) -> Self {
+		Into::<Span>::into(&value.0) + (&value.2).into()
+	}
+}
+
+impl<T> From<&Option<T>> for Span
+where
+	for<'a> &'a T: Into<Span>,
+{
+	fn from(value: &Option<T>) -> Self {
+		value.as_ref().map_or(Span::DUMMY, |t| t.into())
+	}
+}
+
 /// A trait representing an object that can derive its own [Span]. This is very similar to `From<MyStuct> for Span`,
 /// however `From<MyStruct> for Span` requires `Sized`, meaning it is not `dyn` compatible.
 pub trait Spanned {

--- a/crates/css_parse/src/macros/pseudo_class.rs
+++ b/crates/css_parse/src/macros/pseudo_class.rs
@@ -38,7 +38,7 @@
 macro_rules! pseudo_class {
 	($(#[doc = $usage:literal])*$name: ident { $( $variant: ident: $variant_str: tt$(,)?)+ }) => {
 		$(#[doc = $usage])*
-		#[derive(::csskit_derives::ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::ToCursors, ::csskit_derives::IntoSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		pub enum $name {
 			$($variant($crate::T![:], $crate::T![Ident]),)+
@@ -72,14 +72,6 @@ macro_rules! pseudo_class {
 			const MAP: phf::Map<&'static str, $name> = phf::phf_map! {
 					$($variant_str => $name::$variant(<$crate::T![:]>::dummy(), <$crate::T![Ident]>::dummy()),)+
 			};
-		}
-
-		impl From<&$name> for css_lexer::Span {
-			fn from(value: &$name) -> Self {
-				match value {
-					$($name::$variant(a, b) => Into::<::css_lexer::Span>::into(a) + b.into(),)+
-				}
-			}
 		}
 	}
 }

--- a/crates/css_parse/src/syntax/at_rule.rs
+++ b/crates/css_parse/src/syntax/at_rule.rs
@@ -3,6 +3,7 @@ use crate::{
 	syntax::{Block, ComponentValues},
 };
 use css_lexer::KindSet;
+use csskit_derives::IntoSpan;
 
 /// This struct provides the generic [`<at-rule>` grammar][1]. It will [consume an at-rule][2]. This is defined as:
 ///
@@ -18,7 +19,7 @@ use css_lexer::KindSet;
 ///
 /// [1]: https://drafts.csswg.org/css-syntax-3/#at-rule-diagram
 /// [2]: https://drafts.csswg.org/css-syntax-3/#consume-an-at-rule
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct AtRule<'a> {
 	pub name: T![AtKeyword],
@@ -53,7 +54,7 @@ impl ToCursors for AtRule<'_> {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum OptionalBlock<'a> {
 	Block(Block<'a>),

--- a/crates/css_parse/src/syntax/bad_declaration.rs
+++ b/crates/css_parse/src/syntax/bad_declaration.rs
@@ -1,5 +1,6 @@
 use crate::{CursorSink, Parse, Parser, Result as ParserResult, State, T, ToCursors, syntax::ComponentValue};
 use bumpalo::collections::Vec;
+use css_lexer::Span;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -42,6 +43,12 @@ impl<'a> Parse<'a> for BadDeclaration<'a> {
 			//
 			values.push(p.parse::<ComponentValue>()?);
 		}
+	}
+}
+
+impl<'a> From<&'a BadDeclaration<'a>> for Span {
+	fn from(value: &'a BadDeclaration<'a>) -> Self {
+		(&value.0).into()
 	}
 }
 

--- a/crates/css_parse/src/syntax/bang_important.rs
+++ b/crates/css_parse/src/syntax/bang_important.rs
@@ -1,5 +1,6 @@
 use crate::{CursorSink, Parse, Parser, Peek, Result, T, ToCursors, diagnostics};
 use css_lexer::{Cursor, Kind};
+use csskit_derives::IntoSpan;
 
 /// Represents a two tokens, the first being [Kind::Delim] where the char is `!`, and the second being an `Ident` with
 /// the value `important`. [CSS defines this as]:
@@ -19,7 +20,7 @@ use css_lexer::{Cursor, Kind};
 ///
 /// [1]: https://drafts.csswg.org/css-syntax-3/#!important-diagram
 ///
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct BangImportant {
 	pub bang: T![!],

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -1,10 +1,11 @@
 use crate::{Block as BlockTrait, CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 use bumpalo::collections::Vec;
 use css_lexer::{Kind, KindSet};
+use csskit_derives::IntoSpan;
 
 use super::{Declaration, Rule};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct Block<'a> {
 	pub open_curly: T!['{'],

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -3,11 +3,12 @@ use crate::{
 	syntax::{FunctionBlock, SimpleBlock},
 };
 use css_lexer::{Cursor, Kind, KindSet};
+use csskit_derives::IntoSpan;
 
 // https://drafts.csswg.org/css-syntax-3/#consume-component-value
 // A compatible "Token" per CSS grammar, subsetted to the tokens possibly
 // rendered by ComponentValue (so no pairwise, function tokens, etc).
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 pub enum ComponentValue<'a> {
 	SimpleBlock(SimpleBlock<'a>),

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -1,10 +1,11 @@
 use crate::{CursorSink, DeclarationValue, Parse, Parser, Result, ToCursors};
 use bumpalo::collections::Vec;
+use csskit_derives::IntoSpan;
 
 use super::ComponentValue;
 
 // https://drafts.csswg.org/css-syntax-3/#consume-list-of-components
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct ComponentValues<'a> {
 	values: Vec<'a, ComponentValue<'a>>,

--- a/crates/css_parse/src/syntax/function_block.rs
+++ b/crates/css_parse/src/syntax/function_block.rs
@@ -1,7 +1,8 @@
 use crate::{CursorSink, Parse, Parser, Result as ParserResult, T, ToCursors, syntax::ComponentValue};
 use bumpalo::collections::Vec;
+use csskit_derives::IntoSpan;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct FunctionBlock<'a> {
 	pub name: T![Function],

--- a/crates/css_parse/src/syntax/qualified_rule.rs
+++ b/crates/css_parse/src/syntax/qualified_rule.rs
@@ -2,8 +2,9 @@ use crate::{
 	CursorSink, Parse, Parser, QualifiedRule as QualifiedRuleTrait, Result, ToCursors,
 	syntax::{BadDeclaration, Block, ComponentValues},
 };
+use csskit_derives::IntoSpan;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct QualifiedRule<'a> {
 	pub prelude: ComponentValues<'a>,

--- a/crates/css_parse/src/syntax/rule.rs
+++ b/crates/css_parse/src/syntax/rule.rs
@@ -1,8 +1,9 @@
 use crate::{CursorSink, Parse, Parser, Result as ParserResult, T, ToCursors};
+use csskit_derives::IntoSpan;
 
 use super::{AtRule, QualifiedRule};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub enum Rule<'a> {
 	AtRule(AtRule<'a>),

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -1385,6 +1385,12 @@ impl PairWiseStart {
 	}
 }
 
+impl ToCursors for PairWiseStart {
+	fn to_cursors(&self, s: &mut impl CursorSink) {
+		s.append((*self).into());
+	}
+}
+
 impl<'a> Peek<'a> for PairWiseStart {
 	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::LeftCurly, Kind::LeftSquare, Kind::LeftParen]);
 }
@@ -1413,6 +1419,12 @@ impl PairWiseEnd {
 			Kind::RightSquare => Kind::LeftSquare,
 			k => k,
 		}
+	}
+}
+
+impl ToCursors for PairWiseEnd {
+	fn to_cursors(&self, s: &mut impl CursorSink) {
+		s.append((*self).into());
 	}
 }
 

--- a/crates/csskit_derives/src/into_span.rs
+++ b/crates/csskit_derives/src/into_span.rs
@@ -1,0 +1,120 @@
+use itertools::{Itertools, Position};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Type, TypePath};
+
+use crate::err;
+
+trait TypeIsOption {
+	fn is_option(&self) -> bool;
+}
+
+impl TypeIsOption for Type {
+	fn is_option(&self) -> bool {
+		match self {
+			Self::Path(TypePath { path, .. }) => path.segments.last().map_or(false, |s| s.ident == "Option"),
+			_ => false,
+		}
+	}
+}
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+	let ident = input.ident;
+	let generics = &mut input.generics.clone();
+	let (impl_generics, _, _) = generics.split_for_impl();
+	let body = match input.data {
+		Data::Union(_) => err(ident.span(), "Cannot derive Into<Span> on a Union"),
+
+		Data::Struct(DataStruct { fields, .. }) => {
+			let members: Vec<_> = fields.members().zip(fields.iter().map(|f| f.ty.is_option())).collect();
+			if members.len() == 1 {
+				let member = fields.members().next().unwrap();
+				quote! { (&value.#member).into() }
+
+			// All members are Option<T>, so we have no choice but to try and add them all to get something useful.
+			} else if members.iter().all(|(_, is_option)| *is_option) {
+				let members = fields.members();
+				quote! { #(Into::<Span>::into(&value.#members))+* }
+			} else {
+				// To get a reliable span we need to find the first member, and the last. However as some members are
+				// Optional<T>, and could potentially all be none, we need to find the first non-optional member to guarantee we can get a Span.
+				members
+					.iter()
+					.take_while_inclusive(|(_, is_option)| *is_option)
+					.with_position()
+					.map(|(position, (member, _))| match position {
+						Position::Only => quote! { let first = Into::<Span>::into(&value.#member); },
+						Position::First => quote! {
+							let first = if let Some(value) = value.#member {
+								Into::<Span>::into(&value)
+							}
+						},
+						Position::Middle => quote! {
+							else if let Some(value) = value.#member {
+								Into::<Span>::into(&value)
+							}
+						},
+						Position::Last => quote! {
+							else {
+								Into::<Span>::into(&value.#member)
+							};
+						},
+					})
+					.chain(members.iter().rev().take_while_inclusive(|(_, is_option)| *is_option).with_position().map(
+						|(position, (member, _))| match position {
+							Position::Only => quote! { first + (&value.#member).into() },
+							Position::First => quote! {
+								let last = if let Some(ref value) = value.#member {
+									value.into()
+								}
+							},
+							Position::Middle => quote! {
+								else if let Some(ref value) = value.#member {
+									value.into()
+								}
+							},
+							Position::Last => quote! {
+								else {
+									(&value.#member).into()
+								};
+								first + last
+							},
+						},
+					))
+					.collect()
+			}
+		}
+
+		Data::Enum(DataEnum { variants, .. }) => {
+			let steps: TokenStream = variants
+				.iter()
+				.map(|variant| {
+					let variant_ident = &variant.ident;
+					let len = variant.fields.len();
+					if len == 1 {
+						quote! { #ident::#variant_ident(val) => val.into(), }
+					} else {
+						let rest = (2..len).map(|_| quote! { _ }).chain([quote! {last}]);
+						quote! {
+							#ident::#variant_ident(first, #(#rest),*) => Into::<Span>::into(first) + last.into(),
+						}
+					}
+				})
+				.collect();
+			quote! {
+				match value {
+					#steps
+				}
+			}
+		}
+	};
+	quote! {
+		#[automatically_derived]
+		impl #impl_generics From<&#ident #impl_generics> for ::css_lexer::Span {
+			fn from(value: &#ident) -> ::css_lexer::Span {
+				use ::css_lexer::Span;
+				#body
+			}
+		}
+	}
+}

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -4,6 +4,7 @@ use proc_macro2::Span;
 use syn::Error;
 
 mod into_cursor;
+mod into_span;
 mod parse;
 mod peek;
 mod to_cursors;
@@ -30,6 +31,12 @@ pub fn derive_peek(stream: TokenStream) -> TokenStream {
 pub fn derive_into_cursor(stream: TokenStream) -> TokenStream {
 	let input = syn::parse(stream).unwrap();
 	into_cursor::derive(input).into()
+}
+
+#[proc_macro_derive(IntoSpan)]
+pub fn derive_into_span(stream: TokenStream) -> TokenStream {
+	let input = syn::parse(stream).unwrap();
+	into_span::derive(input).into()
 }
 
 fn err(span: Span, msg: &str) -> proc_macro2::TokenStream {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Auto : "auto", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", Bar : "bar", Baz : "baz", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { None : "none", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { FitContent : "fit-content", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Normal : "normal", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { None : "none", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Auto : "auto", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Keyword : "keyword", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Keyword : "keyword", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { None : "none", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
@@ -7,6 +7,7 @@ expression: pretty
     "pink", }
 );
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Auto : "auto", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { LineThrough : "line-through", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
@@ -4,6 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::IntoSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/value.rs
+++ b/crates/csskit_proc_macro/src/value.rs
@@ -44,7 +44,7 @@ pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 		#keyword_def
 
 		#(#attrs)*
-		#[derive(::csskit_derives::ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::IntoSpan, ::csskit_derives::ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		#def
 		#peek_impl


### PR DESCRIPTION
It's important that AST nodes have an easy way to get their span. This is useful in, for example, `csskit_highlight` which takes those spans to highlight code. 

Traditionally we hand wrote `Into<Span>` implementations. However this is laborious and so they were done sparingly. While cleaning up derive code in #170 I realised we could probably make a derive macro for this, and so I did.

So this change adds the new `IntoSpan` derive macro, which will figure out the first and last members of an AST node and get their spans, adding them together. The result is a generated implementation that can reliably output Span information for all AST nodes.

This change also applies `IntoSpan` to all viable AST nodes, by first applying it to `Stylesheet` and working our way down.