### PR TITLE
css_ast: tidy up build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,19 +414,19 @@ dependencies = [
  "css_parse",
  "csskit_derives",
  "csskit_proc_macro",
+ "csskit_source_finder",
  "glob",
- "grep-matcher",
- "grep-regex",
- "grep-searcher",
  "heck",
  "insta",
  "miette",
  "phf",
  "pprof",
+ "quote",
  "serde",
  "serde_json",
  "similar",
  "smallvec",
+ "syn",
 ]
 
 [[package]]
@@ -548,6 +548,18 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "csskit_source_finder"
+version = "0.0.0"
+dependencies = [
+ "glob",
+ "grep-matcher",
+ "grep-regex",
+ "grep-searcher",
+ "heck",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ csskit_proc_macro = { version = "0.0.0", path = "crates/csskit_proc_macro" }
 css_parse = { version = "0.0.1", path = "crates/css_parse" }
 css_lexer = { version = "0.0.1", path = "crates/css_lexer" }
 css_ast = { version = "0.0.0", path = "crates/css_ast" }
+csskit_source_finder = { version = "0.0.0", path = "crates/csskit_source_finder" }
 csskit_transform = { version = "0.0.0", path = "crates/csskit_transform" }
 csskit_highlight = { version = "0.0.0", path = "crates/csskit_highlight" }
 csskit_lsp = { version = "0.0.0", path = "crates/csskit_lsp" }
@@ -69,7 +70,7 @@ serde_json = { version = "1.0.140" }
 
 # Testing, benchmarking
 similar = { version = "2.7.0" }
-criterion = { version = "0.5.1" } # Help back for pprof (https://github.com/tikv/pprof-rs/pull/271)
+criterion = { version = "0.5.1" }     # Help back for pprof (https://github.com/tikv/pprof-rs/pull/271)
 pprof = { version = "0.15.0" }
 flate2 = { version = "1.1.2" }
 insta = { version = "1.43.1" }

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -29,10 +29,9 @@ serde_json = { workspace = true, optional = true }
 bitmask-enum = { workspace = true }
 
 [build-dependencies]
-grep-regex = { workspace = true }
-grep-searcher = { workspace = true }
-grep-matcher = { workspace = true }
-glob = { workspace = true }
+csskit_source_finder = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 heck = { workspace = true }
 
 [dev-dependencies]

--- a/crates/csskit_source_finder/Cargo.toml
+++ b/crates/csskit_source_finder/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "csskit_source_finder"
+version = "0.0.0"
+authors.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+bench = false
+
+[dependencies]
+grep-regex = { workspace = true }
+grep-searcher = { workspace = true }
+grep-matcher = { workspace = true }
+glob = { workspace = true }
+heck = { workspace = true }
+syn = { workspace = true }

--- a/crates/csskit_source_finder/src/lib.rs
+++ b/crates/csskit_source_finder/src/lib.rs
@@ -1,0 +1,71 @@
+use std::collections::HashSet;
+use std::io;
+use std::path::PathBuf;
+use std::str::from_utf8;
+
+use glob::glob;
+use grep_matcher::{Captures, Matcher};
+use grep_regex::{RegexMatcher, RegexMatcherBuilder};
+use grep_searcher::{Searcher, SearcherBuilder, Sink, SinkError, SinkMatch};
+use syn::{Type, parse_str};
+
+pub struct NodeMatcher<'a> {
+	matcher: &'a RegexMatcher,
+	matches: &'a mut HashSet<Type>,
+}
+
+impl Sink for NodeMatcher<'_> {
+	type Error = io::Error;
+
+	fn matched(&mut self, _searcher: &Searcher, mat: &SinkMatch<'_>) -> Result<bool, io::Error> {
+		let mut captures = self.matcher.new_captures()?;
+		let line = match from_utf8(mat.bytes()) {
+			Ok(matched) => matched,
+			Err(err) => return Err(io::Error::error_message(err)),
+		};
+		self.matcher.captures_iter(mat.bytes(), &mut captures, |captures| -> bool {
+			dbg!(&line, &captures, captures.get(2).map(|r| &line[r]), captures.get(5).map(|r| &line[r]));
+			let capture = &line[captures.get(5).unwrap()];
+			if !capture.is_empty() {
+				if let Ok(ty) = parse_str(capture) {
+					self.matches.insert(ty);
+				}
+			} else {
+				dbg!(&line);
+				panic!("#[visit] or #[value] on unknown");
+			}
+			true
+		})?;
+		Ok(true)
+	}
+}
+
+pub fn find_visitable_nodes(dir: &str, matches: &mut HashSet<Type>, path_callback: impl Fn(&PathBuf)) {
+	let matcher = RegexMatcherBuilder::new()
+		.multi_line(true)
+		.dot_matches_new_line(true)
+		.ignore_whitespace(true)
+		.build(
+			r#"
+			# match the #[value] or #[visit] attribute
+			^\s*\#\[(value|visit)
+			# munch the data between the attribute and the definition
+			.*?
+			(
+				# Is this a public definition?
+				pub\s*(?:struct|enum)\s*
+			)
+			# munch any comments/attributes between this and our name (for macros)
+			(:?\n?\s*(:?\/\/|\#)[^\n]*)*
+			# finally grab the word (plus any lifetime definition)
+			\s*(\w*(:?<'a>)?)"#,
+		)
+		.unwrap();
+	let mut searcher = SearcherBuilder::new().line_number(false).multi_line(true).build();
+	let entries = glob(dir).unwrap();
+	for entry in entries.filter_map(|p| p.ok()) {
+		path_callback(&entry);
+		let context = NodeMatcher { matcher: &matcher, matches };
+		searcher.search_path(&matcher, entry, context).unwrap();
+	}
+}


### PR DESCRIPTION
The build script was getting a little unwieldy because:

- It was all in one file with not much separation going on.
- It has a big old chunk of grep code which was intermingled among debug lines and cargo build lines.
- It did a bunch of string manipulation to get the matches from grep into something resembling idents.
- It threw those strings into a bunch of other strings, to write out as Rust, rather than using something a little more robust like Syn.

This is an attempt to start to fix some of those issues and clean it up a bit:

- I've split a major chunk into a separate library, which means it can be reused, as well as better tested/modified/separated further. But also...
- The grep code is now separated (in the library) from the cargo build code, and so cargo logs for example aren't quite so tangled within it all.
- The new library outputs `syn::Type`s rather than strings, so there is a much better sense that the matches actually parse to valid Rust.
- The build.rs now uses syn/quote to generate Rust code, which gives me a lot more confidence that it will generate syntactically valid rust. Also it's much easier to read to boot.

Overall perhaps not _less_ code, but definitely cleaner code.