### PR TITLE
Modify all Into<Span>/From<T> for Span to `ToSpan` trait

### DIFF
--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -21,7 +21,7 @@ pub use units::*;
 pub use values::*;
 pub use visit::*;
 
-use css_lexer::Span;
+use css_lexer::{Span, ToSpan};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, diagnostics};
 
 // TODO! - delete this when we're done ;)
@@ -48,9 +48,9 @@ impl ToCursors for Todo {
 	fn to_cursors(&self, _: &mut impl CursorSink) {}
 }
 
-impl From<&Todo> for Span {
-	fn from(_: &Todo) -> Self {
-		Self::DUMMY
+impl ToSpan for Todo {
+	fn to_span(&self) -> Span {
+		Span::DUMMY
 	}
 }
 

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	Build, Declaration, DeclarationValue, Parse, Parser, Peek, Result as ParserResult, State, T, keyword_set,
 	syntax::BangImportant, syntax::ComponentValues,
 };
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 use std::{fmt::Debug, hash::Hash};
 
@@ -13,7 +13,7 @@ use super::{Visit, Visitable};
 // The build.rs generates a list of CSS properties from the value mods
 include!(concat!(env!("OUT_DIR"), "/css_apply_properties.rs"));
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Custom<'a>(pub ComponentValues<'a>);
 
@@ -28,7 +28,7 @@ impl<'a> Parse<'a> for Custom<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Computed<'a>(pub ComponentValues<'a>);
 
@@ -62,7 +62,7 @@ impl<'a> Parse<'a> for Computed<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Unknown<'a>(pub ComponentValues<'a>);
 
@@ -77,7 +77,7 @@ impl<'a> Parse<'a> for Unknown<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "property"))]
 #[visit]
 pub struct Property<'a> {
@@ -113,7 +113,7 @@ impl<'a> Visitable<'a> for Property<'a> {
 
 macro_rules! style_value {
 	( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $str: tt,)+ ) => {
-		#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename_all = "kebab-case"))]
 		#[visit]
 		pub enum StyleValue<'a> {

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 // https://drafts.csswg.org/css-syntax-3/#charset-rule
-#[derive(IntoSpan, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct CharsetRule {

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	AtRule, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Peek, PreludeList, Result as ParserResult,
 	RuleList, T, diagnostics, keyword_set,
 };
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, stylesheet::Rule};
@@ -13,7 +13,7 @@ mod features;
 pub use features::*;
 
 // https://drafts.csswg.org/css-contain-3/#container-rule
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct ContainerRule<'a> {
@@ -53,7 +53,7 @@ impl<'a> Visitable<'a> for ContainerRule<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct ContainerRules<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -4,13 +4,13 @@ use css_parse::{
 	AtRule, Build, CommaSeparatedPreludeList, Parse, Parser, Result as ParserResult, RuleList, T, diagnostics,
 	function_set,
 };
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, stylesheet::Rule};
 
 // https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct DocumentRule<'a> {
@@ -132,7 +132,7 @@ impl<'a> Visitable<'a> for DocumentMatcher {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct DocumentRuleBlock<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -4,13 +4,13 @@ use css_parse::{
 	AtRule, Declaration, NoPreludeAllowed, Parse, Parser, Peek, Result as ParserResult, RuleList, T, keyword_set,
 	syntax::BangImportant,
 };
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, properties::StyleValue};
 
 // https://drafts.csswg.org/css-fonts/#font-face-rule
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct FontFaceRule<'a> {
@@ -38,7 +38,7 @@ impl<'a> Visitable<'a> for FontFaceRule<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct FontFaceRuleBlock<'a> {
 	pub open: T!['{'],
@@ -65,7 +65,7 @@ impl<'a> Visitable<'a> for FontFaceRuleBlock<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "property"))]
 #[visit]
 pub struct FontFaceRuleProperty<'a> {

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -4,13 +4,13 @@ use css_parse::{
 	AtRule, Build, CommaSeparatedPreludeList, DeclarationList, Parse, Parser, Peek, QualifiedRule, QualifiedRuleList,
 	Result as ParserResult, T, diagnostics, keyword_set, syntax::BadDeclaration,
 };
-use csskit_derives::{IntoCursor, IntoSpan, Peek, ToCursors};
+use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, properties::Property};
 
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct KeyframesRule<'a> {
@@ -68,7 +68,7 @@ impl<'a> Parse<'a> for KeyframesName {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct KeyframesBlock<'a> {
 	pub open: T!['{'],
@@ -95,7 +95,7 @@ impl<'a> Visitable<'a> for KeyframesBlock<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct Keyframe<'a> {
@@ -124,7 +124,7 @@ impl<'a> Visitable<'a> for Keyframe<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct KeyframeSelectors<'a>(pub Vec<'a, (KeyframeSelector, Option<T![,]>)>);
 
@@ -146,7 +146,7 @@ impl<'a> Visitable<'a> for KeyframeSelectors<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct KeyframeBlock<'a> {
 	open: T!['{'],

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -1,13 +1,13 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{AtRule, CommaSeparatedPreludeList, Parse, Parser, Result as ParserResult, RuleList, T, diagnostics};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, stylesheet::Rule};
 
 // https://drafts.csswg.org/css-cascade-5/#layering
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct LayerRule<'a> {
@@ -95,7 +95,7 @@ impl<'a> Visitable<'a> for LayerName<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum OptionalLayerRuleBlock<'a> {
 	None(T![;]),
@@ -120,7 +120,7 @@ impl<'a> Visitable<'a> for OptionalLayerRuleBlock<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct LayerRuleBlock<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/media/features/hack.rs
+++ b/crates/css_ast/src/rules/media/features/hack.rs
@@ -1,4 +1,4 @@
-use css_lexer::Cursor;
+use css_lexer::{Cursor, ToSpan};
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
 use csskit_derives::ToCursors;
 
@@ -13,7 +13,7 @@ impl<'a> Parse<'a> for HackMediaFeature {
 		let open = p.parse::<T!['(']>()?;
 		let keyword = p.parse::<T![Ident]>()?;
 		if !p.eq_ignore_ascii_case(keyword.into(), "min-width") {
-			Err(diagnostics::UnexpectedIdent(p.parse_str(keyword.into()).into(), (&keyword).into()))?
+			Err(diagnostics::UnexpectedIdent(p.parse_str(keyword.into()).into(), keyword.to_span()))?
 		}
 		let colon = p.parse::<T![:]>()?;
 		let dimension = p.parse::<T![Dimension]>()?;

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	AtRule, Block, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Peek, PreludeList,
 	Result as ParserResult, T, diagnostics, keyword_set,
 };
-use csskit_derives::{IntoCursor, IntoSpan, ToCursors};
+use csskit_derives::{IntoCursor, ToCursors, ToSpan};
 
 use crate::{Property, Visit, Visitable, stylesheet::Rule};
 
@@ -12,7 +12,7 @@ mod features;
 use features::*;
 
 // https://drafts.csswg.org/mediaqueries-4/
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct MediaRule<'a> {
 	pub at_keyword: T![AtKeyword],
@@ -45,7 +45,7 @@ impl<'a> Visitable<'a> for MediaRule<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct MediaRules<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -1,13 +1,13 @@
 use css_lexer::Cursor;
 use css_parse::{AtRule, Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 use super::{DocumentMatcherList, DocumentRuleBlock};
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct MozDocumentRule<'a> {

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	AtRule, Build, CommaSeparatedPreludeList, DeclarationList, DeclarationRuleList, NoPreludeAllowed, Parse, Parser,
 	Peek, Result as ParserResult, T, atkeyword_set, diagnostics, keyword_set,
 };
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
 
 // https://drafts.csswg.org/cssom-1/#csspagerule
 // https://drafts.csswg.org/css-page-3/#at-page-rule
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct PageRule<'a> {
@@ -145,7 +145,7 @@ impl ToSpecificity for PagePseudoClass {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct PageRuleBlock<'a> {
 	pub open: T!['{'],
@@ -186,7 +186,7 @@ impl<'a> Visitable<'a> for PageRuleBlock<'a> {
 }
 
 // https://drafts.csswg.org/cssom-1/#cssmarginrule
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct MarginRule<'a> {
@@ -236,7 +236,7 @@ impl<'a> Visitable<'a> for MarginRule<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct MarginRuleBlock<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -5,12 +5,12 @@ use css_parse::{
 	AtRule, Build, Declaration, DeclarationList, DeclarationValue, Parse, Parser, Peek, Result as ParserResult, T,
 	diagnostics, keyword_set, syntax::ComponentValues,
 };
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 // https://drafts.csswg.org/cssom-1/#csspagerule
 // https://drafts.csswg.org/css-page-3/#at-page-rule
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct PropertyRule<'a> {
@@ -47,7 +47,7 @@ impl<'a> Visitable<'a> for PropertyRule<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct PropertyRuleBlock<'a> {
 	pub open: T!['{'],
@@ -67,7 +67,7 @@ impl<'a> DeclarationList<'a> for PropertyRuleBlock<'a> {
 	type Declaration = PropertyRuleProperty<'a>;
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct PropertyRuleProperty<'a> {
@@ -97,7 +97,7 @@ impl<'a> Visitable<'a> for PropertyRuleProperty<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PropertyRuleStyleValue<'a> {
 	InitialValue(ComponentValues<'a>),

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -5,11 +5,11 @@ use css_parse::{
 	AtRule, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Result as ParserResult, RuleList, T,
 	diagnostics, function_set, syntax::ComponentValues,
 };
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 // https://drafts.csswg.org/css-conditional-3/#at-supports
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct SupportsRule<'a> {
@@ -73,7 +73,7 @@ impl<'a> Visitable<'a> for SupportsRule<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SupportsRuleBlock<'a> {
 	pub open: T!['{'],

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -1,6 +1,6 @@
 use css_lexer::Span;
 use css_parse::{AtRule, Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -8,7 +8,7 @@ use crate::{Visit, Visitable};
 use super::{KeyframesBlock, KeyframesName};
 
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct WebkitKeyframesRule<'a> {

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -1,13 +1,13 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, IntoSpan, Peek, ToCursors};
+use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 use super::NamespacePrefix;
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct Attribute {
@@ -50,7 +50,7 @@ impl<'a> Visitable<'a> for Attribute {
 	}
 }
 
-#[derive(IntoSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value"))]
 pub enum AttributeOperator {
 	Exact(T![=]),

--- a/crates/css_ast/src/selector/class.rs
+++ b/crates/css_ast/src/selector/class.rs
@@ -1,11 +1,11 @@
 use css_lexer::{Cursor, Kind};
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct Class {

--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -1,11 +1,11 @@
 use css_parse::{Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 // https://drafts.csswg.org/selectors/#combinators
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit]
 pub enum Combinator {

--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Result as ParserResult, T, function_set, keyword_set};
-use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 use crate::{Visit, Visitable};
 
@@ -31,7 +31,7 @@ macro_rules! apply_functional_pseudo_class {
 
 macro_rules! define_functional_pseudo_class {
 	( $($ident: ident: $str: tt: $ty: ty: $val_ty: ty $(,)*)+ ) => {
-		#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(
 			feature = "serde",
 			derive(serde::Serialize),
@@ -91,7 +91,7 @@ impl<'a> Visitable<'a> for FunctionalPseudoClass<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct DirPseudoFunction {
 	pub colon: T![:],
@@ -102,7 +102,7 @@ pub struct DirPseudoFunction {
 
 keyword_set!(DirValue { Rtl: "rtl", Ltr: "ltr" });
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct HasPseudoFunction<'a> {
 	pub colon: T![:],
@@ -111,7 +111,7 @@ pub struct HasPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct HostPseudoFunction<'a> {
 	pub colon: T![:],
@@ -120,7 +120,7 @@ pub struct HostPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct HostContextPseudoFunction<'a> {
 	pub colon: T![:],
@@ -129,7 +129,7 @@ pub struct HostContextPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct IsPseudoFunction<'a> {
 	pub colon: T![:],
@@ -138,7 +138,7 @@ pub struct IsPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LangPseudoFunction<'a> {
 	pub colon: T![:],
@@ -147,11 +147,11 @@ pub struct LangPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LangValues<'a>(pub Vec<'a, LangValue>);
 
-#[derive(IntoSpan, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum LangValue {
 	Ident(T![Ident], Option<T![,]>),
@@ -172,7 +172,7 @@ impl<'a> Parse<'a> for LangValue {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NotPseudoFunction<'a> {
 	pub colon: T![:],
@@ -181,7 +181,7 @@ pub struct NotPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthChildPseudoFunction<'a> {
 	pub colon: T![:],
@@ -190,7 +190,7 @@ pub struct NthChildPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthColPseudoFunction<'a> {
 	pub colon: T![:],
@@ -199,7 +199,7 @@ pub struct NthColPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthLastChildPseudoFunction<'a> {
 	pub colon: T![:],
@@ -208,7 +208,7 @@ pub struct NthLastChildPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthLastColPseudoFunction<'a> {
 	pub colon: T![:],
@@ -217,7 +217,7 @@ pub struct NthLastColPseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthLastOfTypePseudoFunction<'a> {
 	pub colon: T![:],
@@ -226,7 +226,7 @@ pub struct NthLastOfTypePseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NthOfTypePseudoFunction<'a> {
 	pub colon: T![:],
@@ -235,7 +235,7 @@ pub struct NthOfTypePseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct WherePseudoFunction<'a> {
 	pub colon: T![:],
@@ -244,7 +244,7 @@ pub struct WherePseudoFunction<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct StatePseudoFunction {
 	pub colon: T![:],

--- a/crates/css_ast/src/selector/functional_pseudo_element.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_element.rs
@@ -1,14 +1,14 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
 
 use super::CompoundSelector;
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename_all = "kebab-case"))]
 #[visit]
 pub enum FunctionalPseudoElement<'a> {
@@ -60,7 +60,7 @@ impl<'a> Visitable<'a> for FunctionalPseudoElement<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct HighlightPseudoElement {
 	pub colons: T![::],
@@ -69,7 +69,7 @@ pub struct HighlightPseudoElement {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SlottedPseudoElement<'a> {
 	pub colons: T![::],
@@ -78,7 +78,7 @@ pub struct SlottedPseudoElement<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct PartPseudoElement<'a> {
 	pub colons: T![::],

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	Build, CompoundSelector as CompoundSelectorTrait, Parse, Parser, Result as ParserResult,
 	SelectorComponent as SelectorComponentTrait, SelectorList as SelectorListTrait, T,
 };
-use csskit_derives::{IntoCursor, IntoSpan, Peek, ToCursors};
+use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 mod attribute;
@@ -47,7 +47,7 @@ use super::{Visit, Visitable};
 ///     │                       ╰───────╯ │
 ///     ╰─────────────────────────────────╯
 /// ```
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct SelectorList<'a>(pub Vec<'a, (CompoundSelector<'a>, Option<T![,]>)>);
@@ -71,7 +71,7 @@ impl<'a> Visitable<'a> for SelectorList<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct CompoundSelector<'a>(pub Vec<'a, SelectorComponent<'a>>);
@@ -136,7 +136,7 @@ impl<'a> Visitable<'a> for Wildcard {
 // This encapsulates all `simple-selector` subtypes (e.g. `wq-name`,
 // `id-selector`) into one enum, as it makes parsing and visiting much more
 // practical.
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(
 	feature = "serde",
 	derive(serde::Serialize),

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,6 +1,6 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, IntoSpan, Peek, ToCursors};
+use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -8,7 +8,7 @@ use crate::{Visit, Visitable};
 use super::Tag;
 
 // https://drafts.csswg.org/selectors/#combinators
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit]
 pub struct Namespace {
@@ -49,7 +49,7 @@ impl<'a> Visitable<'a> for Namespace {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NamespacePrefix {
 	None(T![|]),

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -1,5 +1,5 @@
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, Kind, KindSet, Span};
+use css_lexer::{Cursor, Kind, KindSet, Span, ToSpan};
 use css_parse::{CursorSink, Parse, Parser, Result as ParserResult, T, ToCursors, diagnostics};
 
 use crate::units::CSSInt;
@@ -125,13 +125,13 @@ impl<'a> ToCursors for Nth<'a> {
 	}
 }
 
-impl<'a> From<&Nth<'a>> for Span {
-	fn from(value: &Nth<'a>) -> Self {
-		match value {
-			Nth::Odd(c) => c.into(),
-			Nth::Even(c) => c.into(),
-			Nth::Integer(c) => c.into(),
-			Nth::Anb(_, _, c) => c.into(),
+impl<'a> ToSpan for Nth<'a> {
+	fn to_span(&self) -> Span {
+		match self {
+			Nth::Odd(c) => c.to_span(),
+			Nth::Even(c) => c.to_span(),
+			Nth::Integer(c) => c.to_span(),
+			Nth::Anb(_, _, c) => c.to_span(),
 		}
 	}
 }

--- a/crates/css_ast/src/selector/pseudo_class.rs
+++ b/crates/css_ast/src/selector/pseudo_class.rs
@@ -1,5 +1,5 @@
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -65,7 +65,7 @@ macro_rules! apply_pseudo_class {
 
 macro_rules! define_pseudo_class {
 	( $($ident: ident: $str: tt $(,)*)+ ) => {
-		#[derive(ToCursors, IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 		#[visit]
 		pub enum PseudoClass {

--- a/crates/css_ast/src/selector/pseudo_element.rs
+++ b/crates/css_ast/src/selector/pseudo_element.rs
@@ -1,6 +1,6 @@
 use css_lexer::KindSet;
 use css_parse::{Build, Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set, pseudo_class};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable};
@@ -31,7 +31,7 @@ macro_rules! apply_pseudo_element {
 
 macro_rules! define_pseudo_element {
 	( $($ident: ident: $str: tt $(,)*)+ ) => {
-		#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 		#[visit]
 		pub enum PseudoElement {

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -2,7 +2,7 @@ use crate::{properties::Property, selector::SelectorList};
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Block, Parse, Parser, QualifiedRule, Result as ParserResult, State, T, syntax::BadDeclaration};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use super::{UnknownAtRule, UnknownQualifiedRule, Visit, Visitable, rules};
@@ -19,7 +19,7 @@ use super::{UnknownAtRule, UnknownQualifiedRule, Visit, Visitable, rules};
 /// ```
 ///
 /// [1]: https://drafts.csswg.org/cssom-1/#the-cssstylerule-interface
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "stylerule"))]
 #[visit]
 pub struct StyleRule<'a> {
@@ -52,7 +52,7 @@ impl<'a> Visitable<'a> for StyleRule<'a> {
 }
 
 // https://drafts.csswg.org/cssom-1/#the-cssstylerule-interface
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "style-declaration"))]
 #[visit]
 pub struct StyleDeclaration<'a> {
@@ -104,7 +104,7 @@ macro_rules! nested_group_rule {
         $name: ident$(<$a: lifetime>)?: $str: pat,
     )+ ) => {
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
-		#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 		pub enum NestedGroupRule<'a> {
 			$(

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -4,13 +4,13 @@ use css_parse::{
 	Parse, Parser, Result as ParserResult, StyleSheet as StyleSheetTrait, T,
 	syntax::{AtRule, QualifiedRule},
 };
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 use csskit_proc_macro::visit;
 
 use crate::{Visit, Visitable, rules, stylerule::StyleRule};
 
 // https://drafts.csswg.org/cssom-1/#the-cssstylesheet-interface
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename = "stylesheet"))]
 #[visit]
 pub struct StyleSheet<'a> {
@@ -73,7 +73,7 @@ macro_rules! apply_rules {
 	};
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct UnknownAtRule<'a>(AtRule<'a>);
@@ -90,7 +90,7 @@ impl<'a> Visitable<'a> for UnknownAtRule<'a> {
 	}
 }
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct UnknownQualifiedRule<'a>(QualifiedRule<'a>);
@@ -112,7 +112,7 @@ macro_rules! rule {
         $name: ident$(<$a: lifetime>)?: $str: pat,
     )+ ) => {
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
-		#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 		pub enum Rule<'a> {
 			$(

--- a/crates/css_ast/src/types/anchor_name.rs
+++ b/crates/css_ast/src/types/anchor_name.rs
@@ -1,7 +1,7 @@
 use css_parse::T;
-use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 // https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-name
-#[derive(IntoSpan, Parse, Peek, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Parse, Peek, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct AnchorName(T![DashedIdent]);

--- a/crates/css_ast/src/types/attr.rs
+++ b/crates/css_ast/src/types/attr.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 use crate::types::Syntax;
 
@@ -11,7 +11,7 @@ type DeclarationValue<'a> = Vec<'a, crate::Todo>;
 // https://drafts.csswg.org/css-values-5/#attr-notation
 // attr() = attr( <attr-name> <attr-type>? , <declaration-value>?)
 //<attr-type> = type( <syntax> ) | raw-string | <attr-unit>
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Attr<'a>(
 	pub T![Function],
@@ -47,7 +47,7 @@ impl<'a> Parse<'a> for Attr<'a> {
 }
 
 // <attr-name> = [ <ident-token>? '|' ]? <ident-token>
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct AttrName(pub Option<T![Ident]>, pub Option<T![|]>, pub Option<T![Ident]>);
 
@@ -85,7 +85,7 @@ impl<'a> Parse<'a> for AttrName {
 keyword_set!(AttrTypeRawString, "raw-string");
 
 // <attr-type> = type( <syntax> ) | raw-string | <attr-unit>
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum AttrType {
 	Type(T![Function], Syntax),

--- a/crates/css_ast/src/types/bg_image.rs
+++ b/crates/css_ast/src/types/bg_image.rs
@@ -1,4 +1,4 @@
-use css_lexer::Cursor;
+use css_lexer::{Cursor, ToSpan};
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
 use csskit_derives::ToCursors;
 
@@ -28,7 +28,7 @@ impl<'a> Parse<'a> for BgImage<'a> {
 			let ident = p.parse::<T![Ident]>()?;
 			let c: Cursor = ident.into();
 			if !p.eq_ignore_ascii_case(c, "none") {
-				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), (&ident).into()))?;
+				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), ident.to_span()))?;
 			}
 			Ok(Self::None(ident))
 		}

--- a/crates/css_ast/src/types/color/color_function.rs
+++ b/crates/css_ast/src/types/color/color_function.rs
@@ -1,7 +1,7 @@
 use crate::units::Angle;
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
-use csskit_derives::{IntoCursor, IntoSpan, ToCursors};
+use csskit_derives::{IntoCursor, ToCursors, ToSpan};
 
 function_set!(ColorFunctionName {
 	Color: "color",
@@ -83,7 +83,7 @@ keyword_set!(ColorSpace {
 });
 
 // https://drafts.csswg.org/css-color/#typedef-color-function
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum ColorFunction {
 	// https://drafts.csswg.org/css-color/#funcdef-color

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -4,13 +4,13 @@ mod system;
 
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 pub use color_function::*;
 pub use named::*;
 pub use system::*;
 
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Color {
 	Currentcolor(T![Ident]),

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -2,13 +2,13 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set, keyword_set};
-use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 use crate::types::{Attr, Counter, Image, LeaderType, Quote, Target};
 
 // https://drafts.csswg.org/css-content-3/#content-values
 // <content-list> = [ <string> | <image> | <attr()> | contents | <quote> | <leader()> | <target> | <string()> | <content()> | <counter> ]+
-#[derive(IntoSpan, Peek, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Peek, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct ContentList<'a>(pub Vec<'a, ContentListItem<'a>>);
 
@@ -23,7 +23,7 @@ keyword_set!(ContentFunctionKeywords {
 });
 function_set!(ContentListFunctionNames { String: "string", Leader: "leader", Content: "content" });
 
-#[derive(IntoSpan, ToCursors, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum ContentListItem<'a> {
 	String(T![String]),

--- a/crates/css_ast/src/types/counter_functions.rs
+++ b/crates/css_ast/src/types/counter_functions.rs
@@ -1,6 +1,6 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 use crate::types::CounterStyle;
 
@@ -8,7 +8,7 @@ function_set!(CounterFunctionNames { Counter: "counter", Counters: "counters" })
 
 // https://drafts.csswg.org/css-lists-3/#counter-functions
 // <counter> = <counter()> | <counters()>
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Counter<'a> {
 	// <counter()>  =  counter( <counter-name>, <counter-style>? )

--- a/crates/css_ast/src/types/counter_style.rs
+++ b/crates/css_ast/src/types/counter_style.rs
@@ -1,10 +1,10 @@
 use css_lexer::Cursor;
 use css_parse::{Parser, Peek, T, keyword_set};
-use csskit_derives::{IntoSpan, Parse, ToCursors};
+use csskit_derives::{Parse, ToCursors, ToSpan};
 
 use super::Symbols;
 
-#[derive(IntoSpan, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum CounterStyle<'a> {
 	Predefined(PredefinedCounter),

--- a/crates/css_ast/src/types/dynamic_range_limit_mix.rs
+++ b/crates/css_ast/src/types/dynamic_range_limit_mix.rs
@@ -1,9 +1,9 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct DynamicRangeLimitMix<'a> {
 	function: T![Function],

--- a/crates/css_ast/src/types/easing_function.rs
+++ b/crates/css_ast/src/types/easing_function.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 use crate::CSSInt;
 
@@ -45,7 +45,7 @@ keyword_set!(StepPosition {
 // steps() = steps( <integer>, <step-position>?)
 //
 // <step-position> = jump-start | jump-end | jump-none | jump-both | start | end
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum EasingFunction<'a> {
 	Linear(T![Ident]),

--- a/crates/css_ast/src/types/gradient.rs
+++ b/crates/css_ast/src/types/gradient.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, Kind};
+use css_lexer::{Cursor, Kind, ToSpan};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 use crate::{
 	types::Position,
@@ -18,7 +18,7 @@ function_set!(GradientFunctionName {
 });
 
 // https://drafts.csswg.org/css-images-3/#typedef-gradient
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Gradient<'a> {
 	Linear(T![Function], Option<LinearDirection>, Option<T![,]>, Vec<'a, ColorStopOrHint>, Option<T![')']>),
@@ -173,7 +173,7 @@ impl<'a> Parse<'a> for LinearDirection {
 			let to = p.parse::<T![Ident]>()?;
 			let c: Cursor = to.into();
 			if !p.eq_ignore_ascii_case(c, "to") {
-				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), (&to).into()))?
+				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), to.to_span()))?
 			}
 			let first = p.parse::<NamedDirection>()?;
 			let second = p.parse_if_peek::<NamedDirection>()?;
@@ -235,7 +235,7 @@ impl<'a> Parse<'a> for RadialSize {
 // https://drafts.csswg.org/css-images-3/#typedef-radial-shape
 keyword_set!(RadialShape { Circle: "circle", Ellipse: "ellipse" });
 
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum ColorStopOrHint {
 	Stop(Color, Option<LengthPercentage>, Option<T![,]>),

--- a/crates/css_ast/src/types/grid_line.rs
+++ b/crates/css_ast/src/types/grid_line.rs
@@ -1,6 +1,6 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoSpan, Peek, ToCursors};
+use csskit_derives::{Peek, ToCursors, ToSpan};
 
 use crate::Unit;
 
@@ -8,7 +8,7 @@ keyword_set!(GridLineKeywords { Auto: "auto", Span: "span" });
 
 // https://drafts.csswg.org/css-grid-2/#typedef-grid-row-start-grid-line
 // <grid-line> = auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]
-#[derive(IntoSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum GridLine {
 	Auto(GridLineKeywords),

--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -1,11 +1,11 @@
-use css_lexer::Cursor;
+use css_lexer::{Cursor, ToSpan};
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 use super::Gradient;
 
 // https://drafts.csswg.org/css-images-3/#typedef-image
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Image<'a> {
 	Url(T![Url]),
@@ -30,7 +30,7 @@ impl<'a> Parse<'a> for Image<'a> {
 		} else {
 			let func = p.parse::<T![Function]>()?;
 			if !p.eq_ignore_ascii_case(func.into(), "url") {
-				Err(diagnostics::UnexpectedFunction(p.parse_str(func.into()).into(), (&func).into()))?
+				Err(diagnostics::UnexpectedFunction(p.parse_str(func.into()).into(), func.to_span()))?
 			}
 			let string = p.parse::<T![String]>()?;
 			let close = p.parse::<T![')']>()?;

--- a/crates/css_ast/src/types/image_1d.rs
+++ b/crates/css_ast/src/types/image_1d.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 use crate::{types::Color, units::LengthPercentageOrFlex};
 
@@ -9,7 +9,7 @@ use crate::{types::Color, units::LengthPercentageOrFlex};
 // <image-1D> = <stripes()>
 // <stripes()> = stripes( <color-stripe># )
 // <color-stripe> = <color> && [ <length-percentage> | <flex> ]?
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Image1D<'a> {
 	pub function: T![Function],

--- a/crates/css_ast/src/types/leader_type.rs
+++ b/crates/css_ast/src/types/leader_type.rs
@@ -1,11 +1,11 @@
 use css_parse::{T, keyword_set};
-use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 keyword_set!(LeaderTypeKeywords { Dotted: "dotted", Solid: "solid", Space: "space" });
 
 // https://drafts.csswg.org/css-content-3/#typedef-leader-type
 // <leader-type> = dotted | solid | space | <string>
-#[derive(IntoSpan, Parse, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Parse, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum LeaderType {
 	Keyword(LeaderTypeKeywords),

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -1,6 +1,6 @@
 use css_lexer::{Cursor, Kind, Token};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoCursor, IntoSpan, ToCursors};
+use csskit_derives::{IntoCursor, ToCursors, ToSpan};
 
 use crate::units::LengthPercentage;
 
@@ -16,7 +16,7 @@ use crate::units::LengthPercentage;
 //   [ [ left | right ] <length-percentage> ] &&
 //   [ [ top | bottom ] <length-percentage> ]
 // ]
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Position {
 	SingleValue(PositionSingleValue),

--- a/crates/css_ast/src/types/position_area.rs
+++ b/crates/css_ast/src/types/position_area.rs
@@ -1,6 +1,6 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 // https://drafts.csswg.org/css-anchor-position-1/#typedef-position-area
 // <position-area> = [
@@ -29,7 +29,7 @@ use csskit_derives::{IntoSpan, ToCursors};
 // |
 //   [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}
 // ]
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum PositionArea {
 	Physical(Option<PositionAreaPhsyicalHorizontal>, Option<PositionAreaPhsyicalVertical>),

--- a/crates/css_ast/src/types/ratio.rs
+++ b/crates/css_ast/src/types/ratio.rs
@@ -1,9 +1,9 @@
 use crate::units::CSSInt;
 use css_parse::{Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{IntoSpan, Peek, ToCursors};
+use csskit_derives::{Peek, ToCursors, ToSpan};
 
 // https://drafts.csswg.org/css-values-4/#ratios
-#[derive(IntoSpan, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Ratio {
 	pub numerator: CSSInt,

--- a/crates/css_ast/src/types/repeat_style.rs
+++ b/crates/css_ast/src/types/repeat_style.rs
@@ -1,10 +1,10 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 // https://drafts.csswg.org/css-backgrounds-4/#background-repeat
 // <repeat-style> = repeat-x | repeat-y | <repetition>{1,2}
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum RepeatStyle {
 	RepeatX(T![Ident]),

--- a/crates/css_ast/src/types/single_transition.rs
+++ b/crates/css_ast/src/types/single_transition.rs
@@ -1,14 +1,14 @@
 #![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset, Span};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics, keyword_set};
-use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 use crate::types::{EasingFunction, SingleTransitionProperty, TransitionBehaviorValue};
 use crate::units::Time;
 
 // https://drafts.csswg.org/css-transitions-2/#single-transition
 // <single-transition> = [ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SingleTransition<'a> {
 	pub property: Option<SingleTransitionPropertyOrNone>,
@@ -21,7 +21,7 @@ pub struct SingleTransition<'a> {
 keyword_set!(NoneKeyword, "none");
 
 // [ none | <single-transition-property> ]
-#[derive(IntoSpan, ToCursors, Parse, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Parse, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum SingleTransitionPropertyOrNone {
 	None(NoneKeyword),

--- a/crates/css_ast/src/types/single_transition_property.rs
+++ b/crates/css_ast/src/types/single_transition_property.rs
@@ -1,11 +1,11 @@
 #![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
-use csskit_derives::{IntoSpan, Peek, ToCursors};
+use csskit_derives::{Peek, ToCursors, ToSpan};
 
 // https://drafts.csswg.org/css-transitions-1/#single-transition-property
 // <single-transition-property> = all | <custom-ident>
-#[derive(IntoSpan, ToCursors, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum SingleTransitionProperty {
 	All(T![Ident]),

--- a/crates/css_ast/src/types/snap_block.rs
+++ b/crates/css_ast/src/types/snap_block.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 use crate::units::LengthPercentage;
 
 // https://drafts.csswg.org/css-page-floats-3/#funcdef-float-snap-block
 // snap-block() = snap-block( <length> , [ start | end | near ]? )
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub struct SnapBlock {
 	pub function: T![Function],

--- a/crates/css_ast/src/types/snap_inline.rs
+++ b/crates/css_ast/src/types/snap_inline.rs
@@ -1,12 +1,12 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 use crate::units::LengthPercentage;
 
 // https://drafts.csswg.org/css-page-floats-3/#funcdef-float-snap-inline
 // snap-inline() = snap-inline( <length> , [ left | right | near ]? )
-#[derive(IntoSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub struct SnapInline {
 	pub function: T![Function],

--- a/crates/css_ast/src/types/symbols.rs
+++ b/crates/css_ast/src/types/symbols.rs
@@ -1,12 +1,12 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
-use csskit_derives::{IntoSpan, ToCursors};
+use csskit_derives::{ToCursors, ToSpan};
 
 use crate::types::Image;
 
 // https://drafts.csswg.org/css-counter-styles-3/#funcdef-symbols
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Symbols<'a> {
 	pub function: T![Function],
@@ -50,7 +50,7 @@ impl<'a> Parse<'a> for Symbols<'a> {
 }
 
 // https://drafts.csswg.org/css-counter-styles-3/#funcdef-symbols
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Symbol<'a> {
 	String(T![String]),

--- a/crates/css_ast/src/types/target_functions.rs
+++ b/crates/css_ast/src/types/target_functions.rs
@@ -1,6 +1,6 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
-use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 use crate::types::CounterStyle;
 
@@ -16,7 +16,7 @@ pub enum TargetCounterKind {
 
 // https://drafts.csswg.org/css-content-3/#typedef-target
 // <target> = <target-counter()> | <target-counters()> | <target-text()>
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Target<'a> {
 	// https://drafts.csswg.org/css-content-3/#target-counter

--- a/crates/css_ast/src/types/transform_function.rs
+++ b/crates/css_ast/src/types/transform_function.rs
@@ -5,7 +5,7 @@ use css_lexer::Cursor;
 use css_parse::{
 	Build, CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics, function_set,
 };
-use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 #[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -29,7 +29,7 @@ function_set!(TransformFunctionName {
 });
 
 // https://drafts.csswg.org/css-transforms-1/#two-d-transform-functions
-#[derive(IntoSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum TransformFunction {
 	// https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -1,11 +1,11 @@
 use bumpalo::collections::Vec;
-use csskit_derives::{IntoSpan, Parse, Peek, ToCursors};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 use crate::TransformFunction;
 
 // https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
 // <transform-list> = <transform-function>+
-#[derive(IntoSpan, Peek, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Peek, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct TransformList<'a>(pub Vec<'a, TransformFunction>);
 

--- a/crates/css_lexer/src/cursor.rs
+++ b/crates/css_lexer/src/cursor.rs
@@ -1,5 +1,5 @@
 use crate::{
-	CommentStyle, DimensionUnit, Kind, KindSet, QuoteStyle, SourceOffset, Span, Token,
+	CommentStyle, DimensionUnit, Kind, KindSet, QuoteStyle, SourceOffset, Span, ToSpan, Token,
 	span::SpanContents,
 	syntax::{ParseEscape, is_newline},
 };
@@ -317,14 +317,14 @@ impl PartialEq<Token> for Cursor {
 	}
 }
 
-impl From<Cursor> for Span {
-	fn from(cursor: Cursor) -> Self {
-		cursor.span()
+impl ToSpan for Cursor {
+	fn to_span(&self) -> Span {
+		self.span()
 	}
 }
 
-impl From<&Cursor> for Span {
-	fn from(cursor: &Cursor) -> Self {
+impl From<Cursor> for Span {
+	fn from(cursor: Cursor) -> Self {
 		cursor.span()
 	}
 }

--- a/crates/css_lexer/src/lib.rs
+++ b/crates/css_lexer/src/lib.rs
@@ -99,7 +99,7 @@ pub use kindset::KindSet;
 pub use pairwise::PairWise;
 pub use quote_style::QuoteStyle;
 pub use source_offset::SourceOffset;
-pub use span::{Span, SpanContents, Spanned};
+pub use span::{Span, SpanContents, ToSpan};
 pub use token::Token;
 pub use whitespace_style::Whitespace;
 

--- a/crates/css_lexer/src/source_offset.rs
+++ b/crates/css_lexer/src/source_offset.rs
@@ -10,6 +10,7 @@ pub struct SourceOffset(pub u32);
 impl SourceOffset {
 	/// Represents a fake SourceOffset with [u32::MAX] as the number.
 	pub const DUMMY: SourceOffset = SourceOffset(u32::MAX);
+	pub const ZERO: SourceOffset = SourceOffset(0);
 
 	/// Providing a [Token] can produce a [Span].
 	pub fn as_span(&self, t: Token) -> Span {

--- a/crates/css_parse/src/macros/pseudo_class.rs
+++ b/crates/css_parse/src/macros/pseudo_class.rs
@@ -38,7 +38,7 @@
 macro_rules! pseudo_class {
 	($(#[doc = $usage:literal])*$name: ident { $( $variant: ident: $variant_str: tt$(,)?)+ }) => {
 		$(#[doc = $usage])*
-		#[derive(::csskit_derives::ToCursors, ::csskit_derives::IntoSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::ToCursors, ::csskit_derives::ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		pub enum $name {
 			$($variant($crate::T![:], $crate::T![Ident]),)+
@@ -63,7 +63,8 @@ macro_rules! pseudo_class {
 						$(Self::$variant(_, _) => Ok(Self::$variant(colon, ident)),)+
 					}
 				} else {
-					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), (&ident).into()))?
+					use ::css_lexer::ToSpan;
+					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.to_span()))?
 				}
 			}
 		}

--- a/crates/css_parse/src/macros/pseudo_element.rs
+++ b/crates/css_parse/src/macros/pseudo_element.rs
@@ -61,7 +61,8 @@ macro_rules! pseudo_element {
 						$(Self::$variant(_, _) => Ok(Self::$variant(colons, ident)),)+
 					}
 				} else {
-					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), (&ident).into()))?
+					use ::css_lexer::ToSpan;
+					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.to_span()))?
 				}
 			}
 		}
@@ -77,18 +78,18 @@ macro_rules! pseudo_element {
 			}
 		}
 
+		impl ::css_lexer::ToSpan for $name {
+			fn to_span(&self) -> ::css_lexer::Span {
+				match self {
+					$($name::$variant(a, b) => a.to_span() + b.to_span(),)+
+				}
+			}
+		}
+
 		impl $name {
 			const MAP: phf::Map<&'static str, $name> = phf::phf_map! {
 					$($variant_str => $name::$variant(<$crate::T![::]>::dummy(), <$crate::T![Ident]>::dummy()),)+
 			};
-		}
-
-		impl From<&$name> for css_lexer::Span {
-			fn from(value: &$name) -> Self {
-				match value {
-					$($name::$variant(a, b) => Into::<::css_lexer::Span>::into(a) + b.into(),)+
-				}
-			}
 		}
 	}
 }

--- a/crates/css_parse/src/parser_checkpoint.rs
+++ b/crates/css_parse/src/parser_checkpoint.rs
@@ -1,4 +1,4 @@
-use css_lexer::{Cursor, Kind, Span, Token};
+use css_lexer::{Cursor, Kind, Span, ToSpan, Token};
 
 /// Represents a point during the [Parser's][crate::Parser] lifecycle; retaining state that can then be rewound.
 ///
@@ -29,9 +29,9 @@ impl From<ParserCheckpoint> for Kind {
 	}
 }
 
-impl From<ParserCheckpoint> for Span {
-	fn from(value: ParserCheckpoint) -> Self {
-		value.cursor.span()
+impl ToSpan for ParserCheckpoint {
+	fn to_span(&self) -> Span {
+		self.cursor.span()
 	}
 }
 

--- a/crates/css_parse/src/syntax/at_rule.rs
+++ b/crates/css_parse/src/syntax/at_rule.rs
@@ -3,7 +3,7 @@ use crate::{
 	syntax::{Block, ComponentValues},
 };
 use css_lexer::KindSet;
-use csskit_derives::IntoSpan;
+use csskit_derives::ToSpan;
 
 /// This struct provides the generic [`<at-rule>` grammar][1]. It will [consume an at-rule][2]. This is defined as:
 ///
@@ -19,7 +19,7 @@ use csskit_derives::IntoSpan;
 ///
 /// [1]: https://drafts.csswg.org/css-syntax-3/#at-rule-diagram
 /// [2]: https://drafts.csswg.org/css-syntax-3/#consume-an-at-rule
-#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct AtRule<'a> {
 	pub name: T![AtKeyword],
@@ -54,7 +54,7 @@ impl ToCursors for AtRule<'_> {
 	}
 }
 
-#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum OptionalBlock<'a> {
 	Block(Block<'a>),

--- a/crates/css_parse/src/syntax/bad_declaration.rs
+++ b/crates/css_parse/src/syntax/bad_declaration.rs
@@ -1,6 +1,6 @@
 use crate::{CursorSink, Parse, Parser, Result as ParserResult, State, T, ToCursors, syntax::ComponentValue};
 use bumpalo::collections::Vec;
-use css_lexer::Span;
+use css_lexer::{Span, ToSpan};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -46,9 +46,9 @@ impl<'a> Parse<'a> for BadDeclaration<'a> {
 	}
 }
 
-impl<'a> From<&'a BadDeclaration<'a>> for Span {
-	fn from(value: &'a BadDeclaration<'a>) -> Self {
-		(&value.0).into()
+impl<'a> ToSpan for BadDeclaration<'a> {
+	fn to_span(&self) -> Span {
+		self.0.to_span()
 	}
 }
 

--- a/crates/css_parse/src/syntax/bang_important.rs
+++ b/crates/css_parse/src/syntax/bang_important.rs
@@ -1,6 +1,6 @@
 use crate::{CursorSink, Parse, Parser, Peek, Result, T, ToCursors, diagnostics};
-use css_lexer::{Cursor, Kind};
-use csskit_derives::IntoSpan;
+use css_lexer::{Cursor, Kind, ToSpan};
+use csskit_derives::ToSpan;
 
 /// Represents a two tokens, the first being [Kind::Delim] where the char is `!`, and the second being an `Ident` with
 /// the value `important`. [CSS defines this as]:
@@ -20,7 +20,7 @@ use csskit_derives::IntoSpan;
 ///
 /// [1]: https://drafts.csswg.org/css-syntax-3/#!important-diagram
 ///
-#[derive(IntoSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct BangImportant {
 	pub bang: T![!],
@@ -43,7 +43,7 @@ impl<'a> Parse<'a> for BangImportant {
 		let bang = p.parse::<T![!]>()?;
 		let important = p.parse::<T![Ident]>()?;
 		if !p.eq_ignore_ascii_case(important.into(), "important") {
-			Err(diagnostics::ExpectedIdentOf("important", p.parse_str(important.into()).into(), (&important).into()))?
+			Err(diagnostics::ExpectedIdentOf("important", p.parse_str(important.into()).into(), important.to_span()))?
 		}
 		Ok(Self { bang, important })
 	}

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -1,11 +1,11 @@
 use crate::{Block as BlockTrait, CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 use bumpalo::collections::Vec;
 use css_lexer::{Kind, KindSet};
-use csskit_derives::IntoSpan;
+use csskit_derives::ToSpan;
 
 use super::{Declaration, Rule};
 
-#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct Block<'a> {
 	pub open_curly: T!['{'],

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -3,12 +3,12 @@ use crate::{
 	syntax::{FunctionBlock, SimpleBlock},
 };
 use css_lexer::{Cursor, Kind, KindSet};
-use csskit_derives::IntoSpan;
+use csskit_derives::ToSpan;
 
 // https://drafts.csswg.org/css-syntax-3/#consume-component-value
 // A compatible "Token" per CSS grammar, subsetted to the tokens possibly
 // rendered by ComponentValue (so no pairwise, function tokens, etc).
-#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 pub enum ComponentValue<'a> {
 	SimpleBlock(SimpleBlock<'a>),

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -1,12 +1,12 @@
 use crate::{CursorSink, DeclarationValue, Parse, Parser, Peek, Result, ToCursors};
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
-use csskit_derives::IntoSpan;
+use csskit_derives::ToSpan;
 
 use super::ComponentValue;
 
 // https://drafts.csswg.org/css-syntax-3/#consume-list-of-components
-#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct ComponentValues<'a> {
 	values: Vec<'a, ComponentValue<'a>>,

--- a/crates/css_parse/src/syntax/function_block.rs
+++ b/crates/css_parse/src/syntax/function_block.rs
@@ -1,8 +1,8 @@
 use crate::{CursorSink, Parse, Parser, Result as ParserResult, T, ToCursors, syntax::ComponentValue};
 use bumpalo::collections::Vec;
-use csskit_derives::IntoSpan;
+use csskit_derives::ToSpan;
 
-#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct FunctionBlock<'a> {
 	pub name: T![Function],

--- a/crates/css_parse/src/syntax/qualified_rule.rs
+++ b/crates/css_parse/src/syntax/qualified_rule.rs
@@ -2,9 +2,9 @@ use crate::{
 	CursorSink, Parse, Parser, QualifiedRule as QualifiedRuleTrait, Result, ToCursors,
 	syntax::{BadDeclaration, Block, ComponentValues},
 };
-use csskit_derives::IntoSpan;
+use csskit_derives::ToSpan;
 
-#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct QualifiedRule<'a> {
 	pub prelude: ComponentValues<'a>,

--- a/crates/css_parse/src/syntax/rule.rs
+++ b/crates/css_parse/src/syntax/rule.rs
@@ -1,9 +1,9 @@
 use crate::{CursorSink, Parse, Parser, Result as ParserResult, T, ToCursors};
-use csskit_derives::IntoSpan;
+use csskit_derives::ToSpan;
 
 use super::{AtRule, QualifiedRule};
 
-#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub enum Rule<'a> {
 	AtRule(AtRule<'a>),

--- a/crates/css_parse/src/syntax/simple_block.rs
+++ b/crates/css_parse/src/syntax/simple_block.rs
@@ -1,8 +1,8 @@
 use crate::{CursorSink, Parse, Parser, Result as ParserResult, T, ToCursors, syntax::ComponentValues};
 use css_lexer::KindSet;
-use csskit_derives::IntoSpan;
+use csskit_derives::ToSpan;
 
-#[derive(IntoSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct SimpleBlock<'a> {
 	pub open: T![PairWiseStart],

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -1,4 +1,4 @@
-use css_lexer::{Cursor, DimensionUnit, Kind, KindSet, Span, Token};
+use css_lexer::{Cursor, DimensionUnit, Kind, KindSet, Span, ToSpan, Token};
 use csskit_derives::IntoCursor;
 
 use crate::{Build, CursorSink, Parse, Parser, Peek, Result, ToCursors, diagnostics};
@@ -246,9 +246,9 @@ macro_rules! custom_double_delim {
 			}
 		}
 
-		impl From<&$ident> for ::css_lexer::Span {
-			fn from(value: &$ident) -> Self {
-				Into::<::css_lexer::Span>::into(&value.0) + Into::<::css_lexer::Span>::into(&value.1)
+		impl ::css_lexer::ToSpan for $ident {
+			fn to_span(&self) -> ::css_lexer::Span {
+				self.0.to_span() + self.1.to_span()
 			}
 		}
 	};
@@ -332,9 +332,9 @@ macro_rules! keyword_set {
 			}
 		}
 
-		impl From<&$name> for css_lexer::Span {
-			fn from(value: &$name) -> Self {
-				match value {
+		impl ::css_lexer::ToSpan for $name {
+			fn to_span(&self) -> ::css_lexer::Span {
+				match self {
 					$($name::$variant(t) => (t.span()),)+
 				}
 			}
@@ -445,9 +445,9 @@ macro_rules! function_set {
 			}
 		}
 
-		impl From<&$name> for css_lexer::Span {
-			fn from(value: &$name) -> Self {
-				match value {
+		impl ::css_lexer::ToSpan for $name {
+			fn to_span(&self) -> ::css_lexer::Span {
+				match self {
 					$($name::$variant(t) => (t.span()),)+
 				}
 			}
@@ -533,9 +533,9 @@ macro_rules! atkeyword_set {
 			}
 		}
 
-		impl From<&$name> for css_lexer::Span {
-			fn from(value: &$name) -> Self {
-				match value {
+		impl ::css_lexer::ToSpan for $name {
+			fn to_span(&self) -> ::css_lexer::Span {
+				match self {
 					$($name::$variant(t) => (t.span()),)+
 				}
 			}
@@ -755,9 +755,9 @@ impl<'a> Build<'a> for DimensionIdent {
 	}
 }
 
-impl From<&DimensionIdent> for Span {
-	fn from(value: &DimensionIdent) -> Self {
-		Into::<Span>::into(&value.0)
+impl ToSpan for DimensionIdent {
+	fn to_span(&self) -> Span {
+		self.0.span()
 	}
 }
 
@@ -1038,9 +1038,9 @@ pub mod double {
 		}
 	}
 
-	impl From<&ColonColon> for Span {
-		fn from(value: &ColonColon) -> Self {
-			Into::<Span>::into(&value.0) + Into::<Span>::into(&value.1)
+	impl ::css_lexer::ToSpan for ColonColon {
+		fn to_span(&self) -> Span {
+			self.0.to_span() + self.1.to_span()
 		}
 	}
 }

--- a/crates/css_parse/src/traits/rules/at_rule.rs
+++ b/crates/css_parse/src/traits/rules/at_rule.rs
@@ -45,6 +45,7 @@ use css_lexer::{Cursor, KindSet};
 ///
 /// ```
 /// use css_parse::*;
+/// use css_lexer::*;
 ///
 /// /// A grammar like `@test foo {}`
 /// #[derive(Debug)]
@@ -60,7 +61,7 @@ use css_lexer::{Cursor, KindSet};
 ///     if let Some(prelude) = prelude {
 ///       Ok(Self { name, prelude, block })
 ///     } else {
-///       Err(diagnostics::MissingAtRulePrelude((&name).into()))?
+///       Err(diagnostics::MissingAtRulePrelude((&name).to_span()))?
 ///     }
 ///   }
 /// }

--- a/crates/css_parse/src/traits/rules/qualified_rule.rs
+++ b/crates/css_parse/src/traits/rules/qualified_rule.rs
@@ -1,5 +1,5 @@
 use crate::{Parse, Parser, Result, State, T, diagnostics};
-use css_lexer::{Kind, KindSet};
+use css_lexer::{Kind, KindSet, ToSpan};
 
 /// A QualifiedRule represents a block with a prelude which may contain other rules.
 /// Examples of QualifiedRules are StyleRule, KeyframeRule (no s!).
@@ -52,11 +52,11 @@ pub trait QualifiedRule<'a>: Sized + Parse<'a> {
 				if p.is(State::Nested) {
 					p.rewind(checkpoint);
 					p.parse::<Self::BadDeclaration>()?;
-					Err(diagnostics::BadDeclaration(checkpoint.into()))?
+					Err(diagnostics::BadDeclaration(checkpoint.to_span()))?
 				// If nested is false, consume a block from input, and return nothing.
 				} else {
 					Self::consume_block(p);
-					Err(diagnostics::BadDeclaration(checkpoint.into()))?
+					Err(diagnostics::BadDeclaration(checkpoint.to_span()))?
 				}
 			}
 			p.rewind(checkpoint);

--- a/crates/csskit_derives/src/into_cursor.rs
+++ b/crates/csskit_derives/src/into_cursor.rs
@@ -55,9 +55,9 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 		}
 
 		#[automatically_derived]
-		impl #impl_generics From<&#ident #impl_generics> for ::css_lexer::Span {
-			fn from(value: &#ident) -> ::css_lexer::Span {
-				Into::<::css_lexer::Cursor>::into(*value).into()
+		impl #impl_generics ::css_lexer::ToSpan for #ident #impl_generics {
+			fn to_span(&self) -> ::css_lexer::Span {
+				Into::<::css_lexer::Cursor>::into(*self).span()
 			}
 		}
 

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -4,10 +4,10 @@ use proc_macro2::Span;
 use syn::Error;
 
 mod into_cursor;
-mod into_span;
 mod parse;
 mod peek;
 mod to_cursors;
+mod to_span;
 
 #[proc_macro_derive(ToCursors, attributes(to_cursors))]
 pub fn derive_to_cursors(stream: TokenStream) -> TokenStream {
@@ -33,10 +33,10 @@ pub fn derive_into_cursor(stream: TokenStream) -> TokenStream {
 	into_cursor::derive(input).into()
 }
 
-#[proc_macro_derive(IntoSpan)]
+#[proc_macro_derive(ToSpan)]
 pub fn derive_into_span(stream: TokenStream) -> TokenStream {
 	let input = syn::parse(stream).unwrap();
-	into_span::derive(input).into()
+	to_span::derive(input).into()
 }
 
 fn err(span: Span, msg: &str) -> proc_macro2::TokenStream {

--- a/crates/csskit_derives/src/to_span.rs
+++ b/crates/csskit_derives/src/to_span.rs
@@ -23,18 +23,18 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	let generics = &mut input.generics.clone();
 	let (impl_generics, _, _) = generics.split_for_impl();
 	let body = match input.data {
-		Data::Union(_) => err(ident.span(), "Cannot derive Into<Span> on a Union"),
+		Data::Union(_) => err(ident.span(), "Cannot derive ToSpan on a Union"),
 
 		Data::Struct(DataStruct { fields, .. }) => {
 			let members: Vec<_> = fields.members().zip(fields.iter().map(|f| f.ty.is_option())).collect();
 			if members.len() == 1 {
 				let member = fields.members().next().unwrap();
-				quote! { (&value.#member).into() }
+				quote! { self.#member.to_span() }
 
 			// All members are Option<T>, so we have no choice but to try and add them all to get something useful.
 			} else if members.iter().all(|(_, is_option)| *is_option) {
 				let members = fields.members();
-				quote! { #(Into::<Span>::into(&value.#members))+* }
+				quote! { #(self.#members.to_span())+* }
 			} else {
 				// To get a reliable span we need to find the first member, and the last. However as some members are
 				// Optional<T>, and could potentially all be none, we need to find the first non-optional member to guarantee we can get a Span.
@@ -43,39 +43,39 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 					.take_while_inclusive(|(_, is_option)| *is_option)
 					.with_position()
 					.map(|(position, (member, _))| match position {
-						Position::Only => quote! { let first = Into::<Span>::into(&value.#member); },
+						Position::Only => quote! { let first = self.#member.to_span(); },
 						Position::First => quote! {
-							let first = if let Some(value) = value.#member {
-								Into::<Span>::into(&value)
+							let first = if let Some(ref value) = self.#member {
+								value.to_span()
 							}
 						},
 						Position::Middle => quote! {
-							else if let Some(value) = value.#member {
-								Into::<Span>::into(&value)
+							else if let Some(ref value) = self.#member {
+								value.to_span()
 							}
 						},
 						Position::Last => quote! {
 							else {
-								Into::<Span>::into(&value.#member)
+								self.#member.to_span()
 							};
 						},
 					})
 					.chain(members.iter().rev().take_while_inclusive(|(_, is_option)| *is_option).with_position().map(
 						|(position, (member, _))| match position {
-							Position::Only => quote! { first + (&value.#member).into() },
+							Position::Only => quote! { first + self.#member.to_span() },
 							Position::First => quote! {
-								let last = if let Some(ref value) = value.#member {
-									value.into()
+								let last = if let Some(ref value) = self.#member {
+									value.to_span()
 								}
 							},
 							Position::Middle => quote! {
-								else if let Some(ref value) = value.#member {
-									value.into()
+								else if let Some(ref value) = self.#member {
+									value.to_span()
 								}
 							},
 							Position::Last => quote! {
 								else {
-									(&value.#member).into()
+									self.#member.to_span()
 								};
 								first + last
 							},
@@ -92,17 +92,17 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 					let variant_ident = &variant.ident;
 					let len = variant.fields.len();
 					if len == 1 {
-						quote! { #ident::#variant_ident(val) => val.into(), }
+						quote! { #ident::#variant_ident(val) => val.to_span(), }
 					} else {
 						let rest = (2..len).map(|_| quote! { _ }).chain([quote! {last}]);
 						quote! {
-							#ident::#variant_ident(first, #(#rest),*) => Into::<Span>::into(first) + last.into(),
+							#ident::#variant_ident(first, #(#rest),*) => first.to_span() + last.to_span(),
 						}
 					}
 				})
 				.collect();
 			quote! {
-				match value {
+				match self {
 					#steps
 				}
 			}
@@ -110,9 +110,9 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	};
 	quote! {
 		#[automatically_derived]
-		impl #impl_generics From<&#ident #impl_generics> for ::css_lexer::Span {
-			fn from(value: &#ident) -> ::css_lexer::Span {
-				use ::css_lexer::Span;
+		impl #impl_generics ::css_lexer::ToSpan for #ident #impl_generics {
+			fn to_span(&self) -> ::css_lexer::Span {
+				use ::css_lexer::{Span, ToSpan};
 				#body
 			}
 		}

--- a/crates/csskit_highlight/src/css.rs
+++ b/crates/csskit_highlight/src/css.rs
@@ -2,13 +2,13 @@ use css_ast::{
 	Property, PropertyRule, PropertyRuleProperty, PropertyRuleStyleValue, PseudoClass, StyleDeclaration, StyleValue,
 	Tag, Visit,
 };
-use css_lexer::Span;
+use css_lexer::ToSpan;
 
 use crate::{SemanticKind, SemanticModifier, TokenHighlighter};
 
 impl<'a> Visit<'a> for TokenHighlighter {
 	fn visit_tag(&mut self, tag: &Tag) {
-		let span: Span = tag.into();
+		let span = tag.to_span();
 		let mut modifier = SemanticModifier::none();
 		match tag {
 			Tag::HtmlNonConforming(_) => {
@@ -31,7 +31,7 @@ impl<'a> Visit<'a> for TokenHighlighter {
 	}
 
 	fn visit_pseudo_class(&mut self, class: &PseudoClass) {
-		let span: Span = class.into();
+		let span = class.to_span();
 		let mut modifier = SemanticModifier::none();
 		match class {
 			PseudoClass::Webkit(_) | PseudoClass::Moz(_) | PseudoClass::O(_) | PseudoClass::Ms(_) => {
@@ -43,14 +43,14 @@ impl<'a> Visit<'a> for TokenHighlighter {
 	}
 
 	fn visit_style_declaration(&mut self, rule: &StyleDeclaration<'a>) {
-		self.insert((&rule.open).into(), SemanticKind::Punctuation, SemanticModifier::none());
+		self.insert(rule.open.to_span(), SemanticKind::Punctuation, SemanticModifier::none());
 		if let Some(close) = rule.close {
-			self.insert((&close).into(), SemanticKind::Punctuation, SemanticModifier::none());
+			self.insert(close.to_span(), SemanticKind::Punctuation, SemanticModifier::none());
 		}
 	}
 
 	fn visit_property(&mut self, property: &Property<'a>) {
-		let span: Span = (&property.name).into();
+		let span = property.name.to_span();
 		let mut modifier = SemanticModifier::none();
 		if matches!(&property.value, StyleValue::Unknown(_)) {
 			modifier |= SemanticModifier::Unknown;
@@ -59,16 +59,15 @@ impl<'a> Visit<'a> for TokenHighlighter {
 			modifier |= SemanticModifier::Custom;
 		}
 		self.insert(span, SemanticKind::Declaration, modifier);
-		self.insert((&property.colon).into(), SemanticKind::Punctuation, SemanticModifier::none());
+		self.insert(property.colon.to_span(), SemanticKind::Punctuation, SemanticModifier::none());
 	}
 
 	fn visit_property_rule(&mut self, property: &PropertyRule<'a>) {
-		let span: Span = (&property.name).into();
-		self.insert(span, SemanticKind::Declaration, SemanticModifier::Custom);
+		self.insert(property.name.to_span(), SemanticKind::Declaration, SemanticModifier::Custom);
 	}
 
 	fn visit_property_rule_property(&mut self, property: &PropertyRuleProperty<'a>) {
-		let span: Span = (&property.name).into();
+		let span = property.name.to_span();
 		let mut modifier = SemanticModifier::none();
 		if matches!(&property.value, PropertyRuleStyleValue::Unknown(_)) {
 			modifier |= SemanticModifier::Unknown;
@@ -77,6 +76,6 @@ impl<'a> Visit<'a> for TokenHighlighter {
 			modifier |= SemanticModifier::Custom;
 		}
 		self.insert(span, SemanticKind::Declaration, modifier);
-		self.insert((&property.colon).into(), SemanticKind::Punctuation, SemanticModifier::none());
+		self.insert(property.colon.to_span(), SemanticKind::Punctuation, SemanticModifier::none());
 	}
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Auto : "auto", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", Bar : "bar", Baz : "baz", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { None : "none", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { FitContent : "fit-content", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Normal : "normal", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { None : "none", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Auto : "auto", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Keyword : "keyword", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Keyword : "keyword", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { None : "none", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
@@ -7,7 +7,7 @@ expression: pretty
     "pink", }
 );
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Auto : "auto", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { LineThrough : "line-through", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
@@ -4,7 +4,7 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(FooKeywords { Foo : "foo", });
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
-    ::csskit_derives::IntoSpan,
+    ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     Debug,
     Clone,

--- a/crates/csskit_proc_macro/src/value.rs
+++ b/crates/csskit_proc_macro/src/value.rs
@@ -44,7 +44,7 @@ pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 		#keyword_def
 
 		#(#attrs)*
-		#[derive(::csskit_derives::IntoSpan, ::csskit_derives::ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::ToSpan, ::csskit_derives::ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		#def
 		#peek_impl


### PR DESCRIPTION
After running into some tricky recursion issues due to implementing From/Into Span, I realised this isn't the best way to create a trait an unilaterally apply it to a bunch of generics, due to - I think - From<T> for Span getting the blanker Into<Span> which can create a recursive relationship for things like `From<&Vec<T>> for Span where &T: Span` because `&T` could also be a `&Vec<T>`. After much trial and error it seems the way around this is just a custom trait, which has less automatic implementations and therefore subtly avoids these recursion issues.

Conveniently we already had a macro for this - Spanned - , because apparently we'd encountered issues before for `From<T> for Span` (in that it's sized so not dyn compatible). It didn't dawn upon me when implementing a bunch of `From<T> for Span` impls to use the thing right in front of my eyes, so I pressed on only to get bit by another issue with From.

This also changes the name of `Spanned` which could have a clearer name, so it's now `ToSpan` (akin to ToCursors). This also means a name change for the derive trait, hence the massive diff of renames. Other than the renaming, not too much has changed. One additional small refactoring here though, is using a macro for `ToSpan for (T, U...)` style tuples, so we can easily add more should we need them.

All this to say hopefully this will avoid recursion issues as we implement generic structs.