### PR TITLE
css_parse/css_ast: move parsing steps for Declarations into parse

### DIFF
--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -1,4 +1,4 @@
-use crate::StyleValue;
+use crate::{Computed, StyleValue};
 use css_lexer::Cursor;
 use css_parse::{
 	AtRule, DeclarationList, DeclarationValue, NoPreludeAllowed, Parser, Peek, Result as ParserResult, atkeyword_set,
@@ -42,6 +42,8 @@ keyword_set!(pub enum FontFaceRulePropertyId {
 struct FontFaceRuleStyleValue<'a>(StyleValue<'a>);
 
 impl<'a> DeclarationValue<'a> for FontFaceRuleStyleValue<'a> {
+	type ComputedValue = Computed<'a>;
+
 	fn valid_declaration_name(p: &Parser, c: Cursor) -> bool {
 		FontFaceRulePropertyId::peek(p, c)
 	}

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -5,6 +5,8 @@ use css_parse::{
 };
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
 
+use crate::Computed;
+
 atkeyword_set!(pub struct AtPropertyKeyword "property");
 
 // https://drafts.csswg.org/cssom-1/#csspagerule
@@ -50,6 +52,8 @@ keyword_set!(
 pub struct SyntaxValue(T![String]);
 
 impl<'a> DeclarationValue<'a> for PropertyRuleValue<'a> {
+	type ComputedValue = Computed<'a>;
+
 	fn valid_declaration_name(p: &Parser<'a>, c: Cursor) -> bool {
 		PropertyRulePropertyId::peek(p, c)
 	}

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_blueprint.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_blueprint.snap
@@ -1356,10 +1356,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "type": "inherit",
-              "kind": "Ident",
-              "offset": 602,
-              "len": 7
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 601,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 602,
+                  "len": 7
+                }
+              ]
             },
             "important": null,
             "semicolon": {

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_inuitcss.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_inuitcss.snap
@@ -3058,10 +3058,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "type": "inherit",
-              "kind": "Ident",
-              "offset": 15284,
-              "len": 7
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 15283,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 15284,
+                  "len": 7
+                }
+              ]
             },
             "important": null,
             "semicolon": {
@@ -18559,10 +18567,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "type": "inherit",
-              "kind": "Ident",
-              "offset": 33599,
-              "len": 7
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 33598,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 33599,
+                  "len": 7
+                }
+              ]
             },
             "important": null,
             "semicolon": {

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_pure.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_pure.snap
@@ -1707,10 +1707,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "type": "inherit",
-              "kind": "Ident",
-              "offset": 3242,
-              "len": 7
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 3241,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 3242,
+                  "len": 7
+                }
+              ]
             },
             "important": null,
             "semicolon": {
@@ -4071,10 +4079,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "type": "inherit",
-              "kind": "Ident",
-              "offset": 6009,
-              "len": 7
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 6008,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 6009,
+                  "len": 7
+                }
+              ]
             },
             "important": null,
             "semicolon": {

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_reset.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_reset.snap
@@ -1855,10 +1855,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "type": "inherit",
-              "kind": "Ident",
-              "offset": 659,
-              "len": 7
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 658,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 659,
+                  "len": 7
+                }
+              ]
             },
             "important": null,
             "semicolon": {

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_decls.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_decls.snap
@@ -184,37 +184,28 @@ expression: result.output.unwrap()
         "offset": 87,
         "len": 10
       },
-      "prelude": {
-        "values": [
+      "prelude": null,
+      "block": {
+        "open_curly": {
+          "kind": "LeftCurly",
+          "offset": 98,
+          "len": 1
+        },
+        "declarations": [
           {
-            "kind": "Whitespace",
-            "offset": 97,
-            "len": 1
-          },
-          {
-            "type": "SimpleBlock",
-            "open": {
-              "kind": "LeftCurly",
-              "offset": 98,
+            "type": "Declaration",
+            "name": {
+              "kind": "Ident",
+              "offset": 104,
+              "len": 11
+            },
+            "colon": {
+              "kind": "Colon",
+              "offset": 115,
               "len": 1
             },
-            "values": {
+            "value": {
               "values": [
-                {
-                  "kind": "Whitespace",
-                  "offset": 99,
-                  "len": 5
-                },
-                {
-                  "kind": "Ident",
-                  "offset": 104,
-                  "len": 11
-                },
-                {
-                  "kind": "Colon",
-                  "offset": 115,
-                  "len": 1
-                },
                 {
                   "kind": "Whitespace",
                   "offset": 116,
@@ -224,30 +215,33 @@ expression: result.output.unwrap()
                   "kind": "String",
                   "offset": 117,
                   "len": 10
-                },
-                {
-                  "kind": "Semicolon",
-                  "offset": 127,
-                  "len": 1
                 }
               ]
             },
-            "close": {
-              "kind": "RightCurly",
-              "offset": 129,
+            "important": null,
+            "semicolon": {
+              "kind": "Semicolon",
+              "offset": 127,
               "len": 1
             }
-          },
-          {
-            "kind": "Whitespace",
-            "offset": 130,
-            "len": 2
-          },
-          {
-            "kind": "AtKeyword",
-            "offset": 132,
-            "len": 9
-          },
+          }
+        ],
+        "close_curly": {
+          "kind": "RightCurly",
+          "offset": 129,
+          "len": 1
+        }
+      },
+      "semicolon": null
+    },
+    {
+      "name": {
+        "kind": "AtKeyword",
+        "offset": 132,
+        "len": 9
+      },
+      "prelude": {
+        "values": [
           {
             "kind": "Whitespace",
             "offset": 141,

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -96,16 +96,15 @@ where
 mod tests {
 	use super::*;
 	use crate::test_helpers::*;
+	use css_lexer::Cursor;
 
 	#[derive(Debug, ToSpan)]
 	struct Decl(T![Ident]);
 	impl<'a> DeclarationValue<'a> for Decl {
-		fn parse_declaration_value(p: &mut Parser<'a>, _: css_lexer::Cursor) -> Result<Self> {
-			p.parse::<T![Ident]>().map(Decl)
-		}
+		type ComputedValue = T![Eof];
 
-		fn is_unknown(&self) -> bool {
-			false
+		fn parse_specified_declaration_value(p: &mut Parser<'a>, _: Cursor) -> Result<Self> {
+			p.parse::<T![Ident]>().map(Self)
 		}
 
 		fn needs_computing(&self) -> bool {

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -40,12 +40,18 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
 }
 
 impl<'a> DeclarationValue<'a> for ComponentValues<'a> {
-	fn parse_declaration_value(p: &mut Parser<'a>, _: css_lexer::Cursor) -> Result<Self> {
+	type ComputedValue = ComponentValues<'a>;
+
+	fn parse_custom_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		Self::parse(p)
 	}
 
-	fn is_unknown(&self) -> bool {
-		true
+	fn parse_unknown_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
+		Self::parse(p)
+	}
+
+	fn parse_computed_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
+		Self::parse(p)
 	}
 
 	fn needs_computing(&self) -> bool {

--- a/crates/css_parse/src/syntax/qualified_rule.rs
+++ b/crates/css_parse/src/syntax/qualified_rule.rs
@@ -115,16 +115,15 @@ where
 mod tests {
 	use super::*;
 	use crate::test_helpers::*;
+	use css_lexer::Cursor;
 
 	#[derive(Debug, ToSpan)]
 	struct Decl(T![Ident]);
 	impl<'a> DeclarationValue<'a> for Decl {
-		fn parse_declaration_value(p: &mut Parser<'a>, _: css_lexer::Cursor) -> Result<Self> {
-			p.parse::<T![Ident]>().map(Decl)
-		}
+		type ComputedValue = T![Eof];
 
-		fn is_unknown(&self) -> bool {
-			false
+		fn parse_specified_declaration_value(p: &mut Parser<'a>, _: Cursor) -> Result<Self> {
+			p.parse::<T![Ident]>().map(Self)
 		}
 
 		fn needs_computing(&self) -> bool {

--- a/crates/css_parse/src/traits/declaration_value.rs
+++ b/crates/css_parse/src/traits/declaration_value.rs
@@ -1,41 +1,118 @@
-use crate::{Result, ToCursors, parser::Parser};
-use css_lexer::{Cursor, ToSpan};
+use crate::{Parser, Peek, Result, T, ToCursors, diagnostics};
+use css_lexer::{Cursor, KindSet, ToSpan};
 
 /// A trait that can be used for AST nodes representing a Declaration's Value. It offers some
 /// convenience functions for handling such values.
-pub trait DeclarationValue<'a>: Sized + ToCursors + ToSpan {
-	/// Determines if the given [Cursor] represents a valid [Ident][crate::token_macros::Ident]
-	/// matching a known property name.
+pub trait DeclarationValue<'a>: Sized + ToCursors + ToSpan + std::fmt::Debug {
+	type ComputedValue: Peek<'a>;
+
+	/// Determines if the given [Cursor] represents a valid [Ident][crate::token_macros::Ident] matching a known property
+	/// name.
 	///
-	/// If implementing a set of declarations where ony limited property-ids are valid (such as the
-	/// declarations allowed by an at-rule) then it might be worthwhile changing this to sometimes
-	/// return `false`, which consumers of this trait can use to error early without having to do too
-	/// much backtracking.
+	/// If implementing a set of declarations where ony limited property-ids are valid (such as the declarations allowed
+	/// by an at-rule) then it might be worthwhile changing this to sometimes return `false`, which consumers of this
+	/// trait can use to error early without having to do too much backtracking.
 	fn valid_declaration_name(_p: &Parser<'a>, _c: Cursor) -> bool {
 		true
 	}
 
 	/// Determines if the parsed Self was parsed as an unknown value.
 	///
-	/// If implementing a set of declarations where any name is accepted, or where the value might
-	/// result in re-parsing as unknown, this method can be used to signal that to upstream consumers
-	/// of this trait. By default this returns `false` because `valid_declaration_name` returns
-	/// `true`, the assumption being that any successful construction of Self is indeed a valid and
-	/// known declaration.
+	/// If implementing a set of declarations where any name is accepted, or where the value might result in re-parsing
+	/// as unknown, this method can be used to signal that to upstream consumers of this trait. By default this returns
+	/// `false` because `valid_declaration_name` returns `true`, the assumption being that any successful construction of
+	/// Self is indeed a valid and known declaration.
 	fn is_unknown(&self) -> bool {
 		false
 	}
 
-	/// Determines if the parsed Self is not a valid literal production of the grammar, and instead
-	/// some of its constituent parts will need additional computation to reify into a known value.
+	/// Determines if the parsed Self was parsed as a Custom value.
 	///
-	/// CSS properties are allowed to include substitutions, such as `calc()` or `var()`. These are
-	/// not defined in the declaration's grammar but are instead stored so that when a style object
-	/// is reified the declarations that had those tokens can be recomputed against the context of
-	/// their node.
+	/// If implementing a set of declarations where custom names are accepted, or where the value might result in
+	/// re-parsing as unknown, this method can be used to signal that to upstream consumers of this trait. By default
+	/// this returns `false` because `valid_declaration_name` returns `true`, the assumption being that any successful
+	/// construction of Self is indeed a valid and known declaration.
+	fn is_custom(&self) -> bool {
+		false
+	}
+
+	/// Determines if the parsed Self is not a valid literal production of the grammar, and instead some of its
+	/// constituent parts will need additional computation to reify into a known value.
+	///
+	/// CSS properties are allowed to include substitutions, such as `calc()` or `var()`. These are not defined in the
+	/// declaration's grammar but are instead stored so that when a style object is reified the declarations that had
+	/// those tokens can be recomputed against the context of their node.
 	fn needs_computing(&self) -> bool;
+
+	/// Like `parse()` but with the additional context of the `name` [Cursor]. This cursor is known to be dashed ident,
+	/// therefore this should return a `Self` reflecting a Custom property. Alternatively, if this DeclarationValue
+	/// disallows custom declarations then this is the right place to return a parse Error.
+	///
+	/// The default implementation of this method is to return an Unexpected Err.
+	fn parse_custom_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
+		let c = p.peek_n(1);
+		Err(diagnostics::Unexpected(c.into(), c.into()))?
+	}
+
+	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called before verifying that
+	/// the next token was peeked to be a ComputedValue, therefore this should return a `Self` reflecting a Computed
+	/// property. Alternatively, if this DeclarationValue disallows computed declarations then this is the right place to
+	/// return a parse Error.
+	///
+	/// The default implementation of this method is to return an Unexpected Err.
+	fn parse_computed_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
+		let c = p.peek_n(1);
+		Err(diagnostics::Unexpected(c.into(), c.into()))?
+	}
+
+	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called on values that are
+	/// assumed to be _specified_, that is, they're not custom and not computed. Therefore this should return a `Self`
+	/// reflecting a specified value. If this results in a Parse error then ComputedValue will be checked to see if the
+	/// parser stopped because it saw a computed value function. If this results in a success, the next token is still
+	/// checked as it may be a ComputedValue, which - if so - the parsed value will be discarded, and the parser rewound
+	/// to re-parse this as a ComputedValue.
+	///
+	/// The default implementation of this method is to return an Unexpected Err.
+	fn parse_specified_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
+		let c = p.peek_n(1);
+		Err(diagnostics::Unexpected(c.into(), c.into()))?
+	}
+
+	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called on values that are
+	/// didn't parse as either a Custom, Computed or Specified value therefore this should return a `Self` reflecting an
+	/// unknown property, or alternatively the right place to return a parse error.
+	///
+	/// The default implementation of this method is to return an Unexpected Err.
+	fn parse_unknown_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
+		let c = p.peek_n(1);
+		Err(diagnostics::Unexpected(c.into(), c.into()))?
+	}
 
 	// Like `parse()` but with the additional context of the `name` [Cursor] - the same [Cursor]
 	// passed to [DeclarationValue::valid_declaration_name()].
-	fn parse_declaration_value(p: &mut Parser<'a>, name: Cursor) -> Result<Self>;
+	fn parse_declaration_value(p: &mut Parser<'a>, name: Cursor) -> Result<Self> {
+		if name.token().is_dashed_ident() {
+			return Self::parse_custom_declaration_value(p, name);
+		}
+		if !Self::valid_declaration_name(p, name) {
+			return Self::parse_unknown_declaration_value(p, name);
+		}
+		if p.peek::<Self::ComputedValue>() {
+			return Self::parse_computed_declaration_value(p, name);
+		}
+		let checkpoint = p.checkpoint();
+		if let Ok(val) = Self::parse_specified_declaration_value(p, name) {
+			if p.at_end() || p.peek_n(1) == KindSet::RIGHT_CURLY_OR_SEMICOLON || p.peek::<T![!]>() {
+				return Ok(val);
+			}
+		}
+		if p.peek::<Self::ComputedValue>() {
+			p.rewind(checkpoint);
+			if let Ok(val) = Self::parse_computed_declaration_value(p, name) {
+				return Ok(val);
+			}
+		}
+		p.rewind(checkpoint);
+		Self::parse_unknown_declaration_value(p, name)
+	}
 }


### PR DESCRIPTION
The parse steps for parsing a DeclarationValue can be quite complex, and while we do this sort of in one place (StyleValue) there are some other places which end up trying to declare their own DeclarationValue: @property rules and @font-face rules.

This change attempts to centralise some of that complexity in css_parse, while also making the DeclarationValues in @property and @font-face a little more consistent, with the ability to parse computed/unknown values also.