### PR TITLE
css_parse/css_ast: make function/atkeyword newtype over their respective token macros

### DIFF
--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -1,8 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{
-	AtRule, Build, Parse, Parser, Result as ParserResult, RuleList, T, diagnostics, function_set,
-	syntax::CommaSeparated,
+	AtRule, Parse, Parser, Result as ParserResult, RuleList, T, diagnostics, function_set, syntax::CommaSeparated,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -68,31 +67,28 @@ impl<'a> Parse<'a> for DocumentMatcher {
 		if p.peek::<T![Url]>() {
 			Ok(Self::Url(p.parse::<T![Url]>()?))
 		} else {
-			let keyword = p.parse::<DocumentMatcherFunctionKeyword>()?;
-			let c = keyword.into();
-			let function = <T![Function]>::build(p, c);
-			match keyword {
-				DocumentMatcherFunctionKeyword::Url(_) => {
+			match p.parse::<DocumentMatcherFunctionKeyword>()? {
+				DocumentMatcherFunctionKeyword::Url(function) => {
 					let string = p.parse::<T![String]>()?;
 					let close = p.parse::<T![')']>()?;
 					Ok(Self::UrlFunction(function, string, close))
 				}
-				DocumentMatcherFunctionKeyword::UrlPrefix(_) => {
+				DocumentMatcherFunctionKeyword::UrlPrefix(function) => {
 					let string = p.parse::<T![String]>()?;
 					let close = p.parse::<T![')']>()?;
 					Ok(Self::UrlPrefix(function, string, close))
 				}
-				DocumentMatcherFunctionKeyword::Domain(_) => {
+				DocumentMatcherFunctionKeyword::Domain(function) => {
 					let string = p.parse::<T![String]>()?;
 					let close = p.parse::<T![')']>()?;
 					Ok(Self::UrlPrefix(function, string, close))
 				}
-				DocumentMatcherFunctionKeyword::MediaDocument(_) => {
+				DocumentMatcherFunctionKeyword::MediaDocument(function) => {
 					let string = p.parse::<T![String]>()?;
 					let close = p.parse::<T![')']>()?;
 					Ok(Self::UrlPrefix(function, string, close))
 				}
-				DocumentMatcherFunctionKeyword::Regexp(_) => {
+				DocumentMatcherFunctionKeyword::Regexp(function) => {
 					let string = p.parse::<T![String]>()?;
 					let close = p.parse::<T![')']>()?;
 					Ok(Self::UrlPrefix(function, string, close))

--- a/crates/css_ast/src/selector/functional_pseudo_element.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_element.rs
@@ -1,5 +1,5 @@
 use bumpalo::collections::Vec;
-use css_parse::{Build, Parse, Parser, Result as ParserResult, T, function_set};
+use css_parse::{Parse, Parser, Result as ParserResult, T, function_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 use super::CompoundSelector;
@@ -28,14 +28,13 @@ impl<'a> Parse<'a> for FunctionalPseudoElement<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		let colons = p.parse::<T![::]>()?;
 		let kw = p.parse::<FunctionKeywords>()?;
-		let function = <T![Function]>::build(p, kw.into());
 		match kw {
-			FunctionKeywords::Highlight(_) => {
+			FunctionKeywords::Highlight(function) => {
 				let value = p.parse::<T![Ident]>()?;
 				let close = p.parse_if_peek::<T![')']>()?;
 				Ok(Self::Highlight(HighlightPseudoElement { colons, function, value, close }))
 			}
-			FunctionKeywords::Part(_) => {
+			FunctionKeywords::Part(function) => {
 				let mut value = Vec::new_in(p.bump());
 				loop {
 					if p.peek::<T![')']>() {
@@ -46,7 +45,7 @@ impl<'a> Parse<'a> for FunctionalPseudoElement<'a> {
 				let close = p.parse_if_peek::<T![')']>()?;
 				Ok(Self::Part(PartPseudoElement { colons, function, value, close }))
 			}
-			FunctionKeywords::Slotted(_) => {
+			FunctionKeywords::Slotted(function) => {
 				let value = p.parse::<CompoundSelector>()?;
 				let close = p.parse_if_peek::<T![')']>()?;
 				Ok(Self::Slotted(SlottedPseudoElement { colons, function, value, close }))

--- a/crates/css_ast/src/types/color/color_function.rs
+++ b/crates/css_ast/src/types/color/color_function.rs
@@ -304,46 +304,46 @@ impl<'a> Parse<'a> for ColorFunction {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		let function = ColorFunctionName::parse(p)?;
 		match function {
-			ColorFunctionName::Color(cursor) => {
+			ColorFunctionName::Color(function) => {
 				let space = p.parse::<ColorSpace>()?;
 				let (a, b, c, d, e) = Self::parse_three_channel(p)?;
-				Ok(Self::Color(<T![Function]>::build(p, cursor), space, a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Color(function, space, a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
 			}
-			ColorFunctionName::Rgb(cursor) => {
+			ColorFunctionName::Rgb(function) => {
 				let (a, b, c, d, e, f, g, h) = Self::parse_rgb(p)?;
-				Ok(Self::Rgb(<T![Function]>::build(p, cursor), a, b, c, d, e, f, g, h, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Rgb(function, a, b, c, d, e, f, g, h, p.parse_if_peek::<T![')']>()?))
 			}
-			ColorFunctionName::Rgba(cursor) => {
+			ColorFunctionName::Rgba(function) => {
 				let (a, b, c, d, e, f, g, h) = Self::parse_rgb(p)?;
-				Ok(Self::Rgba(<T![Function]>::build(p, cursor), a, b, c, d, e, f, g, h, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Rgba(function, a, b, c, d, e, f, g, h, p.parse_if_peek::<T![')']>()?))
 			}
-			ColorFunctionName::Hsl(cursor) => {
+			ColorFunctionName::Hsl(function) => {
 				let (a, b, c, d, e, f, g, h) = Self::parse_hsl(p)?;
-				Ok(Self::Hsl(<T![Function]>::build(p, cursor), a, b, c, d, e, f, g, h, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Hsl(function, a, b, c, d, e, f, g, h, p.parse_if_peek::<T![')']>()?))
 			}
-			ColorFunctionName::Hsla(cursor) => {
+			ColorFunctionName::Hsla(function) => {
 				let (a, b, c, d, e, f, g, h) = Self::parse_hsl(p)?;
-				Ok(Self::Hsla(<T![Function]>::build(p, cursor), a, b, c, d, e, f, g, h, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Hsla(function, a, b, c, d, e, f, g, h, p.parse_if_peek::<T![')']>()?))
 			}
-			ColorFunctionName::Hwb(cursor) => {
+			ColorFunctionName::Hwb(function) => {
 				let (a, b, c, d, e) = Self::parse_hwb(p)?;
-				Ok(Self::Hwb(<T![Function]>::build(p, cursor), a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Hwb(function, a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
 			}
-			ColorFunctionName::Lab(cursor) => {
+			ColorFunctionName::Lab(function) => {
 				let (a, b, c, d, e) = Self::parse_three_channel(p)?;
-				Ok(Self::Lab(<T![Function]>::build(p, cursor), a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Lab(function, a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
 			}
-			ColorFunctionName::Lch(cursor) => {
+			ColorFunctionName::Lch(function) => {
 				let (a, b, c, d, e) = Self::parse_lch(p)?;
-				Ok(Self::Lch(<T![Function]>::build(p, cursor), a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Lch(function, a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
 			}
-			ColorFunctionName::Oklab(cursor) => {
+			ColorFunctionName::Oklab(function) => {
 				let (a, b, c, d, e) = Self::parse_three_channel(p)?;
-				Ok(Self::Oklab(<T![Function]>::build(p, cursor), a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Oklab(function, a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
 			}
-			ColorFunctionName::Oklch(cursor) => {
+			ColorFunctionName::Oklch(function) => {
 				let (a, b, c, d, e) = Self::parse_lch(p)?;
-				Ok(Self::Oklch(<T![Function]>::build(p, cursor), a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
+				Ok(Self::Oklch(function, a, b, c, d, e, p.parse_if_peek::<T![')']>()?))
 			}
 		}
 	}

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -92,29 +92,21 @@ impl<'a> Parse<'a> for ContentListItem<'a> {
 		}
 
 		match p.parse::<ContentListFunctionNames>()? {
-			ContentListFunctionNames::String(cursor) => {
-				return Ok(Self::StringFunction(
-					<T![Function]>::build(p, cursor),
-					p.parse::<T![Ident]>()?,
-					p.parse_if_peek::<T![,]>()?,
-					p.parse_if_peek::<StringFunctionKeywords>()?,
-					p.parse_if_peek::<T![')']>()?,
-				));
+			ContentListFunctionNames::String(function) => Ok(Self::StringFunction(
+				function,
+				p.parse::<T![Ident]>()?,
+				p.parse_if_peek::<T![,]>()?,
+				p.parse_if_peek::<StringFunctionKeywords>()?,
+				p.parse_if_peek::<T![')']>()?,
+			)),
+			ContentListFunctionNames::Leader(function) => {
+				Ok(Self::LeaderFunction(function, p.parse::<LeaderType>()?, p.parse_if_peek::<T![')']>()?))
 			}
-			ContentListFunctionNames::Leader(cursor) => {
-				return Ok(Self::LeaderFunction(
-					<T![Function]>::build(p, cursor),
-					p.parse::<LeaderType>()?,
-					p.parse_if_peek::<T![')']>()?,
-				));
-			}
-			ContentListFunctionNames::Content(cursor) => {
-				return Ok(Self::ContentFunction(
-					<T![Function]>::build(p, cursor),
-					p.parse_if_peek::<ContentFunctionKeywords>()?,
-					p.parse_if_peek::<T![')']>()?,
-				));
-			}
+			ContentListFunctionNames::Content(function) => Ok(Self::ContentFunction(
+				function,
+				p.parse_if_peek::<ContentFunctionKeywords>()?,
+				p.parse_if_peek::<T![')']>()?,
+			)),
 		}
 	}
 }

--- a/crates/css_ast/src/types/counter_functions.rs
+++ b/crates/css_ast/src/types/counter_functions.rs
@@ -1,5 +1,5 @@
 use css_lexer::Cursor;
-use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set};
+use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set};
 use csskit_derives::{ToCursors, ToSpan};
 
 use crate::types::CounterStyle;
@@ -50,15 +50,15 @@ impl<'a> Counter<'a> {
 impl<'a> Parse<'a> for Counter<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		match p.parse::<CounterFunctionNames>()? {
-			CounterFunctionNames::Counter(c) => Ok(Self::Counter(
-				<T![Function]>::build(p, c),
+			CounterFunctionNames::Counter(function) => Ok(Self::Counter(
+				function,
 				Self::parse_counter_name(p)?,
 				p.parse_if_peek::<T![,]>()?,
 				p.parse_if_peek::<CounterStyle<'a>>()?,
 				p.parse_if_peek::<T![')']>()?,
 			)),
-			CounterFunctionNames::Counters(c) => Ok(Self::Counters(
-				<T![Function]>::build(p, c),
+			CounterFunctionNames::Counters(function) => Ok(Self::Counters(
+				function,
 				Self::parse_counter_name(p)?,
 				p.parse_if_peek::<T![,]>()?,
 				p.parse::<T![String]>()?,

--- a/crates/css_ast/src/types/target_functions.rs
+++ b/crates/css_ast/src/types/target_functions.rs
@@ -1,5 +1,5 @@
 use css_lexer::Cursor;
-use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
+use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 use crate::types::CounterStyle;
@@ -70,8 +70,8 @@ impl<'a> Peek<'a> for Target<'a> {
 impl<'a> Parse<'a> for Target<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		match p.parse::<TargetFunctionNames>()? {
-			TargetFunctionNames::Counter(c) => Ok(Self::Counter(
-				<T![Function]>::build(p, c),
+			TargetFunctionNames::Counter(function) => Ok(Self::Counter(
+				function,
 				p.parse::<TargetCounterKind>()?,
 				p.parse_if_peek::<T![,]>()?,
 				p.parse::<T![Ident]>()?,
@@ -79,8 +79,8 @@ impl<'a> Parse<'a> for Target<'a> {
 				p.parse_if_peek::<CounterStyle<'a>>()?,
 				p.parse_if_peek::<T![')']>()?,
 			)),
-			TargetFunctionNames::Counters(c) => Ok(Self::Counters(
-				<T![Function]>::build(p, c),
+			TargetFunctionNames::Counters(function) => Ok(Self::Counters(
+				function,
 				p.parse::<TargetCounterKind>()?,
 				p.parse_if_peek::<T![,]>()?,
 				p.parse::<T![Ident]>()?,
@@ -90,8 +90,8 @@ impl<'a> Parse<'a> for Target<'a> {
 				p.parse_if_peek::<CounterStyle<'a>>()?,
 				p.parse_if_peek::<T![')']>()?,
 			)),
-			TargetFunctionNames::Text(c) => Ok(Self::Text(
-				<T![Function]>::build(p, c),
+			TargetFunctionNames::Text(function) => Ok(Self::Text(
+				function,
 				p.parse::<TargetCounterKind>()?,
 				p.parse_if_peek::<T![,]>()?,
 				p.parse_if_peek::<TextFunctionContent>()?,

--- a/crates/css_ast/src/types/transform_function.rs
+++ b/crates/css_ast/src/types/transform_function.rs
@@ -1,15 +1,11 @@
-#![allow(warnings)]
-
 use crate::units::{Angle, LengthPercentage};
 use css_lexer::Cursor;
-use css_parse::{
-	Build, CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics, function_set,
-};
+use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, function_set};
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 #[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-enum AngleZeroKind {
+pub enum AngleZeroKind {
 	Angle(Angle),
 	Zero(T![Number]),
 }
@@ -92,8 +88,8 @@ impl<'a> Peek<'a> for TransformFunction {
 impl<'a> Parse<'a> for TransformFunction {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		match TransformFunctionName::parse(p)? {
-			TransformFunctionName::Matrix(cursor) => Ok(Self::Matrix(
-				<T![Function]>::build(p, cursor),
+			TransformFunctionName::Matrix(function) => Ok(Self::Matrix(
+				function,
 				p.parse::<T![Number]>()?,
 				p.parse_if_peek::<T![,]>()?,
 				p.parse::<T![Number]>()?,
@@ -107,62 +103,48 @@ impl<'a> Parse<'a> for TransformFunction {
 				p.parse::<T![Number]>()?,
 				p.parse_if_peek::<T![')']>()?,
 			)),
-			TransformFunctionName::Translate(cursor) => Ok(Self::Translate(
-				<T![Function]>::build(p, cursor),
+			TransformFunctionName::Translate(function) => Ok(Self::Translate(
+				function,
 				p.parse::<LengthPercentage>()?,
 				p.parse_if_peek::<T![,]>()?,
 				p.parse_if_peek::<LengthPercentage>()?,
 				p.parse_if_peek::<T![')']>()?,
 			)),
-			TransformFunctionName::TranslateX(cursor) => Ok(Self::TranslateX(
-				<T![Function]>::build(p, cursor),
-				p.parse::<LengthPercentage>()?,
-				p.parse_if_peek::<T![')']>()?,
-			)),
-			TransformFunctionName::TranslateY(cursor) => Ok(Self::TranslateY(
-				<T![Function]>::build(p, cursor),
-				p.parse::<LengthPercentage>()?,
-				p.parse_if_peek::<T![')']>()?,
-			)),
-			TransformFunctionName::Scale(cursor) => Ok(Self::Scale(
-				<T![Function]>::build(p, cursor),
+			TransformFunctionName::TranslateX(function) => {
+				Ok(Self::TranslateX(function, p.parse::<LengthPercentage>()?, p.parse_if_peek::<T![')']>()?))
+			}
+			TransformFunctionName::TranslateY(function) => {
+				Ok(Self::TranslateY(function, p.parse::<LengthPercentage>()?, p.parse_if_peek::<T![')']>()?))
+			}
+			TransformFunctionName::Scale(function) => Ok(Self::Scale(
+				function,
 				p.parse::<T![Number]>()?,
 				p.parse_if_peek::<T![,]>()?,
 				p.parse_if_peek::<T![Number]>()?,
 				p.parse_if_peek::<T![')']>()?,
 			)),
-			TransformFunctionName::ScaleY(cursor) => Ok(Self::ScaleY(
-				<T![Function]>::build(p, cursor),
-				p.parse::<T![Number]>()?,
-				p.parse_if_peek::<T![')']>()?,
-			)),
-			TransformFunctionName::ScaleX(cursor) => Ok(Self::ScaleX(
-				<T![Function]>::build(p, cursor),
-				p.parse::<T![Number]>()?,
-				p.parse_if_peek::<T![')']>()?,
-			)),
-			TransformFunctionName::Rotate(cursor) => Ok(Self::Rotate(
-				<T![Function]>::build(p, cursor),
-				p.parse::<AngleZeroKind>()?,
-				p.parse_if_peek::<T![')']>()?,
-			)),
-			TransformFunctionName::Skew(cursor) => Ok(Self::Skew(
-				<T![Function]>::build(p, cursor),
+			TransformFunctionName::ScaleY(function) => {
+				Ok(Self::ScaleY(function, p.parse::<T![Number]>()?, p.parse_if_peek::<T![')']>()?))
+			}
+			TransformFunctionName::ScaleX(function) => {
+				Ok(Self::ScaleX(function, p.parse::<T![Number]>()?, p.parse_if_peek::<T![')']>()?))
+			}
+			TransformFunctionName::Rotate(function) => {
+				Ok(Self::Rotate(function, p.parse::<AngleZeroKind>()?, p.parse_if_peek::<T![')']>()?))
+			}
+			TransformFunctionName::Skew(function) => Ok(Self::Skew(
+				function,
 				p.parse::<AngleZeroKind>()?,
 				p.parse_if_peek::<T![,]>()?,
 				p.parse_if_peek::<AngleZeroKind>()?,
 				p.parse_if_peek::<T![')']>()?,
 			)),
-			TransformFunctionName::SkewX(cursor) => Ok(Self::SkewX(
-				<T![Function]>::build(p, cursor),
-				p.parse::<AngleZeroKind>()?,
-				p.parse_if_peek::<T![')']>()?,
-			)),
-			TransformFunctionName::SkewY(cursor) => Ok(Self::SkewY(
-				<T![Function]>::build(p, cursor),
-				p.parse::<AngleZeroKind>()?,
-				p.parse_if_peek::<T![')']>()?,
-			)),
+			TransformFunctionName::SkewX(function) => {
+				Ok(Self::SkewX(function, p.parse::<AngleZeroKind>()?, p.parse_if_peek::<T![')']>()?))
+			}
+			TransformFunctionName::SkewY(function) => {
+				Ok(Self::SkewY(function, p.parse::<AngleZeroKind>()?, p.parse_if_peek::<T![')']>()?))
+			}
 		}
 	}
 }

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -298,6 +298,8 @@ macro_rules! keyword_set {
 		}
 		impl<'a> $crate::Build<'a> for $name {
 			fn build(p: &$crate::Parser<'a>, c: css_lexer::Cursor) -> Self {
+				use $crate::Peek;
+				debug_assert!(Self::peek(p, c));
 				let val = Self::MAP.get(&p.parse_str_lower(c)).unwrap();
 				match val {
 					$(Self::$variant(_) => Self::$variant(c),)+
@@ -361,6 +363,8 @@ macro_rules! keyword_set {
 
 		impl<'a> $crate::Build<'a> for $name {
 			fn build(p: &$crate::Parser<'a>, c: ::css_lexer::Cursor) -> Self {
+				use $crate::Peek;
+				debug_assert!(Self::peek(p, c));
 				Self(<$crate::T![Ident]>::build(p, c))
 			}
 		}
@@ -402,7 +406,7 @@ macro_rules! function_set {
 		#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		$vis enum $name {
-			$($variant(::css_lexer::Cursor)),+
+			$($variant($crate::token_macros::Function)),+
 		}
 		impl<'a> $crate::Peek<'a> for $name {
 			fn peek(p: &$crate::Parser<'a>, c: css_lexer::Cursor) -> bool {
@@ -411,15 +415,18 @@ macro_rules! function_set {
 		}
 		impl<'a> $crate::Build<'a> for $name {
 			fn build(p: &$crate::Parser<'a>, c: css_lexer::Cursor) -> Self {
+				use $crate::Peek;
+				debug_assert!(Self::peek(p, c));
 				let val = Self::MAP.get(p.parse_str_lower(c)).unwrap();
+				let function = $crate::token_macros::Function::build(p, c);
 				match val {
-					$(Self::$variant(_) => Self::$variant(c),)+
+					$(Self::$variant(_) => Self::$variant(function),)+
 				}
 			}
 		}
 		impl $name {
 			const MAP: phf::Map<&'static str, $name> = phf::phf_map! {
-				$($variant_str => $name::$variant(::css_lexer::Cursor::dummy(::css_lexer::Token::dummy(::css_lexer::Kind::Function)))),+
+				$($variant_str => $name::$variant($crate::token_macros::Function::dummy())),+
 			};
 		}
 
@@ -434,7 +441,7 @@ macro_rules! function_set {
 		impl From<$name> for css_lexer::Cursor {
 			fn from(value: $name) -> Self {
 				match value {
-					$($name::$variant(t) => t,)+
+					$($name::$variant(t) => t.into(),)+
 				}
 			}
 		}
@@ -448,7 +455,7 @@ macro_rules! function_set {
 		impl ::css_lexer::ToSpan for $name {
 			fn to_span(&self) -> ::css_lexer::Span {
 				match self {
-					$($name::$variant(t) => (t.span()),)+
+					$($name::$variant(t) => (t.to_span()),)+
 				}
 			}
 		}
@@ -490,7 +497,7 @@ macro_rules! atkeyword_set {
 		#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		$vis enum $name {
-			$($variant(::css_lexer::Cursor)),+
+			$($variant($crate::token_macros::AtKeyword)),+
 		}
 		impl<'a> $crate::Peek<'a> for $name {
 			fn peek(p: &$crate::Parser<'a>, c: css_lexer::Cursor) -> bool {
@@ -499,15 +506,18 @@ macro_rules! atkeyword_set {
 		}
 		impl<'a> $crate::Build<'a> for $name {
 			fn build(p: &$crate::Parser<'a>, c: css_lexer::Cursor) -> Self {
+				use $crate::Peek;
+				debug_assert!(Self::peek(p, c));
 				let val = Self::MAP.get(&p.parse_str_lower(c)).unwrap();
+				let at_keyword = $crate::token_macros::AtKeyword::build(p, c);
 				match val {
-					$(Self::$variant(_) => Self::$variant(c),)+
+					$(Self::$variant(_) => Self::$variant(at_keyword),)+
 				}
 			}
 		}
 		impl $name {
 			const MAP: phf::Map<&'static str, $name> = phf::phf_map! {
-					$($variant_str => $name::$variant(::css_lexer::Cursor::dummy(::css_lexer::Token::dummy(::css_lexer::Kind::AtKeyword)))),+
+					$($variant_str => $name::$variant($crate::token_macros::AtKeyword::dummy())),+
 			};
 		}
 
@@ -522,7 +532,7 @@ macro_rules! atkeyword_set {
 		impl From<$name> for css_lexer::Cursor {
 			fn from(value: $name) -> Self {
 				match value {
-					$($name::$variant(t) => t,)+
+					$($name::$variant(t) => t.into(),)+
 				}
 			}
 		}
@@ -536,7 +546,7 @@ macro_rules! atkeyword_set {
 		impl ::css_lexer::ToSpan for $name {
 			fn to_span(&self) -> ::css_lexer::Span {
 				match self {
-					$($name::$variant(t) => (t.span()),)+
+					$($name::$variant(t) => (t.to_span()),)+
 				}
 			}
 		}


### PR DESCRIPTION


function_set! and atkeyword_set! could be quite clunky to use because they wrap a Cursor, which means you're often unpacking the cursor, then building that back into a T![Function]/T![AtKeyword] respectively. This is a little pointless when the two macros could construct those types directly, and we could skip a step. So this change does that.

Now function_set! and atkeyword_set! both construct a type which wraps over their respective T! types, a lot of code has been refactored (simplified) to leverage the underlying values rather than rebuilding them.