### PR TITLE
css_parse/css_ast: add vis + enum type for atkeyword_set!

### DIFF
--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -185,24 +185,26 @@ impl<'a> AtRule<'a> for MarginRule<'a> {
 	type Block = MarginRuleBlock<'a>;
 }
 
-atkeyword_set!(MarginRuleKeyword {
-	TopLeftCorner: "top-left-corner",
-	TopLeft: "top-left",
-	TopCenter: "top-center",
-	TopRight: "top-right",
-	TopRightCorner: "top-right-corner",
-	RightTop: "right-top",
-	RightMiddle: "right-middle",
-	RightBottom: "right-bottom",
-	BottomRightCorner: "bottom-right-corner",
-	BottomRight: "bottom-right",
-	BottomCenter: "bottom-center",
-	BottomLeft: "bottom-left",
-	BottomLeftCorner: "bottom-left-corner",
-	LeftBottom: "left-bottom",
-	LeftMiddle: "left-middle",
-	LeftTop: "left-top"
-});
+atkeyword_set!(
+	pub enum MarginRuleKeyword {
+		TopLeftCorner: "top-left-corner",
+		TopLeft: "top-left",
+		TopCenter: "top-center",
+		TopRight: "top-right",
+		TopRightCorner: "top-right-corner",
+		RightTop: "right-top",
+		RightMiddle: "right-middle",
+		RightBottom: "right-bottom",
+		BottomRightCorner: "bottom-right-corner",
+		BottomRight: "bottom-right",
+		BottomCenter: "bottom-center",
+		BottomLeft: "bottom-left",
+		BottomLeftCorner: "bottom-left-corner",
+		LeftBottom: "left-bottom",
+		LeftMiddle: "left-middle",
+		LeftTop: "left-top"
+	}
+);
 
 impl<'a> Parse<'a> for MarginRule<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -465,7 +465,7 @@ macro_rules! function_set {
 /// use bumpalo::Bump;
 /// atkeyword_set!(
 ///   /// Some docs on this type...
-///   Keywords {
+///   pub enum Keywords {
 ///     Foo: "foo",
 ///     Bar: "bar",
 ///     Baz: "baz"
@@ -485,11 +485,11 @@ macro_rules! function_set {
 /// ```
 #[macro_export]
 macro_rules! atkeyword_set {
-	($(#[$meta:meta])*$name: ident { $( $variant: ident: $variant_str: tt$(,)?)+ }) => {
+	($(#[$meta:meta])* $vis:vis enum $name: ident { $( $variant: ident: $variant_str: tt$(,)?)+ }) => {
 		$(#[$meta])*
 		#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-		pub enum $name {
+		$vis enum $name {
 			$($variant(::css_lexer::Cursor)),+
 		}
 		impl<'a> $crate::Peek<'a> for $name {


### PR DESCRIPTION
Just like #198 and #204 we should clean up atkeyword_set! so the visibility and data structure type are part of the invocation, rather than magical.