### PR TITLE
Implement -moz- pseudo elements, and some blanket impls for Peek/Parse/ToCursors

### DIFF
--- a/crates/css_parse/src/traits/peek.rs
+++ b/crates/css_parse/src/traits/peek.rs
@@ -38,6 +38,16 @@ pub trait Peek<'a>: Sized {
 	}
 }
 
+impl<'a, T> Peek<'a> for Option<T>
+where
+	T: Peek<'a>,
+{
+	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
+		T::peek(p, c)
+	}
+}
+
+
 impl<'a, T> Peek<'a> for ::bumpalo::collections::Vec<'a, T>
 where
 	T: Peek<'a>,
@@ -48,3 +58,22 @@ where
 		T::peek(p, c)
 	}
 }
+
+macro_rules! impl_tuple {
+    ($($T:ident),*) => {
+        impl<'a, $($T),*> Peek<'a> for ($($T),*)
+        where
+            $($T: Peek<'a>,)*
+        {
+            const PEEK_KINDSET: KindSet = T::PEEK_KINDSET;
+
+            fn peek(p: &Parser<'a>, c: Cursor) -> bool {
+                T::peek(p, c)
+            }
+        }
+    };
+}
+
+impl_tuple!(T, U);
+impl_tuple!(T, U, V);
+impl_tuple!(T, U, V, W);

--- a/crates/css_parse/src/traits/to_cursors.rs
+++ b/crates/css_parse/src/traits/to_cursors.rs
@@ -38,46 +38,22 @@ where
 	}
 }
 
-// TODO: This is here for types that are todo, and may want to derive ToCursors
-impl ToCursors for () {
-	fn to_cursors(&self, _: &mut impl CursorSink) {}
+macro_rules! impl_tuple {
+    ($($T:ident),*) => {
+        impl<$($T),*> ToCursors for ($($T),*)
+        where
+            $($T: ToCursors,)*
+        {
+            #[allow(non_snake_case)]
+            #[allow(unused)]
+            fn to_cursors(&self, s: &mut impl CursorSink) {
+                let ($($T),*) = self;
+                $($T.to_cursors(s);)*
+            }
+        }
+    };
 }
 
-impl<T, U> ToCursors for (T, U)
-where
-	T: ToCursors,
-	U: ToCursors,
-{
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		ToCursors::to_cursors(&self.0, s);
-		ToCursors::to_cursors(&self.1, s);
-	}
-}
-
-impl<T, U, V> ToCursors for (T, U, V)
-where
-	T: ToCursors,
-	U: ToCursors,
-	V: ToCursors,
-{
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		ToCursors::to_cursors(&self.0, s);
-		ToCursors::to_cursors(&self.1, s);
-		ToCursors::to_cursors(&self.2, s);
-	}
-}
-
-impl<T, U, V, W> ToCursors for (T, U, V, W)
-where
-	T: ToCursors,
-	U: ToCursors,
-	V: ToCursors,
-	W: ToCursors,
-{
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		ToCursors::to_cursors(&self.0, s);
-		ToCursors::to_cursors(&self.1, s);
-		ToCursors::to_cursors(&self.2, s);
-		ToCursors::to_cursors(&self.3, s);
-	}
-}
+impl_tuple!(T, U);
+impl_tuple!(T, U, V);
+impl_tuple!(T, U, V, W);


### PR DESCRIPTION
I wanted to drop `impl ToCursors for () {` because I'm sure this will cause us bugs in the future, but to do so we needed to implement `MozFunctionalPseudoElement`, which relied on this blanket impl. I thought I'd use it as an exercise to impl some more blanket impls for the Park/Peek/ToCursors traits, which got us some nice succinct code for this Parse impl. We're very close to being able to just `derive(Parse)` on this one, but still need a way to discriminate on `T![Function]` & `!T[Ident]` & co, so not just yet.

