### PR TITLE
css_ast: zoom is not a set of optionals

### DIFF
--- a/crates/css_ast/src/values/viewport/impls.rs
+++ b/crates/css_ast/src/values/viewport/impls.rs
@@ -8,7 +8,7 @@ mod tests {
 
 	#[test]
 	pub fn size_test() {
-		assert_eq!(std::mem::size_of::<ZoomStyleValue>(), 32);
+		assert_eq!(std::mem::size_of::<ZoomStyleValue>(), 16);
 	}
 
 	#[test]
@@ -24,5 +24,7 @@ mod tests {
 		assert_parse_error!(ZoomStyleValue, "-100%");
 		assert_parse_error!(ZoomStyleValue, "-10");
 		assert_parse_error!(ZoomStyleValue, "smaller");
+		assert_parse_error!(ZoomStyleValue, "10 10%");
+		assert_parse_error!(ZoomStyleValue, "10% 10");
 	}
 }

--- a/crates/css_ast/src/values/viewport/mod.rs
+++ b/crates/css_ast/src/values/viewport/mod.rs
@@ -7,11 +7,11 @@ use impls::*;
  */
 
 // https://drafts.csswg.org/css-viewport-1/#zoom
-#[value(" <number [0,∞]> || <percentage [0,∞]> ")]
+#[value(" <number [0,∞]> | <percentage [0,∞]> ")]
 #[initial("1")]
 #[applies_to("all <length> property values of all elements")]
 #[inherited("no")]
 #[percentages("converted to <number>")]
 #[canonical_order("per grammar")]
 #[animation_type("not animatable")]
-pub struct ZoomStyleValue;
+pub enum ZoomStyleValue {}

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_960.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_960.snap
@@ -14801,12 +14801,11 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "number": {
+              "Number": {
                 "kind": "Number",
                 "offset": 9987,
                 "len": 1
-              },
-              "percentage": null
+              }
             },
             "important": null
           },


### PR DESCRIPTION
This is a result of https://github.com/w3c/csswg-drafts/pull/12452.