### PR TITLE
css_ast: support url()/src() functions in images

### DIFF
--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -1,42 +1,17 @@
-use css_lexer::{Cursor, ToSpan};
-use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
-use csskit_derives::{ToCursors, ToSpan};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
-use super::Gradient;
+use super::{Gradient, Url};
 
-// https://drafts.csswg.org/css-images-3/#typedef-image
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// <https://drafts.csswg.org/css-images-3/#typedef-image>
+///
+/// ```text
+/// <image> = <url> | <gradient>
+/// ```
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Image<'a> {
-	Url(T![Url]),
-	UrlFunction(T![Function], T![String], T![')']),
+	Url(Url),
 	Gradient(Gradient<'a>),
-}
-
-impl<'a> Peek<'a> for Image<'a> {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![Url]>::peek(p, c)
-			|| <Gradient>::peek(p, c)
-			|| (<T![Function]>::peek(p, c) && p.eq_ignore_ascii_case(c, "url"))
-	}
-}
-
-impl<'a> Parse<'a> for Image<'a> {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		if p.peek::<T![Url]>() {
-			Ok(Self::Url(p.parse::<T![Url]>()?))
-		} else if p.peek::<Gradient>() {
-			return Ok(Self::Gradient(p.parse::<Gradient>()?));
-		} else {
-			let func = p.parse::<T![Function]>()?;
-			if !p.eq_ignore_ascii_case(func.into(), "url") {
-				Err(diagnostics::UnexpectedFunction(p.parse_str(func.into()).into(), func.to_span()))?
-			}
-			let string = p.parse::<T![String]>()?;
-			let close = p.parse::<T![')']>()?;
-			return Ok(Self::UrlFunction(func, string, close));
-		}
-	}
 }
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/mod.rs
+++ b/crates/css_ast/src/types/mod.rs
@@ -77,6 +77,7 @@ mod transform_function;
 mod transform_list;
 mod transition_behavior_value;
 mod try_size;
+mod url;
 mod visual_box;
 
 pub use absolute_size::*;
@@ -158,4 +159,5 @@ pub use transform_function::*;
 pub use transform_list::*;
 pub use transition_behavior_value::*;
 pub use try_size::*;
+pub use url::*;
 pub use visual_box::*;

--- a/crates/css_ast/src/types/url.rs
+++ b/crates/css_ast/src/types/url.rs
@@ -1,0 +1,72 @@
+use css_lexer::Cursor;
+use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, function_set};
+use csskit_derives::{ToCursors, ToSpan};
+
+/// <https://drafts.csswg.org/css-values-4/#url-value>
+///
+/// ```text
+/// <url> = <url()> | <src()>
+/// <url()> = url( <string> <url-modifier>* ) | <url-token>
+/// <src()> = src( <string> <url-modifier>* )
+/// ```
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+pub enum Url {
+	Url(T![Url]),
+	UrlFunction(T![Function], T![String], T![')']),
+	SrcFunction(T![Function], T![String], T![')']),
+}
+
+function_set!(
+	pub enum UrlFunctionKeywords {
+		Url: "url",
+		Src: "src"
+	}
+);
+
+impl<'a> Peek<'a> for Url {
+	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
+		<T![Url]>::peek(p, c) || <UrlFunctionKeywords>::peek(p, c)
+	}
+}
+
+impl<'a> Parse<'a> for Url {
+	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
+		if let Some(url) = p.parse_if_peek::<T![Url]>()? {
+			return Ok(Self::Url(url));
+		}
+		let keyword = p.parse::<UrlFunctionKeywords>()?;
+		let c: Cursor = keyword.into();
+		let function = <T![Function]>::build(p, c);
+		match keyword {
+			UrlFunctionKeywords::Url(_) => {
+				let string = p.parse::<T![String]>()?;
+				let close = p.parse::<T![')']>()?;
+				Ok(Self::SrcFunction(function, string, close))
+			}
+			UrlFunctionKeywords::Src(_) => {
+				let string = p.parse::<T![String]>()?;
+				let close = p.parse::<T![')']>()?;
+				Ok(Self::SrcFunction(function, string, close))
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use css_parse::assert_parse;
+
+	#[test]
+	fn size_test() {
+		assert_eq!(std::mem::size_of::<Url>(), 40);
+	}
+
+	#[test]
+	fn test_writes() {
+		assert_parse!(Url, "url('foo')");
+		assert_parse!(Url, "url(\"foo\")");
+		assert_parse!(Url, "url(foo)");
+	}
+}


### PR DESCRIPTION
`<image>` has a syntax of `<url>`. `<url>` is a type, distinct to `<url-token>` (the token). The `<url>` type is one of `url()` or `src()`. This type also allows for either the `<url-token>` production or cases which do not satisfy that lex token, and instead lex as a Function.

This change introduces the new `<url>` type, and refactors `<image>` to use this type.