### PR TITLE
Create Visitable derive macro, derive it everywhere.

### DIFF
--- a/crates/css_ast/build.rs
+++ b/crates/css_ast/build.rs
@@ -130,7 +130,8 @@ fn main() {
 		}}",
 		visit_matches.iter().fold(String::new(), |mut out, prop| {
 			let method_name = prop.trim_end_matches("<'a>");
-			writeln!(out, "\t\t\t\t\tvisit_{}({}),", snake(method_name.into()), prop).unwrap();
+			let life = if method_name == prop { "" } else { "<'a>" };
+			writeln!(out, "\t\t\t\t\tvisit_{}{}({}),", snake(method_name.into()), life, prop).unwrap();
 			out
 		})
 	);

--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -11,6 +11,7 @@ mod units;
 mod values;
 mod visit;
 
+use csskit_derives::Visitable;
 pub use properties::*;
 pub use rules::*;
 pub use selector::*;
@@ -25,8 +26,9 @@ use css_lexer::{Span, ToSpan};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, diagnostics};
 
 // TODO! - delete this when we're done ;)
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Visitable, Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
+#[visit(skip)]
 pub enum Todo {
 	#[default]
 	Todo,
@@ -52,8 +54,4 @@ impl ToSpan for Todo {
 	fn to_span(&self) -> Span {
 		Span::DUMMY
 	}
-}
-
-impl<'a> Visitable<'a> for Todo {
-	fn accept<V: Visit<'a>>(&self, _: &mut V) {}
 }

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -1,14 +1,11 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::{ToCursors, ToSpan};
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-syntax-3/#charset-rule
-#[derive(ToSpan, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[visit(self)]
 pub struct CharsetRule {
 	at_keyword: T![AtKeyword],
 	space: T![' '],
@@ -35,12 +32,6 @@ impl<'a> Parse<'a> for CharsetRule {
 		// TODO: check quote style as it should be "
 		let semicolon = p.parse::<T![;]>().ok();
 		Ok(Self { at_keyword, space, string, semicolon })
-	}
-}
-
-impl<'a> Visitable<'a> for CharsetRule {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_charset_rule(self);
 	}
 }
 

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -4,16 +4,17 @@ use css_parse::{
 	AtRule, Block, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Peek, PreludeList,
 	Result as ParserResult, T, diagnostics, keyword_set,
 };
-use csskit_derives::{IntoCursor, ToCursors, ToSpan};
+use csskit_derives::{IntoCursor, ToCursors, ToSpan, Visitable};
 
-use crate::{Property, Visit, Visitable, stylesheet::Rule};
+use crate::{Property, stylesheet::Rule};
 
 mod features;
 use features::*;
 
 // https://drafts.csswg.org/mediaqueries-4/
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
+#[visit(self)]
 pub struct MediaRule<'a> {
 	pub at_keyword: T![AtKeyword],
 	pub query: MediaQueryList<'a>,
@@ -37,12 +38,6 @@ impl<'a> AtRule<'a> for MediaRule<'a> {
 	const NAME: Option<&'static str> = Some("media");
 	type Prelude = MediaQueryList<'a>;
 	type Block = MediaRules<'a>;
-}
-
-impl<'a> Visitable<'a> for MediaRule<'a> {
-	fn accept<V: Visit<'a>>(&self, _v: &mut V) {
-		todo!();
-	}
 }
 
 #[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -1,16 +1,14 @@
 use css_lexer::Cursor;
 use css_parse::{AtRule, Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::{ToCursors, ToSpan};
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 use super::{DocumentMatcherList, DocumentRuleBlock};
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct MozDocumentRule<'a> {
+	#[visit(skip)]
 	pub at_keyword: T![AtKeyword],
 	pub matchers: DocumentMatcherList<'a>,
 	pub block: DocumentRuleBlock<'a>,
@@ -33,12 +31,6 @@ impl<'a> AtRule<'a> for MozDocumentRule<'a> {
 	const NAME: Option<&'static str> = Some("-moz-document");
 	type Prelude = DocumentMatcherList<'a>;
 	type Block = DocumentRuleBlock<'a>;
-}
-
-impl<'a> Visitable<'a> for MozDocumentRule<'a> {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_moz_document_rule(self);
-	}
 }
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -1,17 +1,15 @@
 use css_lexer::Span;
 use css_parse::{AtRule, Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::{ToCursors, ToSpan};
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 use super::{KeyframesBlock, KeyframesName};
 
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct WebkitKeyframesRule<'a> {
+	#[visit(skip)]
 	at_keyword: T![AtKeyword],
 	name: KeyframesName,
 	block: KeyframesBlock<'a>,
@@ -33,12 +31,6 @@ impl<'a> AtRule<'a> for WebkitKeyframesRule<'a> {
 	const NAME: Option<&'static str> = Some("-webkit-keyframes");
 	type Prelude = KeyframesName;
 	type Block = KeyframesBlock<'a>;
-}
-
-impl<'a> Visitable<'a> for WebkitKeyframesRule<'a> {
-	fn accept<V: Visit<'a>>(&self, _v: &mut V) {
-		todo!();
-	}
 }
 
 #[cfg(test)]

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -1,22 +1,23 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan};
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan, Visitable};
 
 use super::NamespacePrefix;
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit]
 pub struct Attribute {
+	#[visit(skip)]
 	pub open: T!['['],
+	#[visit(skip)]
 	pub namespace_prefix: Option<NamespacePrefix>,
+	#[visit(skip)]
 	pub attribute: T![Ident],
 	pub operator: Option<AttributeOperator>,
 	pub value: Option<AttributeValue>,
 	pub modifier: Option<AttributeModifier>,
+	#[visit(skip)]
 	pub close: Option<T![']']>,
 }
 
@@ -44,14 +45,9 @@ impl<'a> Parse<'a> for Attribute {
 	}
 }
 
-impl<'a> Visitable<'a> for Attribute {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_attribute(self);
-	}
-}
-
-#[derive(ToSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, Peek, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value"))]
+#[visit(self)]
 pub enum AttributeOperator {
 	Exact(T![=]),
 	SpaceList(T![~=]),
@@ -80,8 +76,9 @@ impl<'a> Parse<'a> for AttributeOperator {
 	}
 }
 
-#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value"))]
+#[visit(self)]
 pub enum AttributeValue {
 	String(T![String]),
 	Ident(T![Ident]),
@@ -97,8 +94,9 @@ impl<'a> Build<'a> for AttributeValue {
 	}
 }
 
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 pub enum AttributeModifier {
 	Sensitive(T![Ident]),
 	Insensitive(T![Ident]),

--- a/crates/css_ast/src/selector/class.rs
+++ b/crates/css_ast/src/selector/class.rs
@@ -1,13 +1,10 @@
 use css_lexer::{Cursor, Kind};
 use css_parse::{Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{ToCursors, ToSpan};
-use csskit_proc_macro::visit;
+use csskit_derives::{ToCursors, ToSpan, Visitable};
 
-use crate::{Visit, Visitable};
-
-#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
-#[visit]
+#[visit(self)]
 pub struct Class {
 	pub dot: T![.],
 	pub name: T![Ident],
@@ -24,11 +21,5 @@ impl<'a> Parse<'a> for Class {
 		let dot = p.parse::<T![.]>()?;
 		let name = p.parse::<T![Ident]>()?;
 		Ok(Self { dot, name })
-	}
-}
-
-impl<'a> Visitable<'a> for Class {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_class(self);
 	}
 }

--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -1,13 +1,10 @@
 use css_parse::{Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{ToCursors, ToSpan};
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/selectors/#combinators
-#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-#[visit]
+#[visit(self)]
 pub enum Combinator {
 	Child(T![>]),
 	NextSibling(T![+]),
@@ -32,12 +29,6 @@ impl<'a> Parse<'a> for Combinator {
 		} else {
 			Ok(Self::Descendant(p.parse::<T![' ']>()?))
 		}
-	}
-}
-
-impl<'a> Visitable<'a> for Combinator {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_combinator(self);
 	}
 }
 

--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -1,9 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Result as ParserResult, T, function_set, keyword_set};
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
-
-use crate::{Visit, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
 use super::{ForgivingSelector, Nth, RelativeSelector, SelectorList};
 
@@ -31,7 +29,7 @@ macro_rules! apply_functional_pseudo_class {
 
 macro_rules! define_functional_pseudo_class {
 	( $($ident: ident: $str: tt: $ty: ty: $val_ty: ty $(,)*)+ ) => {
-		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(
 			feature = "serde",
 			derive(serde::Serialize),
@@ -78,21 +76,9 @@ impl<'a> Parse<'a> for FunctionalPseudoClass<'a> {
 	}
 }
 
-impl<'a> Visitable<'a> for FunctionalPseudoClass<'a> {
-	fn accept<V: Visit<'a>>(&self, _v: &mut V) {
-		// macro_rules! match_keyword {
-		// 	( $($ident: ident: $str: tt: $ty: ty: $val_ty: ty $(,)*)+ ) => {
-		// 		match self {
-		// 			$(Self::$ident(c) => Visitable::accept(c, v),)+
-		// 		}
-		// 	}
-		// }
-		// apply_functional_pseudo_class!(match_keyword);
-	}
-}
-
-#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 pub struct DirPseudoFunction {
 	pub colon: T![:],
 	pub function: T![Function],
@@ -102,44 +88,61 @@ pub struct DirPseudoFunction {
 
 keyword_set!(pub enum DirValue { Rtl: "rtl", Ltr: "ltr" });
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct HasPseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: RelativeSelector<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct HostPseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: SelectorList<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct HostContextPseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: SelectorList<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct IsPseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: ForgivingSelector<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 pub struct LangPseudoFunction<'a> {
 	pub colon: T![:],
 	pub function: T![Function],
@@ -172,80 +175,113 @@ impl<'a> Parse<'a> for LangValue {
 	}
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct NotPseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: SelectorList<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct NthChildPseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: Nth<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct NthColPseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: Nth<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct NthLastChildPseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: Nth<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct NthLastColPseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: Nth<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct NthLastOfTypePseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: Nth<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct NthOfTypePseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: Nth<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct WherePseudoFunction<'a> {
+	#[visit(skip)]
 	pub colon: T![:],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: ForgivingSelector<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 pub struct StatePseudoFunction {
 	pub colon: T![:],
 	pub function: T![Function],

--- a/crates/css_ast/src/selector/functional_pseudo_element.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_element.rs
@@ -1,14 +1,11 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
-use csskit_derives::{ToCursors, ToSpan};
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 use super::CompoundSelector;
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename_all = "kebab-case"))]
 #[visit]
 pub enum FunctionalPseudoElement<'a> {
@@ -54,14 +51,9 @@ impl<'a> Parse<'a> for FunctionalPseudoElement<'a> {
 	}
 }
 
-impl<'a> Visitable<'a> for FunctionalPseudoElement<'a> {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_functional_pseudo_element(self);
-	}
-}
-
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 pub struct HighlightPseudoElement {
 	pub colons: T![::],
 	pub function: T![Function],
@@ -69,17 +61,22 @@ pub struct HighlightPseudoElement {
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct SlottedPseudoElement<'a> {
+	#[visit(skip)]
 	pub colons: T![::],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: CompoundSelector<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 pub struct PartPseudoElement<'a> {
 	pub colons: T![::],
 	pub function: T![Function],

--- a/crates/css_ast/src/selector/moz.rs
+++ b/crates/css_ast/src/selector/moz.rs
@@ -3,16 +3,14 @@ use css_parse::{
 	Build, Parse, Parser, Result as ParserResult, T, diagnostics, function_set, pseudo_class, pseudo_element,
 	syntax::CommaSeparated,
 };
-use csskit_derives::ToCursors;
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::{ToCursors, Visitable};
 
 use super::functional_pseudo_class::DirValue;
 
 pseudo_element!(
 	/// https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#pseudo-elements_and_pseudo-classes
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum MozPseudoElement {
 		AnonymousBlock: "-moz-anonymous-block",
 		AnonymousItem: "-moz-anonymous-item",
@@ -91,15 +89,9 @@ pseudo_element!(
 	}
 );
 
-impl<'a> Visitable<'a> for MozPseudoElement {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_moz_pseudo_element(self);
-	}
-}
-
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-#[visit]
+#[visit(self)]
 pub enum MozFunctionalPseudoElement<'a> {
 	TreeCell(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
 	TreeCellText(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
@@ -145,15 +137,10 @@ impl<'a> Parse<'a> for MozFunctionalPseudoElement<'a> {
 	}
 }
 
-impl<'a> Visitable<'a> for MozFunctionalPseudoElement<'a> {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_moz_functional_pseudo_element(self);
-	}
-}
-
 pseudo_class!(
 	/// <https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#pseudo-elements_and_pseudo-classes>
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum MozPseudoClass {
 		Any: "-moz-any",
 		AnyLink: "-moz-any-link",
@@ -185,13 +172,7 @@ pseudo_class!(
 	}
 );
 
-impl<'a> Visitable<'a> for MozPseudoClass {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_moz_pseudo_class(self);
-	}
-}
-
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit]
 pub enum MozFunctionalPseudoClass {
@@ -213,14 +194,9 @@ impl<'a> Parse<'a> for MozFunctionalPseudoClass {
 	}
 }
 
-impl<'a> Visitable<'a> for MozFunctionalPseudoClass {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_moz_functional_pseudo_class(self);
-	}
-}
-
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
+#[visit(self)]
 pub struct MozLocaleDirFunctionalPseudoClass {
 	pub colon: T![:],
 	pub function: T![Function],

--- a/crates/css_ast/src/selector/ms.rs
+++ b/crates/css_ast/src/selector/ms.rs
@@ -1,10 +1,9 @@
 use css_parse::{pseudo_class, pseudo_element};
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::Visitable;
 
 pseudo_element!(
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum MsPseudoElement {
 		Backdrop: "-ms-backdrop",
 		Browse: "-ms-browse",
@@ -27,22 +26,11 @@ pseudo_element!(
 	}
 );
 
-impl<'a> Visitable<'a> for MsPseudoElement {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_ms_pseudo_element(self);
-	}
-}
-
 pseudo_class!(
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum MsPseudoClass {
 		Fullscreen: "-ms-fullscreen",
 		InputPlaceholder: "-ms-input-placeholder"
 	}
 );
-
-impl<'a> Visitable<'a> for MsPseudoClass {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_ms_pseudo_class(self);
-	}
-}

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,16 +1,13 @@
 use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan};
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan, Visitable};
 
 use super::Tag;
 
 // https://drafts.csswg.org/selectors/#combinators
-#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-#[visit]
+#[visit(self)]
 pub struct Namespace {
 	pub prefix: Option<NamespacePrefix>,
 	pub tag: NamespaceTag,
@@ -40,12 +37,6 @@ impl<'a> Parse<'a> for Namespace {
 		}
 		let tag = p.parse::<NamespaceTag>()?;
 		Ok(Self { prefix: None, tag })
-	}
-}
-
-impl<'a> Visitable<'a> for Namespace {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_namespace(self);
 	}
 }
 

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -1,11 +1,13 @@
 use bumpalo::collections::Vec;
 use css_lexer::{Cursor, Kind, KindSet, Span, ToSpan};
 use css_parse::{CursorSink, Parse, Parser, Result as ParserResult, T, ToCursors, diagnostics};
+use csskit_derives::Visitable;
 
 use crate::units::CSSInt;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 pub enum Nth<'a> {
 	Odd(T![Ident]),
 	Even(T![Ident]),

--- a/crates/css_ast/src/selector/o.rs
+++ b/crates/css_ast/src/selector/o.rs
@@ -1,10 +1,9 @@
 use css_parse::{pseudo_class, pseudo_element};
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::Visitable;
 
 pseudo_element!(
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum OPseudoElement {
 		InnerSpinButton: "-o-inner-spin-button",
 		OuterSpinButton: "-o-outer-spin-button",
@@ -17,21 +16,10 @@ pseudo_element!(
 	}
 );
 
-impl<'a> Visitable<'a> for OPseudoElement {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_o_pseudo_element(self);
-	}
-}
-
 pseudo_class!(
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum OPseudoClass {
 		Prefocus: "-o-prefocus"
 	}
 );
-
-impl<'a> Visitable<'a> for OPseudoClass {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_o_pseudo_class(self);
-	}
-}

--- a/crates/css_ast/src/selector/tag.rs
+++ b/crates/css_ast/src/selector/tag.rs
@@ -1,11 +1,8 @@
 use css_lexer::Cursor;
 use css_parse::{Build, Parser, Peek, T, keyword_set};
-use csskit_derives::{IntoCursor, ToCursors};
-use csskit_proc_macro::visit;
+use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
-use crate::{Visit, Visitable};
-
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub enum Tag {
@@ -44,24 +41,9 @@ impl<'a> Build<'a> for Tag {
 	}
 }
 
-impl<'a> Visitable<'a> for Tag {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_tag(self);
-		match self {
-			Self::Html(c) => Visitable::accept(c, v),
-			Self::HtmlNonConforming(c) => Visitable::accept(c, v),
-			Self::HtmlNonStandard(c) => Visitable::accept(c, v),
-			Self::Svg(c) => Visitable::accept(c, v),
-			Self::Mathml(c) => Visitable::accept(c, v),
-			Self::CustomElement(c) => Visitable::accept(c, v),
-			Self::Unknown(c) => Visitable::accept(c, v),
-		}
-	}
-}
-
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[visit(self)]
 pub struct CustomElementTag(T![Ident]);
 
 impl CustomElementTag {
@@ -125,15 +107,10 @@ impl<'a> Build<'a> for CustomElementTag {
 	}
 }
 
-impl<'a> Visitable<'a> for CustomElementTag {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_custom_element_tag(self);
-	}
-}
-
 keyword_set!(
 	/// <https://html.spec.whatwg.org/multipage/indices.html#elements-3>
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum HtmlTag {
 		A: "a",
 		Abbr: "abbr",
@@ -268,15 +245,10 @@ keyword_set!(
 	}
 );
 
-impl<'a> Visitable<'a> for HtmlTag {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_html_tag(self);
-	}
-}
-
 keyword_set!(
 	/// <https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features>
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum HtmlNonConformingTag {
 		Acronym: "acronym",
 		Applet: "applet",
@@ -310,14 +282,9 @@ keyword_set!(
 	}
 );
 
-impl<'a> Visitable<'a> for HtmlNonConformingTag {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_html_non_conforming_tag(self);
-	}
-}
-
 keyword_set!(
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum HtmlNonStandardTag {
 		// https://wicg.github.io/fenced-frame/#the-fencedframe-element
 		Fencedframe: "fencedframe",
@@ -330,15 +297,10 @@ keyword_set!(
 	}
 );
 
-impl<'a> Visitable<'a> for HtmlNonStandardTag {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_html_non_standard_tag(self);
-	}
-}
-
 keyword_set!(
 	/// <https://svgwg.org/svg2-draft/eltindex.html>
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum SvgTag {
 		A: "a",
 		Animate: "animate",
@@ -407,15 +369,10 @@ keyword_set!(
 	}
 );
 
-impl<'a> Visitable<'a> for SvgTag {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_svg_tag(self);
-	}
-}
-
 keyword_set!(
 	/// <https://w3c.github.io/mathml/#mmlindex_elements>
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum MathmlTag {
 		Abs: "abs",
 		And: "and",
@@ -578,15 +535,9 @@ keyword_set!(
 	}
 );
 
-impl<'a> Visitable<'a> for MathmlTag {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_mathml_tag(self);
-	}
-}
-
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[visit(self)]
 pub struct UnknownTag(T![Ident]);
 
 impl<'a> Peek<'a> for UnknownTag {
@@ -598,12 +549,6 @@ impl<'a> Peek<'a> for UnknownTag {
 impl<'a> Build<'a> for UnknownTag {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		Self(<T![Ident]>::build(p, c))
-	}
-}
-
-impl<'a> Visitable<'a> for UnknownTag {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_unknown_tag(self);
 	}
 }
 

--- a/crates/css_ast/src/selector/webkit.rs
+++ b/crates/css_ast/src/selector/webkit.rs
@@ -1,15 +1,13 @@
 use css_lexer::Cursor;
 use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics, pseudo_class, pseudo_element};
-use csskit_derives::ToCursors;
-use csskit_proc_macro::visit;
-
-use crate::{Visit, Visitable};
+use csskit_derives::{ToCursors, Visitable};
 
 use super::CompoundSelector;
 
 pseudo_element!(
 	/// <https://searchfox.org/wubkat/source/Source/WebCore/css/CSSPseudoSelectors.json>
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum WebkitPseudoElement {
 		CalendarDatePickerIndicator: "-webkit-calendar-picker-indicator",
 		CapsLockIndicator: "-webkit-caps-lock-indicator",
@@ -77,13 +75,7 @@ pseudo_element!(
 	}
 );
 
-impl<'a> Visitable<'a> for WebkitPseudoElement {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_webkit_pseudo_element(self);
-	}
-}
-
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit]
 pub enum WebkitFunctionalPseudoElement<'a> {
@@ -105,42 +97,24 @@ impl<'a> Parse<'a> for WebkitFunctionalPseudoElement<'a> {
 	}
 }
 
-impl<'a> Visitable<'a> for WebkitFunctionalPseudoElement<'a> {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_webkit_functional_pseudo_element(self);
-		match self {
-			Self::Distributed(pseudo) => {
-				pseudo.value.accept(v);
-			}
-		}
-	}
-}
-
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
+#[visit]
 pub struct WebkitDistrubutedFunctionalPseudoElement<'a> {
+	#[visit(skip)]
 	pub colons: T![::],
+	#[visit(skip)]
 	pub function: T![Function],
 	pub value: CompoundSelector<'a>,
+	#[visit(skip)]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit]
 pub enum WebkitFunctionalPseudoClass<'a> {
 	Any(WebkitAnyFunctionalPseudoClass<'a>),
-}
-
-impl<'a> Visitable<'a> for WebkitFunctionalPseudoClass<'a> {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_webkit_functional_pseudo_class(self);
-		match self {
-			Self::Any(pseudo) => {
-				pseudo.value.accept(v);
-			}
-		}
-	}
 }
 
 impl<'a> Parse<'a> for WebkitFunctionalPseudoClass<'a> {
@@ -158,8 +132,9 @@ impl<'a> Parse<'a> for WebkitFunctionalPseudoClass<'a> {
 	}
 }
 
-#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
+#[visit(self)]
 pub struct WebkitAnyFunctionalPseudoClass<'a> {
 	pub colon: T![:],
 	pub function: T![Function],
@@ -169,7 +144,8 @@ pub struct WebkitAnyFunctionalPseudoClass<'a> {
 
 pseudo_class!(
 	/// <https://searchfox.org/wubkat/source/Source/WebCore/css/CSSPseudoSelectors.json>
-	#[visit]
+	#[derive(Visitable)]
+	#[visit(self)]
 	pub enum WebkitPseudoClass {
 		AnimatingFullScreenTransition: "-webkit-animating-full-screen-transition",
 		AnyLink: "-webkit-any-link",  // Alias for :any-link
@@ -185,9 +161,3 @@ pseudo_class!(
 		FullScreenDocument: "-webkit-full-screen-document",
 	}
 );
-
-impl<'a> Visitable<'a> for WebkitPseudoClass {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
-		v.visit_webkit_pseudo_class(self);
-	}
-}

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -1,15 +1,19 @@
 include!(concat!(env!("OUT_DIR"), "/css_node_kind.rs"));
 include!(concat!(env!("OUT_DIR"), "/css_apply_visit_methods.rs"));
 
+use bumpalo::collections::Vec;
+use css_parse::{CommaSeparated, syntax::BadDeclaration};
+
 use crate::*;
 
 macro_rules! visit_mut_trait {
 	( $(
-		$name: ident($obj: ty),
+		$name: ident$(<$life:lifetime>)?($obj: ty),
 	)+ ) => {
-		pub trait VisitMut<'a>: Sized + Default {
+		pub trait VisitMut: Sized + Default {
+			fn visit_bad_declaration<'a>(&mut self, _rule: &mut BadDeclaration<'a>) {}
 			$(
-				fn $name(&mut self, _rule: &mut $obj) {}
+				fn $name$(<$life>)?(&mut self, _rule: &mut $obj) {}
 			)+
 		}
 	}
@@ -18,37 +22,139 @@ apply_visit_methods!(visit_mut_trait);
 
 macro_rules! visit_trait {
 	( $(
-		$name: ident($obj: ty),
+		$name: ident$(<$life:lifetime>)?($obj: ty),
 	)+ ) => {
-		pub trait Visit<'a>: Sized + Default {
+		pub trait Visit: Sized + Default {
+			fn visit_bad_declaration<'a>(&mut self, _rule: &BadDeclaration<'a>) {}
 			$(
-				fn $name(&mut self, _rule: &$obj) {}
+				fn $name$(<$life>)?(&mut self, _rule: &$obj) {}
 			)+
 		}
 	}
 }
 apply_visit_methods!(visit_trait);
 
-pub trait VisitableMut<'a> {
-	fn accept_mut<V: VisitMut<'a>>(&mut self, v: &mut V);
+pub trait VisitableMut {
+	fn accept_mut<V: VisitMut>(&mut self, v: &mut V);
 }
 
-pub trait Visitable<'a> {
-	fn accept<V: Visit<'a>>(&self, v: &mut V);
+pub trait Visitable {
+	fn accept<V: Visit>(&self, v: &mut V);
 }
 
-impl<'a, T: VisitableMut<'a>> VisitableMut<'a> for bumpalo::collections::Vec<'a, T> {
-	fn accept_mut<V: VisitMut<'a>>(&mut self, v: &mut V) {
-		for node in self {
+impl<T> VisitableMut for Option<T>
+where
+	T: VisitableMut,
+{
+	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
+		if let Some(node) = self {
 			node.accept_mut(v)
 		}
 	}
 }
 
-impl<'a, T: Visitable<'a>> Visitable<'a> for bumpalo::collections::Vec<'a, T> {
-	fn accept<V: Visit<'a>>(&self, v: &mut V) {
+impl<T> Visitable for Option<T>
+where
+	T: Visitable,
+{
+	fn accept<V: Visit>(&self, v: &mut V) {
+		if let Some(node) = self {
+			node.accept(v)
+		}
+	}
+}
+
+impl<'a, T> VisitableMut for CommaSeparated<'a, T>
+where
+	T: VisitableMut + Peek<'a> + Parse<'a> + ToCursors + ToSpan,
+{
+	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
+		for (node, _) in self {
+			node.accept_mut(v)
+		}
+	}
+}
+
+impl<'a, T> Visitable for CommaSeparated<'a, T>
+where
+	T: Visitable + Peek<'a> + Parse<'a> + ToCursors + ToSpan,
+{
+	fn accept<V: Visit>(&self, v: &mut V) {
+		for (node, _) in self {
+			node.accept(v)
+		}
+	}
+}
+
+impl<'a, T> VisitableMut for Vec<'a, T>
+where
+	T: VisitableMut,
+{
+	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
+		for node in self {
+			node.accept_mut(v);
+		}
+	}
+}
+
+impl<'a, T> Visitable for Vec<'a, T>
+where
+	T: Visitable,
+{
+	fn accept<V: Visit>(&self, v: &mut V) {
 		for node in self {
 			node.accept(v)
 		}
 	}
 }
+
+impl<'a> VisitableMut for BadDeclaration<'a> {
+	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
+		v.visit_bad_declaration(self);
+	}
+}
+
+impl<'a> Visitable for BadDeclaration<'a> {
+	fn accept<V: Visit>(&self, v: &mut V) {
+		v.visit_bad_declaration(self);
+	}
+}
+
+macro_rules! impl_tuple_mut {
+    ($($T:ident),*) => {
+				impl<$($T),*> VisitableMut for ($($T),*)
+        where
+            $($T: VisitableMut,)*
+        {
+            #[allow(non_snake_case)]
+            #[allow(unused)]
+						fn accept_mut<VI: VisitMut>(&mut self, v: &mut VI) {
+                let ($($T),*) = self;
+                $($T.accept_mut(v);)*
+            }
+        }
+    };
+}
+
+impl_tuple_mut!(T, U);
+impl_tuple_mut!(T, U, V);
+impl_tuple_mut!(T, U, V, W);
+
+macro_rules! impl_tuple {
+    ($($T:ident),*) => {
+				impl<$($T),*> Visitable for ($($T),*)
+        where
+            $($T: Visitable,)*
+        {
+            #[allow(non_snake_case)]
+            #[allow(unused)]
+						fn accept<VI: Visit>(&self, v: &mut VI) {
+                let ($($T),*) = self;
+                $($T.accept(v);)*
+            }
+        }
+    };
+}
+impl_tuple!(T, U);
+impl_tuple!(T, U, V);
+impl_tuple!(T, U, V, W);

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -8,6 +8,7 @@ mod parse;
 mod peek;
 mod to_cursors;
 mod to_span;
+mod visitable;
 
 #[proc_macro_derive(ToCursors, attributes(to_cursors))]
 pub fn derive_to_cursors(stream: TokenStream) -> TokenStream {
@@ -37,6 +38,12 @@ pub fn derive_into_cursor(stream: TokenStream) -> TokenStream {
 pub fn derive_into_span(stream: TokenStream) -> TokenStream {
 	let input = syn::parse(stream).unwrap();
 	to_span::derive(input).into()
+}
+
+#[proc_macro_derive(Visitable, attributes(visit))]
+pub fn derive_visitable(stream: TokenStream) -> TokenStream {
+	let input = syn::parse(stream).unwrap();
+	visitable::derive(input).into()
 }
 
 fn err(span: Span, msg: &str) -> proc_macro2::TokenStream {

--- a/crates/csskit_derives/src/visitable.rs
+++ b/crates/csskit_derives/src/visitable.rs
@@ -1,0 +1,143 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Ident, Meta, parse::Parse, token::SelfValue};
+
+use crate::err;
+
+pub fn snake(str: String) -> String {
+	let mut snake = String::new();
+	for (i, ch) in str.char_indices() {
+		if i > 0 && ch.is_uppercase() {
+			snake.push('_');
+		}
+		snake.push(ch.to_ascii_lowercase());
+	}
+	snake
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum VisitStyle {
+	All,
+	Skip,
+	OnlySelf,
+	#[default]
+	OnlyChildren,
+}
+
+impl VisitStyle {
+	pub fn visit_self(&self) -> bool {
+		matches!(self, Self::All | Self::OnlySelf)
+	}
+	pub fn visit_children(&self) -> bool {
+		matches!(self, Self::All | Self::OnlyChildren)
+	}
+}
+
+impl Parse for VisitStyle {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		if input.parse::<SelfValue>().is_ok() {
+			return Ok(Self::OnlySelf);
+		}
+		match input.parse::<Ident>()? {
+			i if i == "all" => Ok(Self::All),
+			i if i == "skip" => Ok(Self::Skip),
+			i if i == "children" => Ok(Self::OnlyChildren),
+			ident => Err(Error::new(ident.span(), format!("Unrecognized Value arg {ident:?}")))?,
+		}
+	}
+}
+
+impl From<&Vec<Attribute>> for VisitStyle {
+	fn from(attrs: &Vec<Attribute>) -> Self {
+		if let Some(Attribute { meta, .. }) = &attrs.iter().find(|a| a.path().is_ident("visit")) {
+			match meta {
+				// #[visit(keyword)]
+				Meta::List(meta) => meta.parse_args::<VisitStyle>().unwrap(),
+				// #[visit]
+				_ => Self::All,
+			}
+		} else {
+			// No attribute present
+			Self::default()
+		}
+	}
+}
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+	let ident = input.ident;
+	let generics = &mut input.generics.clone();
+	let (impl_generics, _, _) = generics.split_for_impl();
+	let style: VisitStyle = (&input.attrs).into();
+	let visit = if style.visit_self() {
+		let method = format_ident!("visit_{}", snake(ident.to_string()));
+		quote! { v.#method(self); }
+	} else {
+		quote! {}
+	};
+	let [body_mut, body] = if style.visit_children() {
+		[format_ident!("accept_mut"), format_ident!("accept")].map(|accept| match &input.data {
+			Data::Union(_) => err(ident.span(), "Cannot derive Into<Span> on a Union"),
+
+			Data::Struct(DataStruct { fields, .. }) => {
+				let members = fields.members().zip(fields).filter_map(|(member, field)| {
+					if Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip { None } else { Some(member) }
+				});
+				quote! { #(self.#members.#accept(v);)* }
+			}
+
+			Data::Enum(DataEnum { variants, .. }) => {
+				let steps: TokenStream = variants
+					.iter()
+					.map(|variant| {
+						let variant_ident = &variant.ident;
+						if Into::<VisitStyle>::into(&variant.attrs) == VisitStyle::Skip {
+							return quote! {
+								Self::#variant_ident(_) => {},
+							};
+						}
+						let (members, steps): (Vec<_>, Vec<_>) = variant
+							.fields
+							.iter()
+							.enumerate()
+							.map(|(i, field)| {
+								if Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip {
+									(format_ident!("_"), quote! {})
+								} else {
+									let ident = format_ident!("v{}", i);
+									(ident.clone(), quote! { #ident.#accept(v) })
+								}
+							})
+							.collect::<Vec<_>>()
+							.into_iter()
+							.unzip();
+						quote! {
+							Self::#variant_ident(#(#members),*) => { #(#steps;)* },
+						}
+					})
+					.collect();
+				quote! { match self { #steps } }
+			}
+		})
+	} else {
+		[quote! {}, quote! {}]
+	};
+	quote! {
+		#[automatically_derived]
+		impl #impl_generics crate::VisitableMut for #ident #impl_generics {
+			fn accept_mut<V: crate::VisitMut>(&mut self, v: &mut V) {
+				use crate::VisitableMut;
+				#visit
+				#body_mut
+			}
+		}
+
+		#[automatically_derived]
+		impl #impl_generics crate::Visitable for #ident #impl_generics {
+			fn accept<V: crate::Visit>(&self, v: &mut V) {
+				use crate::Visitable;
+				#visit
+				#body
+			}
+		}
+	}
+}

--- a/crates/csskit_highlight/src/css.rs
+++ b/crates/csskit_highlight/src/css.rs
@@ -6,7 +6,7 @@ use css_lexer::ToSpan;
 
 use crate::{SemanticKind, SemanticModifier, TokenHighlighter};
 
-impl<'a> Visit<'a> for TokenHighlighter {
+impl Visit for TokenHighlighter {
 	fn visit_tag(&mut self, tag: &Tag) {
 		let span = tag.to_span();
 		let mut modifier = SemanticModifier::none();
@@ -42,14 +42,14 @@ impl<'a> Visit<'a> for TokenHighlighter {
 		self.insert(span, SemanticKind::PseudoClass, modifier);
 	}
 
-	fn visit_style_declaration(&mut self, rule: &StyleDeclaration<'a>) {
+	fn visit_style_declaration<'a>(&mut self, rule: &StyleDeclaration<'a>) {
 		self.insert(rule.open.to_span(), SemanticKind::Punctuation, SemanticModifier::none());
 		if let Some(close) = rule.close {
 			self.insert(close.to_span(), SemanticKind::Punctuation, SemanticModifier::none());
 		}
 	}
 
-	fn visit_property(&mut self, property: &Property<'a>) {
+	fn visit_property<'a>(&mut self, property: &Property<'a>) {
 		let span = property.name.to_span();
 		let mut modifier = SemanticModifier::none();
 		if matches!(&property.value, StyleValue::Unknown(_)) {
@@ -62,11 +62,11 @@ impl<'a> Visit<'a> for TokenHighlighter {
 		self.insert(property.colon.to_span(), SemanticKind::Punctuation, SemanticModifier::none());
 	}
 
-	fn visit_property_rule(&mut self, property: &PropertyRule<'a>) {
+	fn visit_property_rule<'a>(&mut self, property: &PropertyRule<'a>) {
 		self.insert(property.name.to_span(), SemanticKind::Declaration, SemanticModifier::Custom);
 	}
 
-	fn visit_property_rule_property(&mut self, property: &PropertyRuleProperty<'a>) {
+	fn visit_property_rule_property<'a>(&mut self, property: &PropertyRuleProperty<'a>) {
 		let span = property.name.to_span();
 		let mut modifier = SemanticModifier::none();
 		if matches!(&property.value, PropertyRuleStyleValue::Unknown(_)) {


### PR DESCRIPTION
Visitors have have a fun history here. They started out in 907011a, but got put to bed for a while, revived in 4465ac7, but with lots of todos and in a way which didn't gel very well with the rest of the codebase. They hobbled along until PR #64 (b6083c4) where there was an attempt to revive them so we could get semantic highlighting working in the LSP. The problem is they were working just well enough for demonstration purposes but we needed something a little more comprehensive.

This commit iterates again, but this time hopefully more earnestly. This tweaks the Visitable/VisitableMut traits to be a little more refined by dropping useless lifetimes, and applies them to some generics like Vec, Option, CommaSeparated etc. This also introduces the derive(Visitable) proc macro which will automatically implement both the Visitable/VisitableMut traits on the given struct.

The `derive(Visitable)` trait steals the `#[visit]` attribute (though I've left in csskit_proc_macro::visit for now - it's needed for types that don't derive). `#[visit]` on its own is an alias for `#[visit(all)]` which will iterate over all members and `accept[_mut]()` them. Calling `#[visit(skip)]` on any member will cause it to be missed - which is useful for tokens or other non-visitables. There's also `#[visit(self)]` for leaf-nodes that want to be visited but don't have any meaningful children to visit, and `#[visit(children)]` for delegate nodes that aren't meaningful in of themselves, but can dispatch out to their children. All in all this makes for a fairly robust way of getting Visitable derived in almost all AST nodes.

And so this commit _also_ applies Visitable to just about everything. We should probably put some effort into testing these, but I have some other ideas around how to make use of these in a unilateral way, so until then this will have to be considered good enough!