### PR TITLE
csskit_derives/css_ast: allow state/stop to be set in derive(parse)

### DIFF
--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -1,31 +1,22 @@
 use crate::values;
 use css_lexer::{Cursor, KindSet};
 use css_parse::{
-	Build, ComponentValues, DeclarationValue, Parse, Parser, Peek, Result as ParserResult, State, T, keyword_set,
+	Build, ComponentValues, DeclarationValue, Parser, Peek, Result as ParserResult, State, T, keyword_set,
 };
-use csskit_derives::{ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, ToCursors, ToSpan, Visitable};
 use std::{fmt::Debug, hash::Hash};
 
 // The build.rs generates a list of CSS properties from the value mods
 include!(concat!(env!("OUT_DIR"), "/css_apply_properties.rs"));
 
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[parse(state = State::Nested, stop = KindSet::RIGHT_CURLY_OR_SEMICOLON)]
 pub struct Custom<'a>(pub ComponentValues<'a>);
 
-impl<'a> Parse<'a> for Custom<'a> {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let state = p.set_state(State::Nested);
-		let stop = p.set_stop(KindSet::RIGHT_CURLY_OR_SEMICOLON);
-		let value = p.parse::<ComponentValues>();
-		p.set_state(state);
-		p.set_stop(stop);
-		Ok(Self(value?))
-	}
-}
-
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[parse(state = State::Nested, stop = KindSet::RIGHT_CURLY_OR_SEMICOLON)]
 pub struct Computed<'a>(pub ComponentValues<'a>);
 
 impl<'a> Peek<'a> for Computed<'a> {
@@ -47,31 +38,10 @@ impl<'a> Peek<'a> for Computed<'a> {
 	}
 }
 
-impl<'a> Parse<'a> for Computed<'a> {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let state = p.set_state(State::Nested);
-		let stop = p.set_stop(KindSet::RIGHT_CURLY_OR_SEMICOLON);
-		let values = p.parse::<ComponentValues>();
-		p.set_state(state);
-		p.set_stop(stop);
-		Ok(Self(values?))
-	}
-}
-
-#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[parse(state = State::Nested, stop = KindSet::RIGHT_CURLY_OR_SEMICOLON)]
 pub struct Unknown<'a>(pub ComponentValues<'a>);
-
-impl<'a> Parse<'a> for Unknown<'a> {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let state = p.set_state(State::Nested);
-		let stop = p.set_stop(KindSet::RIGHT_CURLY_OR_SEMICOLON);
-		let values = p.parse::<ComponentValues>();
-		p.set_state(state);
-		p.set_stop(stop);
-		Ok(Self(values?))
-	}
-}
 
 macro_rules! style_value {
 	( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $str: tt,)+ ) => {

--- a/crates/csskit_derives/src/into_cursor.rs
+++ b/crates/csskit_derives/src/into_cursor.rs
@@ -7,7 +7,7 @@ use crate::err;
 pub fn derive(input: DeriveInput) -> TokenStream {
 	let ident = input.ident;
 	let generics = &mut input.generics.clone();
-	let (impl_generics, _, _) = generics.split_for_impl();
+	let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 	let body = match input.data {
 		Data::Union(_) => err(ident.span(), "Cannot derive Into<Cursor> on a Union"),
 
@@ -41,21 +41,21 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	};
 	quote! {
 		#[automatically_derived]
-		impl #impl_generics From<#ident #impl_generics> for ::css_lexer::Cursor {
+		impl #impl_generics From<#ident #type_generics> for ::css_lexer::Cursor #where_clause {
 			fn from(value: #ident) -> ::css_lexer::Cursor {
 				#body
 			}
 		}
 
 		#[automatically_derived]
-		impl #impl_generics From<#ident #impl_generics> for ::css_lexer::Token {
+		impl #impl_generics From<#ident #type_generics> for ::css_lexer::Token #where_clause {
 			fn from(value: #ident) -> ::css_lexer::Token {
 				Into::<::css_lexer::Cursor>::into(value).token()
 			}
 		}
 
 		#[automatically_derived]
-		impl #impl_generics ::css_lexer::ToSpan for #ident #impl_generics {
+		impl #impl_generics ::css_lexer::ToSpan for #ident #type_generics #where_clause {
 			fn to_span(&self) -> ::css_lexer::Span {
 				Into::<::css_lexer::Cursor>::into(*self).span()
 			}

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -1,7 +1,10 @@
 use itertools::{Itertools, Position};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Type};
+use syn::{
+	Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Meta, Token, Type, TypePath, parse::Parse,
+	parse_quote,
+};
 
 use crate::err;
 
@@ -20,10 +23,110 @@ impl ToVarsAndTypes for Fields {
 	}
 }
 
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+struct ParseArg {
+	pub state: Option<Ident>,
+	pub stop: Option<(Ident, Ident)>,
+}
+
+impl Parse for ParseArg {
+	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+		let (mut state, mut stop) = (None, None);
+		while !input.is_empty() {
+			match input.parse::<Ident>()? {
+				i if i == "state" => {
+					if state.is_some() {
+						Err(Error::new(i.span(), "redefinition of 'state'".to_string()))?;
+					}
+					input.parse::<Token![=]>()?;
+					let TypePath { path, .. } = input.parse::<TypePath>()?;
+					let ident = path.segments.first().map(|s| s.ident.clone()).unwrap();
+					if ident != "State" {
+						Err(Error::new(ident.span(), format!("state must use the State type, saw {ident:?}")))?;
+					}
+					let ident = path.segments.last().map(|s| s.ident.clone()).unwrap();
+					state = Some(ident);
+				}
+				i if i == "stop" => {
+					if stop.is_some() {
+						Err(Error::new(i.span(), "redefinition of 'state'".to_string()))?;
+					}
+					input.parse::<Token![=]>()?;
+					let TypePath { path, .. } = input.parse::<TypePath>()?;
+					let kind_or_kindset = path.segments.first().map(|s| s.ident.clone()).unwrap();
+					if kind_or_kindset != "Kind" && kind_or_kindset != "KindSet" {
+						panic!("stop must use the Kind or KindSet type");
+					}
+					let ident = path.segments.last().map(|s| s.ident.clone()).unwrap();
+					stop = Some((kind_or_kindset, ident));
+				}
+				ident => Err(Error::new(ident.span(), format!("Unrecognized Value arg {ident:?}")))?,
+			}
+
+			if !input.is_empty() {
+				input.parse::<Token![,]>()?;
+			}
+		}
+		Ok(Self { state, stop })
+	}
+}
+
+impl From<&Vec<Attribute>> for ParseArg {
+	fn from(attrs: &Vec<Attribute>) -> Self {
+		if let Some(Attribute { meta, .. }) = &attrs.iter().find(|a| a.path().is_ident("parse")) {
+			match meta {
+				Meta::List(meta) => meta.parse_args::<ParseArg>().unwrap(),
+				_ => panic!("could not parse meta"),
+			}
+		} else {
+			Self::default()
+		}
+	}
+}
+
 pub fn derive(input: DeriveInput) -> TokenStream {
 	let ident = input.ident;
-	let generics = &mut input.generics.clone();
-	let (impl_generics, _, _) = generics.split_for_impl();
+	let generics = &input.generics;
+	let mut generic_with_alloc = generics.clone();
+	let (impl_generics, type_generics, where_clause) = if generics.lifetimes().all(|l| l.lifetime.ident != "a") {
+		generic_with_alloc.params.insert(0, parse_quote!('a));
+		let (impl_generics, _, _) = generic_with_alloc.split_for_impl();
+		let (_, type_generics, where_clause) = generics.split_for_impl();
+		(impl_generics, type_generics, where_clause)
+	} else {
+		generics.split_for_impl()
+	};
+	let mut pre_parse_steps = quote! {};
+	let mut post_parse_steps = quote! {};
+	let ParseArg { state, stop } = (&input.attrs).into();
+	if let Some(ident) = state {
+		pre_parse_steps = quote! {
+			let state = p.set_state(State::#ident);
+			#pre_parse_steps
+		};
+		post_parse_steps = quote! {
+			#post_parse_steps
+			p.set_state(state);
+		};
+	}
+	if let Some((kind_or_kindset, ident)) = stop {
+		pre_parse_steps = if kind_or_kindset == "Kind" {
+			quote! {
+				let stop = p.set_stop(KindSet::new(&[Kind::#ident]));
+				#pre_parse_steps
+			}
+		} else {
+			quote! {
+				let stop = p.set_stop(KindSet::#ident);
+				#pre_parse_steps
+			}
+		};
+		post_parse_steps = quote! {
+			#post_parse_steps
+			p.set_stop(stop);
+		};
+	}
+
 	let body = match input.data {
 		Data::Union(_) => err(ident.span(), "Cannot derive Parse on a Union"),
 
@@ -32,6 +135,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 			let (vars, types) = fields.to_vars_and_types();
 			quote! {
 				#( let #vars = p.parse::<#types>()?; )*
+				#post_parse_steps
 				Ok(Self { #(#members: #vars),* })
 			}
 		}
@@ -46,6 +150,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 				let first_type = types.first();
 				let step = quote! {
 					#( let #vars = p.parse::<#types>()?; )*
+					#post_parse_steps
 					Ok(Self::#variant_ident { #(#members: #vars),* })
 				};
 				match position {
@@ -59,9 +164,10 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	};
 	quote! {
 		#[automatically_derived]
-		impl<'a> ::css_parse::Parse<'a> for #ident #impl_generics {
+		impl #impl_generics ::css_parse::Parse<'a> for #ident #type_generics #where_clause {
 			fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
 				use css_parse::{Parse};
+				#pre_parse_steps
 				#body
 			}
 		}

--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -1,14 +1,22 @@
 use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, parse_quote};
 
 use crate::err;
 
 pub fn derive(input: DeriveInput) -> TokenStream {
 	let ident = input.ident;
-	let generics = &mut input.generics.clone();
-	let (impl_generics, _, _) = generics.split_for_impl();
+	let generics = &input.generics;
+	let mut generic_with_alloc = generics.clone();
+	let (impl_generics, type_generics, where_clause) = if generics.lifetimes().all(|l| l.lifetime.ident != "a") {
+		generic_with_alloc.params.insert(0, parse_quote!('a));
+		let (impl_generics, _, _) = generic_with_alloc.split_for_impl();
+		let (_, type_generics, where_clause) = generics.split_for_impl();
+		(impl_generics, type_generics, where_clause)
+	} else {
+		generics.split_for_impl()
+	};
 	let body = match input.data {
 		Data::Union(_) => err(ident.span(), "Cannot derive Peek on a Union"),
 
@@ -24,7 +32,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	};
 	quote! {
 		#[automatically_derived]
-		impl<'a> ::css_parse::Peek<'a> for #ident #impl_generics {
+		impl #impl_generics ::css_parse::Peek<'a> for #ident #type_generics #where_clause {
 			fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
 				use ::css_parse::{Peek};
 				#body

--- a/crates/csskit_proc_macro/src/value.rs
+++ b/crates/csskit_proc_macro/src/value.rs
@@ -38,9 +38,9 @@ pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 		}
 	}
 	let keyword_def = defs.generate_keyword_set(ident);
-	let def = defs.generate_definition(vis, ident, &mut ast.generics.clone());
-	let peek_impl = defs.generate_peek_trait_implementation(ident, &mut ast.generics.clone());
-	let parse_impl = defs.generate_parse_trait_implementation(ident, &mut ast.generics.clone());
+	let def = defs.generate_definition(vis, ident, &ast.generics);
+	let peek_impl = defs.generate_peek_trait_implementation(ident, &ast.generics);
+	let parse_impl = defs.generate_parse_trait_implementation(ident, &ast.generics);
 	quote! {
 		#keyword_def
 


### PR DESCRIPTION
In the interests of optimising properties/mod.rs, I spotted there was some repetition in the Custom/Computed/Unknown parse steps, this is mostly because each one needs to set state and stop tokens. If only derive(Parse) could somehow do this then we could derive(Parse) on all 3 of these.

So this change does exactly that! This introduces the #[parse(state=...,stop=...)] syntax, which allows derive(Parse) to issue some before/after steps to set the state, and tear it down when done. This is not only reduces code in css_ast but also should make for a more consistent & bugfree code for any other property that wants to use state/stop because it can be applied correctly in the derive.