### PR TITLE
css_parse/css_ast: add vis + enum type for function_set!

### DIFF
--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -41,13 +41,15 @@ impl<'a> AtRule<'a> for DocumentRule<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct DocumentMatcherList<'a>(pub CommaSeparated<'a, DocumentMatcher>);
 
-function_set!(DocumentMatcherFunctionKeyword {
-	Url: "url",
-	UrlPrefix: "url-prefix",
-	Domain: "domain",
-	MediaDocument: "media-document",
-	Regexp: "regexp",
-});
+function_set!(
+	pub enum DocumentMatcherFunctionKeyword {
+		Url: "url",
+		UrlPrefix: "url-prefix",
+		Domain: "domain",
+		MediaDocument: "media-document",
+		Regexp: "regexp",
+	}
+);
 
 #[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -171,7 +171,13 @@ pub enum SupportsFeature<'a> {
 	Property(T!['('], Property<'a>, Option<T![')']>),
 }
 
-function_set!(SupportsFeatureKeyword { FontTech: "font-tech", FontFormat: "font-format", Selector: "selector" });
+function_set!(
+	pub enum SupportsFeatureKeyword {
+		FontTech: "font-tech",
+		FontFormat: "font-format",
+		Selector: "selector"
+	}
+);
 
 impl<'a> Parse<'a> for SupportsFeature<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {

--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -44,9 +44,11 @@ apply_functional_pseudo_class!(define_functional_pseudo_class);
 
 macro_rules! define_functional_pseudo_class_keyword {
 	( $($ident: ident: $str: tt: $ty: ty: $val_ty: ty $(,)*)+ ) => {
-		function_set!(FunctionalPseudoClassKeyword {
-			$($ident: $str,)+
-		});
+		function_set!(
+			pub enum FunctionalPseudoClassKeyword {
+				$($ident: $str,)+
+			}
+		);
 	}
 }
 apply_functional_pseudo_class!(define_functional_pseudo_class_keyword);

--- a/crates/css_ast/src/selector/moz.rs
+++ b/crates/css_ast/src/selector/moz.rs
@@ -104,17 +104,19 @@ pub enum MozFunctionalPseudoElement<'a> {
 	TreeTwisty(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
 }
 
-function_set!(MozFunctionalPseudoElementKeyword {
-	TreeCell: "-moz-tree-cell",
-	TreeCellText: "-moz-tree-cell-text",
-	TreeCheckbox: "-moz-tree-checkbox",
-	TreeColumn: "-moz-tree-column",
-	TreeImage: "-moz-tree-image",
-	TreeLine: "-moz-tree-line",
-	TreeRow: "-moz-tree-row",
-	TreeSeparator: "-moz-tree-separator",
-	TreeTwisty: "-moz-tree-twisty",
-});
+function_set!(
+	pub enum MozFunctionalPseudoElementKeyword {
+		TreeCell: "-moz-tree-cell",
+		TreeCellText: "-moz-tree-cell-text",
+		TreeCheckbox: "-moz-tree-checkbox",
+		TreeColumn: "-moz-tree-column",
+		TreeImage: "-moz-tree-image",
+		TreeLine: "-moz-tree-line",
+		TreeRow: "-moz-tree-row",
+		TreeSeparator: "-moz-tree-separator",
+		TreeTwisty: "-moz-tree-twisty",
+	}
+);
 
 impl<'a> Parse<'a> for MozFunctionalPseudoElement<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {

--- a/crates/css_ast/src/types/color/color_function.rs
+++ b/crates/css_ast/src/types/color/color_function.rs
@@ -3,18 +3,20 @@ use css_lexer::Cursor;
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
 use csskit_derives::{IntoCursor, ToCursors, ToSpan};
 
-function_set!(ColorFunctionName {
-	Color: "color",
-	Rgb: "rgb",
-	Rgba: "rgba",
-	Hsl: "hsl",
-	Hsla: "hsla",
-	Hwb: "hwb",
-	Lab: "lab",
-	Lch: "lch",
-	Oklab: "oklab",
-	Oklch: "oklch",
-});
+function_set!(
+	pub enum ColorFunctionName {
+		Color: "color",
+		Rgb: "rgb",
+		Rgba: "rgba",
+		Hsl: "hsl",
+		Hsla: "hsla",
+		Hwb: "hwb",
+		Lab: "lab",
+		Lch: "lch",
+		Oklab: "oklab",
+		Oklch: "oklch",
+	}
+);
 
 #[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -13,15 +13,32 @@ use crate::types::{Attr, Counter, Image, LeaderType, Quote, Target};
 pub struct ContentList<'a>(pub Vec<'a, ContentListItem<'a>>);
 
 keyword_set!(pub struct ContentsKeyword "contents");
-keyword_set!(pub enum StringFunctionKeywords { First: "first", Start: "start", Last: "last", FirstExcept: "first-except" });
-keyword_set!(pub enum ContentFunctionKeywords {
-	Text: "text",
-	Before: "before",
-	After: "after",
-	FirstLetter: "first-letter",
-	Marker: "marker"
-});
-function_set!(ContentListFunctionNames { String: "string", Leader: "leader", Content: "content" });
+keyword_set!(
+	pub enum StringFunctionKeywords {
+		First: "first",
+		Start: "start",
+		Last: "last",
+		FirstExcept: "first-except"
+	}
+);
+
+keyword_set!(
+	pub enum ContentFunctionKeywords {
+		Text: "text",
+		Before: "before",
+		After: "after",
+		FirstLetter: "first-letter",
+		Marker: "marker"
+	}
+);
+
+function_set!(
+	pub enum ContentListFunctionNames {
+		String: "string",
+		Leader: "leader",
+		Content: "content"
+	}
+);
 
 #[derive(ToSpan, ToCursors, Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/types/counter_functions.rs
+++ b/crates/css_ast/src/types/counter_functions.rs
@@ -4,7 +4,12 @@ use csskit_derives::{ToCursors, ToSpan};
 
 use crate::types::CounterStyle;
 
-function_set!(CounterFunctionNames { Counter: "counter", Counters: "counters" });
+function_set!(
+	pub enum CounterFunctionNames {
+		Counter: "counter",
+		Counters: "counters"
+	}
+);
 
 // https://drafts.csswg.org/css-lists-3/#counter-functions
 // <counter> = <counter()> | <counters()>

--- a/crates/css_ast/src/types/easing_function.rs
+++ b/crates/css_ast/src/types/easing_function.rs
@@ -5,26 +5,36 @@ use csskit_derives::{ToCursors, ToSpan};
 
 use crate::CSSInt;
 
-function_set!(EasingFunctionKeyword { Linear: "linear", CubicBezier: "cubic-bezier", Steps: "steps" });
+function_set!(
+	pub enum EasingFunctionKeyword {
+		Linear: "linear",
+		CubicBezier: "cubic-bezier",
+		Steps: "steps"
+	}
+);
 
-keyword_set!(pub enum EasingKeyword {
-	Linear: "linear",
-	Ease: "ease",
-	EaseIn: "ease-in",
-	EaseOut: "ease-out",
-	EaseInOut: "ease-in-out",
-	StepStart: "step-start",
-	StepEnd: "step-end",
-});
+keyword_set!(
+	pub enum EasingKeyword {
+		Linear: "linear",
+		Ease: "ease",
+		EaseIn: "ease-in",
+		EaseOut: "ease-out",
+		EaseInOut: "ease-in-out",
+		StepStart: "step-start",
+		StepEnd: "step-end",
+	}
+);
 
-keyword_set!(pub enum StepPosition {
-	JumpStart: "jump-start",
-	JumpEnd: "jump-end",
-	JumpNone: "jump-none",
-	JumpBoth: "jump-both",
-	Start: "start",
-	End: "end",
-});
+keyword_set!(
+	pub enum StepPosition {
+		JumpStart: "jump-start",
+		JumpEnd: "jump-end",
+		JumpNone: "jump-none",
+		JumpBoth: "jump-both",
+		Start: "start",
+		End: "end",
+	}
+);
 
 // https://drafts.csswg.org/css-easing-2/#typedef-easing-function
 // <easing-function> = <linear-easing-function>

--- a/crates/css_ast/src/types/gradient.rs
+++ b/crates/css_ast/src/types/gradient.rs
@@ -10,12 +10,14 @@ use crate::{
 
 use super::Color;
 
-function_set!(GradientFunctionName {
-	LinearGradient: "linear-gradient",
-	RadialGradient: "radial-gradient",
-	RepeatingLinearGradient: "repeating-linear-gradient",
-	RepeatingRadialGradient: "repeating-radial-gradient",
-});
+function_set!(
+	pub enum GradientFunctionName {
+		LinearGradient: "linear-gradient",
+		RadialGradient: "radial-gradient",
+		RepeatingLinearGradient: "repeating-linear-gradient",
+		RepeatingRadialGradient: "repeating-radial-gradient",
+	}
+);
 
 // https://drafts.csswg.org/css-images-3/#typedef-gradient
 #[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/types/target_functions.rs
+++ b/crates/css_ast/src/types/target_functions.rs
@@ -4,8 +4,21 @@ use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 use crate::types::CounterStyle;
 
-function_set!(TargetFunctionNames { Counter: "target-counter", Counters: "target-counters", Text: "target-text" });
-keyword_set!(pub enum TextFunctionContent { Content: "content", Before: "before", After: "after", FirstLetter: "first-letter" });
+function_set!(
+	pub enum TargetFunctionNames {
+		Counter: "target-counter",
+		Counters: "target-counters",
+		Text: "target-text"
+});
+
+keyword_set!(
+	pub enum TextFunctionContent {
+		Content: "content",
+		Before: "before",
+		After: "after",
+		FirstLetter: "first-letter"
+	}
+);
 
 #[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/types/transform_function.rs
+++ b/crates/css_ast/src/types/transform_function.rs
@@ -14,19 +14,21 @@ enum AngleZeroKind {
 	Zero(T![Number]),
 }
 
-function_set!(TransformFunctionName {
-	Matrix: "matrix",
-	Translate: "translate",
-	TranslateX: "translatex",
-	TranslateY: "translatey",
-	Scale: "scale",
-	ScaleX: "scalex",
-	ScaleY: "scaley",
-	Rotate: "rotate",
-	Skew: "skew",
-	SkewX: "skewx",
-	SkewY: "skewy",
-});
+function_set!(
+	pub enum TransformFunctionName {
+		Matrix: "matrix",
+		Translate: "translate",
+		TranslateX: "translatex",
+		TranslateY: "translatey",
+		Scale: "scale",
+		ScaleX: "scalex",
+		ScaleY: "scaley",
+		Rotate: "rotate",
+		Skew: "skew",
+		SkewX: "skewx",
+		SkewY: "skewy",
+	}
+);
 
 // https://drafts.csswg.org/css-transforms-1/#two-d-transform-functions
 #[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -377,7 +377,7 @@ macro_rules! keyword_set {
 /// use bumpalo::Bump;
 /// function_set!(
 ///   /// Some docs on this type...
-///   Functions {
+///   pub enum Functions {
 ///     Foo: "foo",
 ///     Bar: "bar",
 ///     Baz: "baz"
@@ -397,11 +397,11 @@ macro_rules! keyword_set {
 /// ```
 #[macro_export]
 macro_rules! function_set {
-	($(#[$meta:meta])*$name: ident { $( $variant: ident: $variant_str: tt$(,)?)+ }) => {
+	($(#[$meta:meta])* $vis:vis enum $name: ident { $( $variant: ident: $variant_str: tt$(,)?)+ }) => {
 		$(#[$meta])*
 		#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-		pub enum $name {
+		$vis enum $name {
 			$($variant(::css_lexer::Cursor)),+
 		}
 		impl<'a> $crate::Peek<'a> for $name {


### PR DESCRIPTION
Just like #198 we should clean up `function_set!` so the visibility and data structure type are part of the invocation, rather than magical.