### PR TITLE
add cargo clippy to test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,15 +49,31 @@ jobs:
           git config --global core.eol lf
       - uses: actions/checkout@v4
         with:
-          submodules: 'true'
+          submodules: "true"
       - run: rustup target add ${{ matrix.target }}
       - name: Cache
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: release-${{ matrix.target }}
       - run: cargo test --all-features
-      - run: cargo fmt --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        # Ensure clippy is happy with us
       - run: RUSTFLAGS="-Dwarnings" cargo clippy
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        # Ensure that everything is nicely formatted
+      - run: cargo fmt --check
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
           shared-key: release-${{ matrix.target }}
       - run: cargo test --all-features
       - run: cargo fmt --check
+      - run: RUSTFLAGS="-Dwarnings" cargo clippy
 
   docs:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,29 +352,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,7 +408,7 @@ dependencies = [
  "bitmask-enum",
  "bumpalo",
  "console 0.16.0",
- "criterion 0.6.0",
+ "criterion",
  "css_lexer",
  "css_parse",
  "csskit_derives",
@@ -457,7 +434,7 @@ dependencies = [
  "bitmask-enum",
  "bumpalo",
  "console 0.16.0",
- "criterion 0.6.0",
+ "criterion",
  "glob",
  "insta",
  "miette",
@@ -533,7 +510,7 @@ dependencies = [
  "bitmask-enum",
  "bumpalo",
  "console 0.16.0",
- "criterion 0.6.0",
+ "criterion",
  "crossbeam-channel",
  "css_ast",
  "css_lexer",
@@ -575,7 +552,7 @@ name = "csskit_transform"
 version = "0.0.0"
 dependencies = [
  "bumpalo",
- "criterion 0.6.0",
+ "criterion",
  "css_ast",
  "css_parse",
  "glob",
@@ -890,15 +867,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1206,7 +1174,7 @@ dependencies = [
  "aligned-vec",
  "backtrace",
  "cfg-if",
- "criterion 0.5.1",
+ "criterion",
  "findshlibs",
  "inferno",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = { version = "1.0.140" }
 
 # Testing, benchmarking
 similar = { version = "2.7.0" }
-criterion = { version = "0.6.0" }
+criterion = { version = "0.5.1" } # Help back for pprof (https://github.com/tikv/pprof-rs/pull/271)
 pprof = { version = "0.15.0" }
 flate2 = { version = "1.1.2" }
 insta = { version = "1.43.1" }

--- a/crates/css_ast/build.rs
+++ b/crates/css_ast/build.rs
@@ -108,7 +108,7 @@ fn main() {
 	let mut searcher = SearcherBuilder::new().line_number(false).multi_line(true).build();
 	for entry in glob("src/**/*.rs").unwrap() {
 		let str = &entry.as_ref().unwrap().display();
-		println!("cargo::rerun-if-changed={}", str);
+		println!("cargo::rerun-if-changed={str}");
 		let context = NodeMatcher {
 			matcher: &matcher,
 			visit_matches: &mut visit_matches,
@@ -124,7 +124,7 @@ fn main() {
 		}}",
 		visit_matches.iter().fold(String::new(), |mut out, prop| {
 			let variant_name = prop.trim_end_matches("<'a>");
-			writeln!(out, "\t\t\t\t\t{},", variant_name).unwrap();
+			writeln!(out, "\t\t\t\t\t{variant_name},").unwrap();
 			out
 		})
 	);
@@ -155,9 +155,9 @@ fn main() {
 			let variant_name = prop.trim_end_matches("<'a>").trim_end_matches("StyleValue").to_string();
 			let mut variant_str = kebab(variant_name.to_owned());
 			if variant_str.starts_with("webkit") {
-				variant_str = format!("-{}", variant_str);
+				variant_str = format!("-{variant_str}");
 			}
-			writeln!(out, "\t\t\t\t\t{}: {} = \"{}\",", variant_name, prop, variant_str).unwrap();
+			writeln!(out, "\t\t\t\t\t{variant_name}: {prop} = \"{variant_str}\",").unwrap();
 			out
 		})
 	);

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -177,6 +177,7 @@ impl<'a> Visitable<'a> for ContainerQuery<'a> {
 
 macro_rules! container_feature {
 	( $($name: ident($typ: ident): $str: tt,)+ ) => {
+		#[allow(clippy::large_enum_variant)] // TODO: refine
 		#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		pub enum ContainerFeature<'a> {

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -61,7 +61,7 @@ impl<'a> Parse<'a> for KeyframesName {
 		let ident = p.parse::<T![Ident]>()?;
 		let c: Cursor = ident.into();
 		let str = p.parse_str(c);
-		if !KeyframesName::valid_ident(&str) {
+		if !KeyframesName::valid_ident(str) {
 			Err(diagnostics::ReservedKeyframeName(str.into(), c.into()))?
 		}
 		Ok(Self::Ident(ident))

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -153,6 +153,7 @@ impl<'a> Visitable<'a> for SupportsCondition<'a> {
 	}
 }
 
+#[allow(clippy::large_enum_variant)] // TODO: Box?
 #[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum SupportsFeature<'a> {

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -64,7 +64,7 @@ impl<'a> Parse<'a> for SelectorList<'a> {
 
 impl<'a> Visitable<'a> for SelectorList<'a> {
 	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_selector_list(&self);
+		v.visit_selector_list(self);
 		for (selector, _) in &self.0 {
 			Visitable::accept(selector, v);
 		}
@@ -88,7 +88,7 @@ impl<'a> Parse<'a> for CompoundSelector<'a> {
 
 impl<'a> Visitable<'a> for CompoundSelector<'a> {
 	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_compound_selector(&self);
+		v.visit_compound_selector(self);
 		for component in &self.0 {
 			Visitable::accept(component, v);
 		}

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -103,6 +103,7 @@ macro_rules! nested_group_rule {
     ( $(
         $name: ident$(<$a: lifetime>)?: $str: pat,
     )+ ) => {
+		#[allow(clippy::large_enum_variant)] // TODO: Box?
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
 		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -111,6 +111,7 @@ macro_rules! rule {
     ( $(
         $name: ident$(<$a: lifetime>)?: $str: pat,
     )+ ) => {
+		#[allow(clippy::large_enum_variant)] // TODO: Box?
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
 		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]

--- a/crates/css_ast/src/types/animateable_feature.rs
+++ b/crates/css_ast/src/types/animateable_feature.rs
@@ -95,7 +95,7 @@ impl AnimateableFeature {
 impl<'a> Build<'a> for AnimateableFeature {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		let ident = <T![Ident]>::build(p, c);
-		let feature = Self::MAP.get(&p.parse_str_lower(c));
+		let feature = Self::MAP.get(p.parse_str_lower(c));
 		match feature {
 			Some(Self::WebkitBackdropFilter(_)) => Self::WebkitBackdropFilter(ident),
 			Some(Self::WebkitBoxReflect(_)) => Self::WebkitBoxReflect(ident),

--- a/crates/css_ast/src/types/attr.rs
+++ b/crates/css_ast/src/types/attr.rs
@@ -115,7 +115,7 @@ impl<'a> Parse<'a> for AttrType {
 			return Ok(Self::RawString(raw));
 		}
 
-		return Ok(Self::Unit(p.parse::<T![DimensionIdent]>()?));
+		Ok(Self::Unit(p.parse::<T![DimensionIdent]>()?))
 	}
 }
 

--- a/crates/css_ast/src/types/color/color_function.rs
+++ b/crates/css_ast/src/types/color/color_function.rs
@@ -217,6 +217,8 @@ impl<'a> Peek<'a> for ColorFunction {
 }
 
 impl<'a> ColorFunction {
+
+	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_rgb(
 		p: &mut Parser<'a>,
 	) -> ParserResult<(
@@ -240,6 +242,7 @@ impl<'a> ColorFunction {
 		Ok((a, b, c, d, e, f, g, h))
 	}
 
+	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_hsl(
 		p: &mut Parser<'a>,
 	) -> ParserResult<(
@@ -263,6 +266,7 @@ impl<'a> ColorFunction {
 		Ok((a, b, c, d, e, f, g, h))
 	}
 
+	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_hwb(p: &mut Parser<'a>) -> ParserResult<(Hue, Channel, Channel, Option<T![/]>, Option<Channel>)> {
 		let a = p.parse::<Hue>()?;
 		let b = p.parse::<Channel>()?;
@@ -272,6 +276,7 @@ impl<'a> ColorFunction {
 		Ok((a, b, c, d, e))
 	}
 
+	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_lch(p: &mut Parser<'a>) -> ParserResult<(Channel, Channel, Hue, Option<T![/]>, Option<Channel>)> {
 		let a = p.parse::<Channel>()?;
 		let b = p.parse::<Channel>()?;
@@ -281,6 +286,7 @@ impl<'a> ColorFunction {
 		Ok((a, b, c, d, e))
 	}
 
+	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_three_channel(
 		p: &mut Parser<'a>,
 	) -> ParserResult<(Channel, Channel, Channel, Option<T![/]>, Option<Channel>)> {

--- a/crates/css_ast/src/types/color/color_function.rs
+++ b/crates/css_ast/src/types/color/color_function.rs
@@ -217,7 +217,6 @@ impl<'a> Peek<'a> for ColorFunction {
 }
 
 impl<'a> ColorFunction {
-
 	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_rgb(
 		p: &mut Parser<'a>,

--- a/crates/css_ast/src/types/easing_function.rs
+++ b/crates/css_ast/src/types/easing_function.rs
@@ -45,6 +45,7 @@ keyword_set!(StepPosition {
 // steps() = steps( <integer>, <step-position>?)
 //
 // <step-position> = jump-start | jump-end | jump-none | jump-both | start | end
+#[allow(clippy::type_complexity)] // TODO: simplify types
 #[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum EasingFunction<'a> {

--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -24,7 +24,7 @@ impl<'a> Peek<'a> for Image<'a> {
 impl<'a> Parse<'a> for Image<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		if p.peek::<T![Url]>() {
-			return Ok(Self::Url(p.parse::<T![Url]>()?));
+			Ok(Self::Url(p.parse::<T![Url]>()?))
 		} else if p.peek::<Gradient>() {
 			return Ok(Self::Gradient(p.parse::<Gradient>()?));
 		} else {

--- a/crates/css_ast/src/types/image_1d.rs
+++ b/crates/css_ast/src/types/image_1d.rs
@@ -63,7 +63,7 @@ impl<'a> Parse<'a> for ColorStripe {
 	}
 }
 
-impl<'a> ToCursors for ColorStripe {
+impl ToCursors for ColorStripe {
 	fn to_cursors(&self, s: &mut impl css_parse::CursorSink) {
 		ToCursors::to_cursors(&self.color, s);
 		if let Some(thickness) = self.thickness {

--- a/crates/css_ast/src/types/snap_inline.rs
+++ b/crates/css_ast/src/types/snap_inline.rs
@@ -26,7 +26,7 @@ impl<'a> Parse<'a> for SnapInline {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		let function = p.parse::<T![Function]>()?;
 		let c: Cursor = function.into();
-		if !p.eq_ignore_ascii_case(c.into(), "snap-inline") {
+		if !p.eq_ignore_ascii_case(c, "snap-inline") {
 			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c.into()))?
 		}
 		let length = p.parse::<LengthPercentage>()?;

--- a/crates/css_lexer/src/comment_style.rs
+++ b/crates/css_lexer/src/comment_style.rs
@@ -16,17 +16,17 @@
 /// use css_lexer::*;
 /// let mut lexer = Lexer::new("/* Normal Comment */  /** Double Star Comment */");
 /// {
-///		// This token will be collapsed Whitespace.
-///		let token = lexer.advance();
-///		assert_eq!(token, Kind::Comment);
-///		assert_eq!(token, CommentStyle::Block);
+///     // This token will be collapsed Whitespace.
+///     let token = lexer.advance();
+///     assert_eq!(token, Kind::Comment);
+///     assert_eq!(token, CommentStyle::Block);
 /// }
 /// assert_eq!(lexer.advance(), Kind::Whitespace);
 /// {
-///		// This token will be collapsed Whitespace.
-///		let token = lexer.advance();
-///		assert_eq!(token, Kind::Comment);
-///		assert_eq!(token, CommentStyle::BlockStar);
+///     // This token will be collapsed Whitespace.
+///     let token = lexer.advance();
+///     assert_eq!(token, Kind::Comment);
+///     assert_eq!(token, CommentStyle::BlockStar);
 /// }
 /// ```
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_lexer/src/dimension_unit.rs
+++ b/crates/css_lexer/src/dimension_unit.rs
@@ -16,12 +16,12 @@ use std::hash::Hash;
 /// use css_lexer::*;
 /// let mut lexer = Lexer::new("10px");
 /// {
-///		let token = lexer.advance();
-///		assert_eq!(token, Kind::Dimension);
-///		assert_eq!(token, DimensionUnit::Px);
-///		let unit = token.dimension_unit();
-///		let str: &'static str = unit.into();
-///		assert_eq!(str, "px");
+///     let token = lexer.advance();
+///     assert_eq!(token, Kind::Dimension);
+///     assert_eq!(token, DimensionUnit::Px);
+///     let unit = token.dimension_unit();
+///     let str: &'static str = unit.into();
+///     assert_eq!(str, "px");
 /// }
 /// ```
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]

--- a/crates/css_lexer/src/lib.rs
+++ b/crates/css_lexer/src/lib.rs
@@ -22,17 +22,17 @@
 //! for completeness:
 //!
 //! - Documents are limited to ~4gb in size. [SourceOffset] is a [u32] so cannot represent larger offsets. Attempting to
-//! lex larger documents is considrered [undefined behaviour][2].
+//!   lex larger documents is considrered [undefined behaviour][2].
 //!
 //! - [Tokens][Token] are limited to ~4gb in length. A [Token's][Token] is a [u32] so cannot represent larger lengths.
-//! If the lexer encounters a token with  larger length this is considered [undefined behaviour][2].
+//!   If the lexer encounters a token with  larger length this is considered [undefined behaviour][2].
 //!
 //! - Number [Tokens][Token] are limited to 16,777,216 characters in length. For example encountering a number with
-//! 17MM `0`s is considered [undefined behaviour][2]. This is not the same as the number value, which is an [f32].
-//! (Please note that the CSS spec dictates numbers are f32, CSS does not have larger numbers).
+//!   17MM `0`s is considered [undefined behaviour][2]. This is not the same as the number value, which is an [f32].
+//!   (Please note that the CSS spec dictates numbers are f32, CSS does not have larger numbers).
 //!
 //! - Dimension [Tokens][Token] are limited to 4,096 numeric characters in length and 4,096 ident characters in length.
-//! For example encountering a dimension with 4,097 `0`s is considered [undefined behaviour][2].
+//!   For example encountering a dimension with 4,097 `0`s is considered [undefined behaviour][2].
 //!
 //! # General usage
 //!
@@ -50,24 +50,24 @@
 //! let mut lexer = Lexer::new("width: 1px");
 //! assert_eq!(lexer.offset(), 0);
 //! {
-//! 	let token = lexer.advance();
-//! 	assert_eq!(token, Kind::Ident);
-//! 	let cursor = token.with_cursor(SourceOffset(0));
-//! 	assert_eq!(cursor.str_slice(lexer.source()), "width");
+//!     let token = lexer.advance();
+//!     assert_eq!(token, Kind::Ident);
+//!     let cursor = token.with_cursor(SourceOffset(0));
+//!     assert_eq!(cursor.str_slice(lexer.source()), "width");
 //! }
 //! {
-//! 	let token = lexer.advance();
-//! 	assert_eq!(token, Kind::Colon);
-//! 	assert_eq!(token, ':');
+//!     let token = lexer.advance();
+//!     assert_eq!(token, Kind::Colon);
+//!     assert_eq!(token, ':');
 //! }
 //! {
-//! 	let token = lexer.advance();
-//! 	assert_eq!(token, Kind::Whitespace);
+//!     let token = lexer.advance();
+//!     assert_eq!(token, Kind::Whitespace);
 //! }
 //! {
-//! 	let token = lexer.advance();
-//! 	assert_eq!(token, Kind::Dimension);
-//! 	assert_eq!(token.dimension_unit(), DimensionUnit::Px);
+//!     let token = lexer.advance();
+//!     assert_eq!(token, Kind::Dimension);
+//!     assert_eq!(token.dimension_unit(), DimensionUnit::Px);
 //! }
 //! ```
 //!
@@ -124,17 +124,17 @@ pub use whitespace_style::Whitespace;
 /// [Cursor] small.
 ///
 /// - Documents are limited to ~4gb in size. [SourceOffset] is a [u32] so cannot represent larger offsets. Attempting to
-/// lex larger documents is considrered [undefined behaviour][2].
+///   lex larger documents is considrered [undefined behaviour][2].
 ///
 /// - [Tokens][Token] are limited to ~4gb in length. A [Token's][Token] is a [u32] so cannot represent larger lengths.
-/// If the lexer encounters a token with  larger length this is considered [undefined behaviour][2].
+///   If the lexer encounters a token with  larger length this is considered [undefined behaviour][2].
 ///
 /// - Number [Tokens][Token] are limited to 16,777,216 characters in length. For example encountering a number with
-/// 17MM `0`s is considered [undefined behaviour][2]. This is not the same as the number value, which is an [f32].
-/// (Please note that the CSS spec dictates numbers are f32, CSS does not have larger numbers).
+///   17MM `0`s is considered [undefined behaviour][2]. This is not the same as the number value, which is an [f32].
+///   (Please note that the CSS spec dictates numbers are f32, CSS does not have larger numbers).
 ///
 /// - Dimension [Tokens][Token] are limited to 4,096 numeric characters in length and 4,096 ident characters in length.
-/// For example encountering a dimension with 4,097 `0` is considered [undefined behaviour][2].
+///   For example encountering a dimension with 4,097 `0` is considered [undefined behaviour][2].
 ///
 /// # General usage
 ///
@@ -152,24 +152,24 @@ pub use whitespace_style::Whitespace;
 /// let mut lexer = Lexer::new("width: 1px");
 /// assert_eq!(lexer.offset(), 0);
 /// {
-/// 	let token = lexer.advance();
-/// 	assert_eq!(token, Kind::Ident);
-/// 	let cursor = token.with_cursor(SourceOffset(0));
-/// 	assert_eq!(cursor.str_slice(lexer.source()), "width");
+///     let token = lexer.advance();
+///     assert_eq!(token, Kind::Ident);
+///     let cursor = token.with_cursor(SourceOffset(0));
+///     assert_eq!(cursor.str_slice(lexer.source()), "width");
 /// }
 /// {
-/// 	let token = lexer.advance();
-/// 	assert_eq!(token, Kind::Colon);
-/// 	assert_eq!(token, ':');
+///     let token = lexer.advance();
+///     assert_eq!(token, Kind::Colon);
+///     assert_eq!(token, ':');
 /// }
 /// {
-/// 	let token = lexer.advance();
-/// 	assert_eq!(token, Kind::Whitespace);
+///     let token = lexer.advance();
+///     assert_eq!(token, Kind::Whitespace);
 /// }
 /// {
-/// 	let token = lexer.advance();
-/// 	assert_eq!(token, Kind::Dimension);
-/// 	assert_eq!(token.dimension_unit(), DimensionUnit::Px);
+///     let token = lexer.advance();
+///     assert_eq!(token, Kind::Dimension);
+///     assert_eq!(token.dimension_unit(), DimensionUnit::Px);
 /// }
 /// ```
 ///

--- a/crates/css_lexer/src/pairwise.rs
+++ b/crates/css_lexer/src/pairwise.rs
@@ -16,18 +16,18 @@ use crate::{Kind, Token};
 /// use css_lexer::*;
 /// let mut lexer = Lexer::new("(a)");
 /// {
-///		let token = lexer.advance();
-///		assert_eq!(token, PairWise::Paren);
-///		assert_eq!(token, Kind::LeftParen);
-///		let pair: PairWise = token.to_pairwise().unwrap();
-///		let mut close_token;
-///		loop {
-///			close_token = lexer.advance();
-///			if close_token == pair {
-///				break;
-///			}
-///		}
-///		assert_eq!(close_token, Kind::RightParen);
+///     let token = lexer.advance();
+///     assert_eq!(token, PairWise::Paren);
+///     assert_eq!(token, Kind::LeftParen);
+///     let pair: PairWise = token.to_pairwise().unwrap();
+///     let mut close_token;
+///     loop {
+///         close_token = lexer.advance();
+///         if close_token == pair {
+///             break;
+///         }
+///     }
+///     assert_eq!(close_token, Kind::RightParen);
 /// }
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_lexer/src/quote_style.rs
+++ b/crates/css_lexer/src/quote_style.rs
@@ -9,17 +9,17 @@ use core::fmt;
 /// use css_lexer::*;
 /// let mut lexer = Lexer::new("/* Normal Comment */  /** Double Star Comment */");
 /// {
-///		// This token will be collapsed Whitespace.
-///		let token = lexer.advance();
-///		assert_eq!(token, Kind::Comment);
-///		assert_eq!(token, CommentStyle::Block);
+///     // This token will be collapsed Whitespace.
+///     let token = lexer.advance();
+///     assert_eq!(token, Kind::Comment);
+///     assert_eq!(token, CommentStyle::Block);
 /// }
 /// assert_eq!(lexer.advance(), Kind::Whitespace);
 /// {
-///		// This token will be collapsed Whitespace.
-///		let token = lexer.advance();
-///		assert_eq!(token, Kind::Comment);
-///		assert_eq!(token, CommentStyle::BlockStar);
+///     // This token will be collapsed Whitespace.
+///     let token = lexer.advance();
+///     assert_eq!(token, Kind::Comment);
+///     assert_eq!(token, CommentStyle::BlockStar);
 /// }
 /// ```
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_lexer/src/token.rs
+++ b/crates/css_lexer/src/token.rs
@@ -90,18 +90,18 @@ use crate::{
 /// | [Kind::Comment]    | `---` | (Special)                   | [Token::comment_style()][^comments]      |
 /// | [Kind::Delim]      | `---` | (Special)                   | Stores the char length[^delim]           |
 ///
-///	[^dimension]: Dimensions do not have a [bool] returning method for whether or not the dimension is known, instead
-///	[Token::dimension_unit()] `==` [DimensionUnit::Unknown] can be consulted.
-///	[^quotes]: Strings do not have a [bool] returning method for whether or not the quote is using double or single
-///	quotes, instead the [Token::quote_style()] method will returning the [QuoteStyle] enum for better readability.
-///	[^whitespace]: Whitespace tokens to not have a [bool] returning method, instead [Token::whitespace_style()] will return
-///	the [Whitespace] enum for improved readability.
-///	[^comments]: Rather than using the 3 bits as a bit-mask, Comment tokens use the data to store the [CommentStyle]
-///	enum, which is capable of representing 8 discrete comment styles.
-///	[^delim]: Delims do not store additional "facts" about the character (as the character is stored in the token
-///	itself and so can be fully reasoned about). Instead the `TF` space is used to store the length of the character in
-///	source. This is due to a featute of the CSS syntax which dictates that the rendered character may differ from the
-///	encoded delim; as `\0` and surrogates are replaced with `\u{FFFD}`.
+/// [^dimension]: Dimensions do not have a [bool] returning method for whether or not the dimension is known, instead
+/// [Token::dimension_unit()] `==` [DimensionUnit::Unknown] can be consulted.
+/// [^quotes]: Strings do not have a [bool] returning method for whether or not the quote is using double or single
+/// quotes, instead the [Token::quote_style()] method will returning the [QuoteStyle] enum for better readability.
+/// [^whitespace]: Whitespace tokens to not have a [bool] returning method, instead [Token::whitespace_style()] will return
+/// the [Whitespace] enum for improved readability.
+/// [^comments]: Rather than using the 3 bits as a bit-mask, Comment tokens use the data to store the [CommentStyle]
+/// enum, which is capable of representing 8 discrete comment styles.
+/// [^delim]: Delims do not store additional "facts" about the character (as the character is stored in the token
+/// itself and so can be fully reasoned about). Instead the `TF` space is used to store the length of the character in
+/// source. This is due to a featute of the CSS syntax which dictates that the rendered character may differ from the
+/// encoded delim; as `\0` and surrogates are replaced with `\u{FFFD}`.
 ///
 /// ## K = Kind Bits
 ///

--- a/crates/css_lexer/src/whitespace_style.rs
+++ b/crates/css_lexer/src/whitespace_style.rs
@@ -38,7 +38,7 @@ impl Whitespace {
 		Self { bits: bits & 0b111 }
 	}
 
-	pub(crate) const fn to_bits(&self) -> u8 {
+	pub(crate) const fn to_bits(self) -> u8 {
 		self.bits
 	}
 }

--- a/crates/css_lexer/tests/css-tokenizer-tests.rs
+++ b/crates/css_lexer/tests/css-tokenizer-tests.rs
@@ -251,5 +251,5 @@ fn full_suite() {
 	for case in cases {
 		fails += test_case(case);
 	}
-	assert_eq!(fails, 0, "Should have zero failures but {} tests failed", fails);
+	assert_eq!(fails, 0, "Should have zero failures but {fails} tests failed");
 }

--- a/crates/css_parse/src/comparison.rs
+++ b/crates/css_parse/src/comparison.rs
@@ -50,7 +50,7 @@ impl<'a> Parse<'a> for Comparison {
 	}
 }
 
-impl<'a> ToCursors for Comparison {
+impl ToCursors for Comparison {
 	fn to_cursors(&self, s: &mut impl crate::CursorSink) {
 		match self {
 			Self::LessThan(c) => ToCursors::to_cursors(c, s),

--- a/crates/css_parse/src/parser.rs
+++ b/crates/css_parse/src/parser.rs
@@ -274,7 +274,7 @@ impl<'a> Parser<'a> {
 
 		#[cfg(debug_assertions)]
 		if let Some(last_cursor) = self.last_cursor {
-			debug_assert!(last_cursor != c, "Detected a next loop, {:?} was fetched twice", c);
+			debug_assert!(last_cursor != c, "Detected a next loop, {c:?} was fetched twice");
 		}
 		#[cfg(debug_assertions)]
 		if c == css_lexer::Kind::Eof {

--- a/crates/css_parse/src/parser.rs
+++ b/crates/css_parse/src/parser.rs
@@ -260,6 +260,7 @@ impl<'a> Parser<'a> {
 		}
 	}
 
+	#[allow(clippy::should_implement_trait)]
 	pub fn next(&mut self) -> Cursor {
 		let mut c;
 		let mut offset;

--- a/crates/css_parse/src/syntax/bad_declaration.rs
+++ b/crates/css_parse/src/syntax/bad_declaration.rs
@@ -9,7 +9,7 @@ pub struct BadDeclaration<'a>(Vec<'a, ComponentValue<'a>>);
 // https://drafts.csswg.org/css-syntax-3/#consume-the-remnants-of-a-bad-declaration
 impl<'a> Parse<'a> for BadDeclaration<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let mut values = Vec::new_in(&p.bump());
+		let mut values = Vec::new_in(p.bump());
 		// To consume the remnants of a bad declaration from a token stream input, given a bool nested:
 		//
 		// Process input:

--- a/crates/css_parse/src/syntax/bang_important.rs
+++ b/crates/css_parse/src/syntax/bang_important.rs
@@ -49,7 +49,7 @@ impl<'a> Parse<'a> for BangImportant {
 	}
 }
 
-impl<'a> ToCursors for BangImportant {
+impl ToCursors for BangImportant {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		s.append(self.bang.into());
 		s.append(self.important.into());

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -50,6 +50,7 @@ macro_rules! assert_parse {
 		if expected != actual {
 			panic!("\n\nParse failed: did not match expected format:\n\n   parser input: {:?}\n  parser output: {:?}\n       expected: {:?}\n", source_text, actual, expected);
 		}
+		#[allow(clippy::redundant_pattern_matching)] // Avoid .clone().unwrap()
 		if !matches!(result.output, Some($($ast)|+)) {
 			panic!(
         "\n\nParse succeeded but struct did not match given match pattern:\n\n           input: {:?}\n  match pattern: {}\n  parsed struct: {:#?}\n",
@@ -113,9 +114,9 @@ pub(crate) use assert_parse_error;
 /// ```
 /// use css_parse::*;
 /// assert_parse_span!(T![Ident], r#"
-///	 an_ident another_ident
-///	 ^^^^^^^^
-///	"#);
+///     an_ident another_ident
+///     ^^^^^^^^
+/// "#);
 /// ```
 #[macro_export]
 macro_rules! assert_parse_span {

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -709,10 +709,10 @@ impl From<Dimension> for f32 {
 	}
 }
 
-impl Into<(f32, DimensionUnit)> for Dimension {
-	fn into(self) -> (f32, DimensionUnit) {
-		let value = self.0.token().value();
-		let unit = self.0.token().dimension_unit();
+impl From<Dimension> for (f32, DimensionUnit) {
+	fn from(val: Dimension) -> Self {
+		let value = val.0.token().value();
+		let unit = val.0.token().dimension_unit();
 		(value, unit)
 	}
 }
@@ -738,7 +738,7 @@ pub struct DimensionIdent(Cursor, css_lexer::DimensionUnit);
 
 impl ToCursors for DimensionIdent {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
-		s.append((*self).0.into());
+		s.append(self.0);
 	}
 }
 

--- a/crates/css_parse/src/traits/block.rs
+++ b/crates/css_parse/src/traits/block.rs
@@ -7,7 +7,7 @@ use super::Peek;
 ///
 /// ```md
 /// <block>
-///          
+///
 ///  │├─ "{" ─╭──╮─╭─ <ws-*> ─╮─╭─╮─╭─ ";" ─╮─╭─╮─ <rule> ────────╭─╮─ "}" ─┤│
 ///           │  │ ╰──────────╯ │ │ ╰───────╯ │ ├─ <declaration> ─┤ │
 ///           │  ╰──────────────╯ ╰───────────╯ ╰─────────────────╯ │
@@ -19,6 +19,7 @@ pub trait Block<'a>: Sized + Parse<'a> {
 	type Declaration: Peek<'a> + Parse<'a>;
 	type Rule: Parse<'a>;
 
+	#[allow(clippy::type_complexity)] // TODO: simplify return
 	fn parse_block(
 		p: &mut Parser<'a>,
 	) -> Result<(T!['{'], Vec<'a, (Self::Declaration, Option<T![;]>)>, Vec<'a, Self::Rule>, Option<T!['}']>)> {

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -59,7 +59,7 @@ pub trait BooleanFeature<'a>: Sized {
 			let colon = p.parse::<T![:]>()?;
 			let value = p.parse::<T![Any]>()?;
 			let close = p.parse::<T![')']>()?;
-			return Ok((open, ident, Some((colon, value)), close));
+			Ok((open, ident, Some((colon, value)), close))
 		} else {
 			let close = p.parse::<T![')']>()?;
 			Ok((open, ident, None, close))

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -6,11 +6,11 @@ use crate::{Parser, Result, T, diagnostics};
 /// complementary to the other media features: [RangedFeature][crate::RangedFeature] and
 /// [DiscreteFeature][crate::DiscreteFeature].
 ///
-///	[1]: https://drafts.csswg.org/mediaqueries/#boolean-context
+/// [1]: https://drafts.csswg.org/mediaqueries/#boolean-context
 ///
-///	Rather than implementing this trait on an enum, use the [boolean_feature!][crate::boolean_feature] macro which
-///	expands to define the enum and necessary traits ([Parse][crate::Parse], this trait, and
-///	[ToCursors][crate::ToCursors]) in a single macro call.
+/// Rather than implementing this trait on an enum, use the [boolean_feature!][crate::boolean_feature] macro which
+/// expands to define the enum and necessary traits ([Parse][crate::Parse], this trait, and
+/// [ToCursors][crate::ToCursors]) in a single macro call.
 ///
 /// It does not implement [Parse][crate::Parse], but provides
 /// `parse_boolean_feature(&mut Parser<'a>, name: &str) -> Result<Self>`, which can make for a trivial
@@ -33,7 +33,7 @@ use crate::{Parser, Result, T, diagnostics};
 ///
 /// - Can omit the the `:` and `<value>`.
 /// - Must allow any token as the `<value>`, but the `<dimension>` of `0`, `<number>` of `0` and `<ident>` of `none`
-/// will mean the query evaluates to false.
+///   will mean the query evaluates to false.
 ///
 /// Given these, this trait parses as:
 ///
@@ -45,6 +45,7 @@ use crate::{Parser, Result, T, diagnostics};
 /// ```
 ///
 pub trait BooleanFeature<'a>: Sized {
+	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_boolean_feature(
 		p: &mut Parser<'a>,
 		name: &'static str,
@@ -79,11 +80,11 @@ pub trait BooleanFeature<'a>: Sized {
 ///
 /// // Define the Boolean Feature.
 /// boolean_feature! {
-///		/// A boolean media feature: `(test-feature)`
-///		TestFeature, "test-feature"
-///	}
+///     /// A boolean media feature: `(test-feature)`
+///     TestFeature, "test-feature"
+/// }
 ///
-///	// Test!
+/// // Test!
 /// let allocator = Bump::new();
 /// let mut p = Parser::new(&allocator, "(test-feature)");
 /// let result = p.parse_entirely::<TestFeature>();

--- a/crates/css_parse/src/traits/discrete_feature.rs
+++ b/crates/css_parse/src/traits/discrete_feature.rs
@@ -8,11 +8,11 @@ use super::Parse;
 /// complementary to the other media features: [BooleanFeature][crate::BooleanFeature] and
 /// [DiscreteFeature][crate::DiscreteFeature].
 ///
-///	[1]: https://drafts.csswg.org/mediaqueries/#typedef-mf-plain
+/// [1]: https://drafts.csswg.org/mediaqueries/#typedef-mf-plain
 ///
-///	Rather than implementing this trait on an enum, use the [discrete_feature!][crate::discrete_feature] macro which
-///	expands to define the enum and necessary traits ([Parse], this trait, and [ToCursors][crate::ToCursors]) in a
-///	single macro call.
+/// Rather than implementing this trait on an enum, use the [discrete_feature!][crate::discrete_feature] macro which
+/// expands to define the enum and necessary traits ([Parse], this trait, and [ToCursors][crate::ToCursors]) in a
+/// single macro call.
 ///
 /// It does not implement [Parse], but provides `parse_discrere_feature(&mut Parser<'a>, name: &str) -> Result<Self>`,
 /// which can make for a trivial [Parse] implementation. The `name: &str` parameter refers to the `<feature-name>`
@@ -47,6 +47,7 @@ use super::Parse;
 pub trait DiscreteFeature<'a>: Sized {
 	type Value: Parse<'a>;
 
+	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_descrete_feature(
 		p: &mut Parser<'a>,
 		name: &'static str,
@@ -80,20 +81,20 @@ pub trait DiscreteFeature<'a>: Sized {
 /// use bumpalo::Bump;
 ///
 /// keyword_set!(
-///		/// A keyword that defines text-feature options
-///		FeatureKeywords {
-///			Big: "big",
-///			Small: "small",
-///		}
-///	);
+///     /// A keyword that defines text-feature options
+///     FeatureKeywords {
+///         Big: "big",
+///         Small: "small",
+///     }
+/// );
 ///
 /// // Define the Discrete Feature.
 /// discrete_feature! {
-///		/// A discrete media feature: `(test-feature: big)`, `(test-feature: small)`
-///		TestFeature, "test-feature", FeatureKeywords,
-///	}
+///     /// A discrete media feature: `(test-feature: big)`, `(test-feature: small)`
+///     TestFeature, "test-feature", FeatureKeywords,
+/// }
 ///
-///	// Test!
+/// // Test!
 /// let allocator = Bump::new();
 /// let mut p = Parser::new(&allocator, "(test-feature)");
 /// let result = p.parse_entirely::<TestFeature>();

--- a/crates/css_parse/src/traits/lists/declaration_list.rs
+++ b/crates/css_parse/src/traits/lists/declaration_list.rs
@@ -20,6 +20,7 @@ use bumpalo::collections::Vec;
 pub trait DeclarationList<'a>: Sized + Parse<'a> {
 	type Declaration: Declaration<'a>;
 
+	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_declaration_list(
 		p: &mut Parser<'a>,
 	) -> Result<(T!['{'], Vec<'a, (Self::Declaration, Option<T![;]>)>, Option<T!['}']>)> {

--- a/crates/css_parse/src/traits/lists/declaration_rule_list.rs
+++ b/crates/css_parse/src/traits/lists/declaration_rule_list.rs
@@ -24,6 +24,7 @@ pub trait DeclarationRuleList<'a>: Sized + Parse<'a> {
 	type Declaration: Declaration<'a>;
 	type AtRule: AtRule<'a>;
 
+	#[allow(clippy::type_complexity)] // TODO: simplify types
 	fn parse_declaration_rule_list(
 		p: &mut Parser<'a>,
 	) -> Result<(T!['{'], Vec<'a, (Self::Declaration, Option<T![;]>)>, Vec<'a, Self::AtRule>, Option<T!['}']>)> {

--- a/crates/css_parse/src/traits/lists/feature_condition_list.rs
+++ b/crates/css_parse/src/traits/lists/feature_condition_list.rs
@@ -53,7 +53,7 @@ keyword_set!(ConditionKeyword { And: "and", Not: "not", Or: "or" });
 /// reason about the given condition keyword. This makes the final grammar:
 ///
 /// ```md
-///	<condition-keyword>
+/// <condition-keyword>
 ///  │├──╮─ <ident-token "not"> ─╭──┤│
 ///      ├─ <ident-token "and"> ─┤
 ///      ╰─ <ident-token "or"> ──╯

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -130,7 +130,7 @@ pub trait RangedFeature<'a>: Sized {
 				let close = p.parse::<T![')']>()?;
 				return Self::new_legacy(open, name, colon, value, close);
 			} else if name.is_legacy() {
-				Err(diagnostics::UnexpectedIdent(p.parse_str(c.into()).into(), c.into()))?
+				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
 			}
 			let comparison = p.parse::<Comparison>()?;
 			let value = p.parse::<Self::Value>()?;

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -49,7 +49,7 @@ pub trait RangedFeatureKeyword {
 /// - It does not do the extra validation to ensure a left/right comparison are "directionally equivalent" - in other
 ///   words `<value> "<=" <feature-name> "=>" <value>` is a valid production in this trait - this allows for ASTs to
 ///   factor in error tolerance. If an AST node wishes to be strict, it can check the comparators inside of
-/// [RangedFeature::new_ranged] and return an [Err] there.
+///   [RangedFeature::new_ranged] and return an [Err] there.
 /// - It supports the "Legacy" modes which are defined for certain ranged media features. These legacy productions use
 ///   a colon token and typically have `min` and `max` variants of the [RangedFeature::FeatureName]. For example
 ///   `width: 1024px` is equivalent to `width >= 1024px`, while `max-width: 1024px` is equivalent to

--- a/crates/csskit/src/main.rs
+++ b/crates/csskit/src/main.rs
@@ -84,11 +84,11 @@ fn main() {
 		}
 		Commands::DbgParse { input } => {
 			let source_text = std::fs::read_to_string(input).unwrap();
-			println!("{}", source_text);
+			println!("{source_text}");
 			let bump = Bump::default();
 			let result = css_parse::Parser::new(&bump, source_text.as_str()).parse_entirely::<StyleSheet>();
 			if let Some(stylesheet) = &result.output {
-				println!("{:#?}", stylesheet);
+				println!("{stylesheet:#?}");
 			} else {
 				let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
 				for err in result.errors {
@@ -96,7 +96,7 @@ fn main() {
 					let named = NamedSource::new(input, source_text.clone());
 					let err = err.with_source_code(named);
 					handler.render_report(&mut report, err.as_ref()).unwrap();
-					println!("{}", report);
+					println!("{report}");
 				}
 			}
 		}
@@ -118,7 +118,7 @@ fn main() {
 					if let Some(file) = output {
 						std::fs::write(file, str.as_bytes()).unwrap();
 					} else {
-						println!("{}", str);
+						println!("{str}");
 						eprintln!("Slurped up CSS in {:?}! Neat!", start.elapsed());
 						if *minify {
 							eprintln!("Warning: minification not yet supported");
@@ -131,7 +131,7 @@ fn main() {
 						let named = NamedSource::new(file_name, source_text.clone());
 						let err = err.with_source_code(named);
 						handler.render_report(&mut report, err.as_ref()).unwrap();
-						println!("{}", report);
+						println!("{report}");
 					}
 				}
 			}

--- a/crates/csskit_derives/src/to_span.rs
+++ b/crates/csskit_derives/src/to_span.rs
@@ -12,7 +12,7 @@ trait TypeIsOption {
 impl TypeIsOption for Type {
 	fn is_option(&self) -> bool {
 		match self {
-			Self::Path(TypePath { path, .. }) => path.segments.last().map_or(false, |s| s.ident == "Option"),
+			Self::Path(TypePath { path, .. }) => path.segments.last().is_some_and(|s| s.ident == "Option"),
 			_ => false,
 		}
 	}

--- a/crates/csskit_lsp/src/jsonrpc/response.rs
+++ b/crates/csskit_lsp/src/jsonrpc/response.rs
@@ -131,19 +131,19 @@ mod tests {
 	#[test]
 	fn test_response_deserialize_error() {
 		// Missing result/error
-		assert!(matches!(from_str::<Response>(r#"{"id":3}"#), Err(_)));
+		assert!(from_str::<Response>(r#"{"id":3}"#).is_err());
 
 		// Missing error Code/Message
-		assert!(matches!(from_str::<Response>(r#"{"id":3, "error":{}}"#), Err(_)));
+		assert!(from_str::<Response>(r#"{"id":3, "error":{}}"#).is_err());
 
 		// Missing error Message
-		assert!(matches!(from_str::<Response>(r#"{"id":3, "error":{"code":0}}"#), Err(_)));
+		assert!(from_str::<Response>(r#"{"id":3, "error":{"code":0}}"#).is_err());
 
 		// Missing error Code
-		assert!(matches!(from_str::<Response>(r#"{"id":3, "error":{"message":""}}"#), Err(_)));
+		assert!(from_str::<Response>(r#"{"id":3, "error":{"message":""}}"#).is_err());
 
 		// Both error/result present
-		assert!(matches!(from_str::<Response>(r#"{"id":3, "error":{"code":0, "message": ""}, "result":7}"#), Err(_)));
-		assert!(matches!(from_str::<Response>(r#"{"id":3, "result":7, "error":{"code":0, "message": ""}}"#), Err(_)));
+		assert!(from_str::<Response>(r#"{"id":3, "error":{"code":0, "message": ""}, "result":7}"#).is_err());
+		assert!(from_str::<Response>(r#"{"id":3, "result":7, "error":{"code":0, "message": ""}}"#).is_err());
 	}
 }

--- a/crates/csskit_lsp/src/jsonrpc/tracing_layer.rs
+++ b/crates/csskit_lsp/src/jsonrpc/tracing_layer.rs
@@ -39,31 +39,31 @@ impl MessageVisitor {
 
 impl tracing::field::Visit for MessageVisitor {
 	fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
-		self.insert(field.name(), format!("{:?}", value));
+		self.insert(field.name(), format!("{value:?}"));
 	}
 
 	fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
-		self.insert(field.name(), format!("{:?}", value));
+		self.insert(field.name(), format!("{value:?}"));
 	}
 
 	fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-		self.insert(field.name(), format!("{:?}", value));
+		self.insert(field.name(), format!("{value:?}"));
 	}
 
 	fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-		self.insert(field.name(), format!("{:?}", value));
+		self.insert(field.name(), format!("{value:?}"));
 	}
 
 	fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-		self.insert(field.name(), format!("{:?}", value));
+		self.insert(field.name(), format!("{value:?}"));
 	}
 
 	fn record_error(&mut self, field: &tracing::field::Field, value: &(dyn std::error::Error + 'static)) {
-		self.insert(field.name(), format!("{:?}", value));
+		self.insert(field.name(), format!("{value:?}"));
 	}
 
 	fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-		self.insert(field.name(), format!("{:?}", value));
+		self.insert(field.name(), format!("{value:?}"));
 	}
 }
 

--- a/crates/csskit_lsp/src/server.rs
+++ b/crates/csskit_lsp/src/server.rs
@@ -82,7 +82,7 @@ impl Server {
 					if let Some(response) = response {
 						if let Err(e) = handler_sender.send(response) {
 							warn!("Handler failed to send response {:?}", &e);
-							return Err(io::Error::new(io::ErrorKind::Other, e));
+							return Err(io::Error::other(e));
 						}
 					}
 				}
@@ -112,7 +112,7 @@ impl Server {
 			let mut stdin = io::stdin().lock();
 			while let Some(message) = Message::read(&mut stdin)? {
 				if let Err(e) = read_sender.send(message) {
-					return Err(io::Error::new(io::ErrorKind::Other, e));
+					return Err(io::Error::other(e));
 				}
 			}
 			Ok(())

--- a/crates/csskit_lsp/src/service.rs
+++ b/crates/csskit_lsp/src/service.rs
@@ -114,7 +114,7 @@ impl File {
 	#[instrument]
 	fn get_highlights(&self) -> Vec<(Highlight, Line, Col)> {
 		self.sender.send(FileCall::Highlight).unwrap();
-		while let Ok(ret) = self.receiver.recv() {
+		if let Ok(ret) = self.receiver.recv() {
 			let FileReturn::Highlights(highlights) = ret;
 			return highlights;
 		}

--- a/crates/csskit_proc_macro/src/def.rs
+++ b/crates/csskit_proc_macro/src/def.rs
@@ -283,7 +283,7 @@ impl Parse for DefIdent {
 		let mut last_was_ident = false;
 		loop {
 			if input.peek(Token![>]) || input.peek(token::Bracket) {
-				return Ok(Self(str.into()));
+				return Ok(Self(str));
 			} else if input.peek(Ident::peek_any) && !last_was_ident {
 				last_was_ident = true;
 				let ident = input.call(Ident::parse_any)?;
@@ -298,7 +298,7 @@ impl Parse for DefIdent {
 				input.parse::<Token![-]>()?;
 				str.push('-');
 			} else {
-				return Ok(Self(str.into()));
+				return Ok(Self(str));
 			}
 		}
 	}
@@ -309,7 +309,7 @@ impl Parse for DefType {
 		input.parse::<Token![<]>()?;
 		let ident = if input.peek(LitStr) {
 			let str = input.parse::<StrWrapped<DefIdent>>()?.0.0;
-			DefIdent(format!("{}-style-value", str))
+			DefIdent(format!("{str}-style-value"))
 		} else {
 			input.parse::<DefIdent>()?
 		};
@@ -350,7 +350,7 @@ impl Parse for DefType {
 					}
 					str.push_str("Function");
 				}
-				Self::Custom(iden, DefIdent(str.into()))
+				Self::Custom(iden, DefIdent(str))
 			}
 		};
 		input.parse::<Token![>]>()?;
@@ -420,7 +420,7 @@ impl Def {
 			}
 			Self::DimensionLiteral(int, dim) => {
 				let dim_name: &str = (*dim).into();
-				let variant_str = format!("{}{}", int, dim_name);
+				let variant_str = format!("{int}{dim_name}");
 				let ident = format_ident!("Literal{}", variant_str);
 				quote! { #ident }
 			}
@@ -780,7 +780,7 @@ impl Def {
 					})
 					.collect();
 				let keyword_arms: Vec<_> = opts
-					.into_iter()
+					.iter()
 					.filter_map(|def| {
 						if let Def::Ident(ident) = def {
 							let keyword_variant = format_ident!("{}", pascal(ident.to_string()));
@@ -1383,7 +1383,7 @@ impl GenerateKeywordSet for Def {
 		let kws: Vec<&Def> = match self {
 			Self::Combinator(opts, DefCombinatorStyle::Alternatives)
 			| Self::Combinator(opts, DefCombinatorStyle::Options) => {
-				opts.into_iter().filter(|def| matches!(def, Def::Ident(_))).collect()
+				opts.iter().filter(|def| matches!(def, Def::Ident(_))).collect()
 			}
 			_ => vec![],
 		};
@@ -1620,7 +1620,7 @@ impl ToTokens for DefIdent {
 
 impl DefIdent {
 	pub fn pluralize(&self) -> DefIdent {
-		if self.0.ends_with("s") { self.clone() } else { Self(format!("{}s", self.0).into()) }
+		if self.0.ends_with("s") { self.clone() } else { Self(format!("{}s", self.0)) }
 	}
 
 	pub fn to_member_name(&self, size_hint: usize) -> TokenStream {

--- a/crates/csskit_transform/benches/minify_popular.rs
+++ b/crates/csskit_transform/benches/minify_popular.rs
@@ -1,6 +1,6 @@
 use bumpalo::Bump;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use css_ast::{StyleSheet, VisitableMut};
+use css_ast::StyleSheet;
 use css_parse::{CursorFmtSink, Parser, ToCursors};
 use glob::glob;
 #[cfg(target_family = "unix")]


### PR DESCRIPTION
This adds `cargo clippy` to `test.yml` so that we can have cleaner code in main!

This also runs `cargo clippy --fix` to address most of the easy low-hanging fruit.