### PR TITLE
uncomment and clean up Position tests 

### DIFF
--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -307,7 +307,7 @@ mod tests {
 
 	#[test]
 	fn test_spans() {
-    // Parsing should stop at var()
+		// Parsing should stop at var()
 		assert_parse_span!(
 			Position,
 			r#"
@@ -315,7 +315,7 @@ mod tests {
 			^^^^^
 		"#
 		);
-    // Parsing should stop at four values:
+		// Parsing should stop at four values:
 		assert_parse_span!(
 			Position,
 			r#"

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -10,6 +10,25 @@
 /// ```
 /// use css_parse::*;
 /// assert_parse!(T![Ident], "foo");
+/// // Equivalent to:
+/// assert_parse!(T![Ident], "foo", "foo");
+/// ```
+///
+/// For more complex types (for example enum variants), you might want to assert that the given AST
+/// node matches an expected pattern (for example, one enum variant was chosen over another). In
+/// these cases, passing the match pattern as the third (or fourth) argument will assert that the
+/// parsed output struct matches the given pattern:
+///
+/// ```
+/// use css_parse::*;
+/// use csskit_derives::*;
+/// #[derive(Parse, ToCursors, Debug)]
+/// enum IdentOrNumber {
+///     Ident(T![Ident]),
+///     Number(T![Number]),
+/// }
+/// assert_parse!(IdentOrNumber, "foo", IdentOrNumber::Ident(_));
+/// assert_parse!(IdentOrNumber, "12", IdentOrNumber::Number(_));
 /// ```
 #[macro_export]
 macro_rules! assert_parse {

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -13,7 +13,7 @@
 /// ```
 #[macro_export]
 macro_rules! assert_parse {
-	($ty: ty, $str: literal, $str2: literal, $($ast: pat)*) => {
+	($ty: ty, $str: literal, $str2: literal, $($ast: pat)+) => {
 		let source_text = $str;
 		let expected = $str2;
 		let bump = ::bumpalo::Bump::default();
@@ -31,16 +31,23 @@ macro_rules! assert_parse {
 		if expected != actual {
 			panic!("\n\nParse failed: did not match expected format:\n\n   parser input: {:?}\n  parser output: {:?}\n       expected: {:?}\n", source_text, actual, expected);
 		}
-		$(assert!(matches!(result.output.unwrap(), $ast));)*
+		if !matches!(result.output, Some($($ast)|+)) {
+			panic!(
+        "\n\nParse succeeded but struct did not match given match pattern:\n\n           input: {:?}\n  match pattern: {}\n  parsed struct: {:#?}\n",
+        source_text,
+        stringify!($($ast)|+),
+        result.output.unwrap(),
+      );
+    }
 	};
 	($ty: ty, $str: literal) => {
-		assert_parse!($ty, $str, $str,);
+		assert_parse!($ty, $str, $str, _);
 	};
 	($ty: ty, $str: literal, $str2: literal) => {
-		assert_parse!($ty, $str, $str2,);
+		assert_parse!($ty, $str, $str2, _);
 	};
-	($ty: ty, $str: literal, $($ast: pat)*) => {
-		assert_parse!($ty, $str, $str, $($ast)*);
+	($ty: ty, $str: literal, $($ast: pat)+) => {
+		assert_parse!($ty, $str, $str, $($ast)+);
 	};
 }
 #[cfg(test)]

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -154,5 +154,3 @@ macro_rules! assert_parse_span {
 		}
 	};
 }
-#[cfg(test)]
-pub(crate) use assert_parse_span;


### PR DESCRIPTION
I noticed a bunch of `position` tests were left commented out. So I went to uncomment them, but I couldn't resist building on top of @maraisr's PR #184 which allows matching on the AST nodes, which is especially helpful for a complex type like `Position`. I added some small refinements on top (such as nicer error messages):

<img width="632" height="407" alt="Image" src="https://github.com/user-attachments/assets/8fdb2873-fea4-42c0-9b17-955ac1d32446" />

I also realised we're not really excercising or testing spans, or testing cases where the parser doesn't entirely parse, so I figured I'd also introduce `assert_parse_span`. This lets you write something nice and readable like:

```rs
assert_parse_span!(
	Position,
	r#"
	right var(--foo)
	^^^^^
"#
);
```

and it'll figure out the `^^^^^` bit by re-creating it based on the span data, and checking that the string is right. This means if the span data is wrong, or you put the `^^^^`s in the wrong place, you get an error like:

<img width="623" height="281" alt="Image" src="https://github.com/user-attachments/assets/e3c82614-7e86-4736-848f-9a399ea08eba" />