### PR TITLE
(css_ast): derive `Parse` for a few more Vec impls

### DIFF
--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Result as ParserResult, T, function_set, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
 
 use crate::{Visit, Visitable};
 
@@ -147,24 +147,11 @@ pub struct LangPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct LangValues<'a>(Vec<'a, LangValue>);
+pub struct LangValues<'a>(pub Vec<'a, LangValue>);
 
-impl<'a> Parse<'a> for LangValues<'a> {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let mut values = Vec::new_in(p.bump());
-		loop {
-			values.push(p.parse::<LangValue>()?);
-			if p.peek::<T![')']>() {
-				break;
-			}
-		}
-		Ok(Self(values))
-	}
-}
-
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum LangValue {
 	Ident(T![Ident], Option<T![,]>),

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -8,7 +8,7 @@ use crate::types::{Attr, Counter, Image, LeaderType, Quote, Target};
 
 // https://drafts.csswg.org/css-content-3/#content-values
 // <content-list> = [ <string> | <image> | <attr()> | contents | <quote> | <leader()> | <target> | <string()> | <content()> | <counter> ]+
-#[derive(IntoSpan, Parse, ToCursors, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Peek, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct ContentList<'a>(pub Vec<'a, ContentListItem<'a>>);
 

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -1,24 +1,13 @@
 use bumpalo::collections::Vec;
-use css_parse::{Parse, Parser, Result as ParserResult};
-use csskit_derives::{IntoSpan, Peek, ToCursors};
+use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
 
 use crate::TransformFunction;
 
 // https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
 // <transform-list> = <transform-function>+
-#[derive(IntoSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoSpan, Peek, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct TransformList<'a>(Vec<'a, TransformFunction>);
-
-impl<'a> Parse<'a> for TransformList<'a> {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let mut list = Vec::new_in(p.bump());
-		while let Some(transform) = p.parse_if_peek::<TransformFunction>()? {
-			list.push(transform);
-		}
-		Ok(TransformList(list))
-	}
-}
+pub struct TransformList<'a>(pub Vec<'a, TransformFunction>);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Since https://github.com/csskit/csskit/pull/175 we can now derive `Parse` for simple `struct(Vec)`s. This PR just goes through and adds those in some places.