### PR TITLE
css_parse/css_ast/csskit_proc_macro: make keyword_set newtype over T![Ident] token macro

### DIFF
--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -153,14 +153,13 @@ impl<'a> DeclarationValue<'a> for StyleValue<'a> {
 		if name.token().is_dashed_ident() {
 			return Ok(Self::Custom(p.parse::<Custom>()?));
 		}
-		if let Some(kw) = p.parse_if_peek::<CSSWideKeyword>()? {
-			match kw {
-				CSSWideKeyword::Initial(c) => return Ok(Self::Initial(<T![Ident]>::build(p, c))),
-				CSSWideKeyword::Inherit(c) => return Ok(Self::Inherit(<T![Ident]>::build(p, c))),
-				CSSWideKeyword::Unset(c) => return Ok(Self::Unset(<T![Ident]>::build(p, c))),
-				CSSWideKeyword::Revert(c) => return Ok(Self::Revert(<T![Ident]>::build(p, c))),
-				CSSWideKeyword::RevertLayer(c) => return Ok(Self::RevertLayer(<T![Ident]>::build(p, c))),
-			}
+		match p.parse_if_peek::<CSSWideKeyword>()? {
+			Some(CSSWideKeyword::Initial(ident)) => return Ok(Self::Initial(ident)),
+			Some(CSSWideKeyword::Inherit(ident)) => return Ok(Self::Inherit(ident)),
+			Some(CSSWideKeyword::Unset(ident)) => return Ok(Self::Unset(ident)),
+			Some(CSSWideKeyword::Revert(ident)) => return Ok(Self::Revert(ident)),
+			Some(CSSWideKeyword::RevertLayer(ident)) => return Ok(Self::RevertLayer(ident)),
+			None => {}
 		}
 		if p.peek::<Computed>() {
 			return p.parse::<Computed>().map(Self::Computed);

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{
-	AtRule, Build, DeclarationList, Parse, Parser, Peek, QualifiedRule, QualifiedRuleList, Result as ParserResult, T,
+	AtRule, DeclarationList, Parse, Parser, Peek, QualifiedRule, QualifiedRuleList, Result as ParserResult, T,
 	diagnostics, keyword_set,
 	syntax::{BadDeclaration, CommaSeparated},
 };
@@ -167,8 +167,8 @@ impl<'a> Parse<'a> for KeyframeSelector {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		if let Some(keyword) = p.parse_if_peek::<KeyframeSelectorKeyword>()? {
 			return match keyword {
-				KeyframeSelectorKeyword::From(c) => Ok(Self::From(<T![Ident]>::build(p, c))),
-				KeyframeSelectorKeyword::To(c) => Ok(Self::To(<T![Ident]>::build(p, c))),
+				KeyframeSelectorKeyword::From(ident) => Ok(Self::From(ident)),
+				KeyframeSelectorKeyword::To(ident) => Ok(Self::To(ident)),
 			};
 		}
 		let percent = p.parse::<T![Dimension::%]>()?;

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -131,8 +131,8 @@ impl PositionSingleValue {
 	#[inline]
 	fn to_horizontal_keyword(self) -> Option<PositionHorizontalKeyword> {
 		match self {
-			Self::Left(t) => Some(PositionHorizontalKeyword::Left(t.into())),
-			Self::Right(t) => Some(PositionHorizontalKeyword::Right(t.into())),
+			Self::Left(t) => Some(PositionHorizontalKeyword::Left(t)),
+			Self::Right(t) => Some(PositionHorizontalKeyword::Right(t)),
 			_ => None,
 		}
 	}
@@ -140,8 +140,8 @@ impl PositionSingleValue {
 	#[inline]
 	fn to_vertical_keyword(self) -> Option<PositionVerticalKeyword> {
 		match self {
-			Self::Top(t) => Some(PositionVerticalKeyword::Top(t.into())),
-			Self::Bottom(t) => Some(PositionVerticalKeyword::Bottom(t.into())),
+			Self::Top(t) => Some(PositionVerticalKeyword::Top(t)),
+			Self::Bottom(t) => Some(PositionVerticalKeyword::Bottom(t)),
 			_ => None,
 		}
 	}

--- a/crates/css_parse/src/traits/lists/feature_condition_list.rs
+++ b/crates/css_parse/src/traits/lists/feature_condition_list.rs
@@ -1,7 +1,13 @@
 use crate::{Build, Parse, Parser, Peek, Result, diagnostics, keyword_set};
 use bumpalo::collections::Vec;
 
-keyword_set!(pub enum ConditionKeyword { And: "and", Not: "not", Or: "or" });
+keyword_set!(
+	pub enum ConditionKeyword {
+		And: "and",
+		Not: "not",
+		Or: "or",
+	}
+);
 
 /// This trait can be used for AST nodes representing a list of "Feature Conditions". This is an amalgamation of
 /// [Supports Conditions][1], [Media Conditions][2], and [Container Queries][3]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
@@ -30,13 +30,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Auto(c) => {
-                    return Ok(Self::Auto(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Auto(ident)) => {
+                return Ok(Self::Auto(ident));
             }
+            None => {}
         }
         let combo0 = p.parse::<crate::Length>()?;
         let combo1 = p.parse_if_peek::<crate::Length>()?;

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
@@ -31,13 +31,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Foo(c) => {
-                    return Ok(Self::Foo(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Foo(ident)) => {
+                return Ok(Self::Foo(ident));
             }
+            None => {}
         }
         let combo0 = p.parse_if_peek::<crate::Color>()?;
         let combo1 = p.parse_if_peek::<crate::Color>()?;

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
@@ -42,25 +42,43 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         while val.foo.is_none() || val.bar.is_none() || val.baz.is_none() {
             let c = p.peek_n(1);
             match p.parse_if_peek::<FooKeywords>()? {
-                Some(FooKeywords::Foo(c)) => {
+                Some(FooKeywords::Foo(ident)) => {
                     if val.foo.is_some() {
-                        Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+                        use ::css_lexer::ToSpan;
+                        Err(
+                            ::css_parse::diagnostics::Unexpected(
+                                ident.into(),
+                                c.to_span(),
+                            ),
+                        )?
                     }
-                    val.foo = Some(<::css_parse::T![Ident]>::build(p, c));
+                    val.foo = Some(ident);
                     continue;
                 }
-                Some(FooKeywords::Bar(c)) => {
+                Some(FooKeywords::Bar(ident)) => {
                     if val.bar.is_some() {
-                        Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+                        use ::css_lexer::ToSpan;
+                        Err(
+                            ::css_parse::diagnostics::Unexpected(
+                                ident.into(),
+                                c.to_span(),
+                            ),
+                        )?
                     }
-                    val.bar = Some(<::css_parse::T![Ident]>::build(p, c));
+                    val.bar = Some(ident);
                     continue;
                 }
-                Some(FooKeywords::Baz(c)) => {
+                Some(FooKeywords::Baz(ident)) => {
                     if val.baz.is_some() {
-                        Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+                        use ::css_lexer::ToSpan;
+                        Err(
+                            ::css_parse::diagnostics::Unexpected(
+                                ident.into(),
+                                c.to_span(),
+                            ),
+                        )?
                     }
-                    val.baz = Some(<::css_parse::T![Ident]>::build(p, c));
+                    val.baz = Some(ident);
                     continue;
                 }
                 None => {}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
@@ -31,13 +31,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Foo(c) => {
-                    return Ok(Self::Foo(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Foo(ident)) => {
+                return Ok(Self::Foo(ident));
             }
+            None => {}
         }
         let combo0 = p.parse_if_peek::<crate::Color>()?;
         let combo1 = {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
@@ -35,11 +35,17 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         while val.foo.is_none() || val.bar.is_none() {
             let c = p.peek_n(1);
             match p.parse_if_peek::<FooKeywords>()? {
-                Some(FooKeywords::Foo(c)) => {
+                Some(FooKeywords::Foo(ident)) => {
                     if val.foo.is_some() {
-                        Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+                        use ::css_lexer::ToSpan;
+                        Err(
+                            ::css_parse::diagnostics::Unexpected(
+                                ident.into(),
+                                c.to_span(),
+                            ),
+                        )?
                     }
-                    val.foo = Some(<::css_parse::T![Ident]>::build(p, c));
+                    val.foo = Some(ident);
                     continue;
                 }
                 None => {}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
@@ -30,13 +30,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Foo(c) => {
-                    return Ok(Self::Foo(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Foo(ident)) => {
+                return Ok(Self::Foo(ident));
             }
+            None => {}
         }
         let combo0 = {
             let ident = p.parse::<::css_parse::T![Ident]>()?;

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -30,14 +30,12 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::None(c) => {
-                    return Ok(Self::None(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::None(ident)) => {
+                return Ok(Self::None(ident));
             }
-        }
+            None => {}
+        };
         Ok(Self::CalcSizeFunction(p.parse::<crate::CalcSize>()?))
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -34,13 +34,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::FitContent(c) => {
-                    return Ok(Self::FitContent(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::FitContent(ident)) => {
+                return Ok(Self::FitContent(ident));
             }
+            None => {}
         }
         let function = p.parse::<::css_parse::T![Function]>()?;
         let c: css_lexer::Cursor = function.into();

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -34,13 +34,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Normal(c) => {
-                    return Ok(Self::Normal(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Normal(ident)) => {
+                return Ok(Self::Normal(ident));
             }
+            None => {}
         }
         let function = p.parse::<::css_parse::T![Function]>()?;
         let c: css_lexer::Cursor = function.into();

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
@@ -30,13 +30,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::None(c) => {
-                    return Ok(Self::None(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::None(ident)) => {
+                return Ok(Self::None(ident));
             }
+            None => {}
         }
         let start = p.offset();
         let ty = p.parse::<crate::LengthPercentage>()?;

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
@@ -30,14 +30,12 @@ impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Auto(c) => {
-                    return Ok(Self::Auto(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Auto(ident)) => {
+                return Ok(Self::Auto(ident));
             }
-        }
+            None => {}
+        };
         Ok(
             Self::AnimateableFeatures(
                 p.parse::<::css_parse::CommaSeparated<'a, crate::AnimateableFeature>>()?,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -30,13 +30,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Foo(c) => {
-                    return Ok(Self::Foo(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Foo(ident)) => {
+                return Ok(Self::Foo(ident));
             }
+            None => {}
         }
         let combo0 = {
             let ident = p.parse::<::css_parse::T![Ident]>()?;

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
@@ -30,13 +30,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Keyword(c) => {
-                    return Ok(Self::Keyword(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Keyword(ident)) => {
+                return Ok(Self::Keyword(ident));
             }
+            None => {}
         }
         if let Some(tk) = p.parse_if_peek::<crate::CSSInt>()? {
             match tk.into() {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
@@ -32,13 +32,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Keyword(c) => {
-                    return Ok(Self::Keyword(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Keyword(ident)) => {
+                return Ok(Self::Keyword(ident));
             }
+            None => {}
         }
         if let Some(tk) = p.parse_if_peek::<crate::CSSInt>()? {
             match tk.into() {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
@@ -30,15 +30,13 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::None(c) => {
-                    return Ok(Self::None(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::None(ident)) => {
+                return Ok(Self::None(ident));
             }
-        } else {
-            return Ok(Self::CustomIdent(p.parse::<::css_parse::T![Ident]>()?));
+            None => {
+                return Ok(Self::CustomIdent(p.parse::<::css_parse::T![Ident]>()?));
+            }
         }
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
@@ -35,22 +35,20 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Black(c) => {
-                    return Ok(Self::Black(<::css_parse::T![Ident]>::build(p, c)));
-                }
-                FooKeywords::White(c) => {
-                    return Ok(Self::White(<::css_parse::T![Ident]>::build(p, c)));
-                }
-                FooKeywords::LineThrough(c) => {
-                    return Ok(Self::LineThrough(<::css_parse::T![Ident]>::build(p, c)));
-                }
-                FooKeywords::Pink(c) => {
-                    return Ok(Self::Pink(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Black(ident)) => {
+                return Ok(Self::Black(ident));
             }
+            Some(FooKeywords::White(ident)) => {
+                return Ok(Self::White(ident));
+            }
+            Some(FooKeywords::LineThrough(ident)) => {
+                return Ok(Self::LineThrough(ident));
+            }
+            Some(FooKeywords::Pink(ident)) => {
+                return Ok(Self::Pink(ident));
+            }
+            None => {}
         }
         let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
         Err(::css_parse::diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
@@ -30,13 +30,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Auto(c) => {
-                    return Ok(Self::Auto(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Auto(ident)) => {
+                return Ok(Self::Auto(ident));
             }
+            None => {}
         }
         let combo0 = p.parse::<crate::Color>()?;
         let combo1 = p.parse::<crate::Color>()?;

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
@@ -30,13 +30,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo {
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::LineThrough(c) => {
-                    return Ok(Self::LineThrough(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::LineThrough(ident)) => {
+                return Ok(Self::LineThrough(ident));
             }
+            None => {}
         }
         let start = p.offset();
         let ty = p.parse::<crate::Length>()?;

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
@@ -30,13 +30,11 @@ impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        if let Some(keyword) = p.parse_if_peek::<FooKeywords>()? {
-            use ::css_parse::Build;
-            match keyword {
-                FooKeywords::Foo(c) => {
-                    return Ok(Self::Foo(<::css_parse::T![Ident]>::build(p, c)));
-                }
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Foo(ident)) => {
+                return Ok(Self::Foo(ident));
             }
+            None => {}
         }
         let mut items = ::bumpalo::collections::Vec::new_in(p.bump());
         loop {


### PR DESCRIPTION


Just like function/atkeyword (see #207 / 882b3a9) keyword_set! could also be quite clunky to use due it wrapping a Cursor instead of an ident.

This change makes keyword_set! construct a type which wraps over T![Ident] and subsequently a lot of code has been refactored (simplified) to leverage the underlying values rather than rebuilding them.