### PR TITLE
 csskit_proc_macro: Elide DefGroupStyle::None where possible in def parsing.

### DIFF
--- a/crates/csskit_proc_macro/src/def.rs
+++ b/crates/csskit_proc_macro/src/def.rs
@@ -4,7 +4,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident};
 use std::{
 	fmt::Display,
-	ops::{Range, RangeFrom, RangeTo},
+	ops::{Deref, Range, RangeFrom, RangeTo},
 };
 use syn::{
 	Error, Ident, Lit, LitFloat, LitInt, LitStr, Result, Token, braced, bracketed,
@@ -219,6 +219,14 @@ impl Parse for Def {
 						let options = Self::Combinator(vec![root, children.remove(0)], style);
 						children.insert(0, options);
 						root = next;
+					}
+					(_, Self::Group(inner, DefGroupStyle::None)) => {
+						let children = vec![root, *inner.deref().clone()];
+						root = Self::Combinator(children, style);
+					}
+					(Self::Group(inner, DefGroupStyle::None), _) => {
+						let children = vec![*inner.deref().clone(), next];
+						root = Self::Combinator(children, style);
 					}
 					_ => {
 						let children = vec![root, next];

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -919,7 +919,6 @@ impl GenerateParseImpl for Def {
 					.collect();
 				(quote! { #(#steps)* }, quote! { #(#idents),* })
 			}
-			Self::Group(def, DefGroupStyle::None) => def.parse_steps(),
 			_ => {
 				dbg!("parse_steps", self);
 				todo!("parse_steps");

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
@@ -1,0 +1,44 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(pub enum FooKeywords { Normal : "normal", });
+#[derive(
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::ToCursors,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+enum Foo {
+    Normal(::css_parse::T![Ident]),
+    SelfPosition(Option<crate::OverflowPosition>, crate::SelfPosition),
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for Foo {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+        use ::css_parse::Peek;
+        <::css_parse::T![Ident]>::peek(p, c) || <crate::OverflowPosition>::peek(p, c)
+            || <crate::SelfPosition>::peek(p, c)
+    }
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Foo {
+    fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
+        use ::css_parse::{Parse, Peek};
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Normal(ident)) => {
+                return Ok(Self::Normal(ident));
+            }
+            None => {}
+        }
+        let combo0 = p.parse_if_peek::<crate::OverflowPosition>()?;
+        let combo1 = p.parse::<crate::SelfPosition>()?;
+        Ok(Self::SelfPosition(combo0, combo1))
+    }
+}


### PR DESCRIPTION
Many value grammar productions use groups to improve readability of how a type is parsed, because of the subtle ordering
of combinators. However, these productions don't really make use of the actual semantics of groups (in that groups can
repeat by some number). I believe a Group with a DefGroupStyle::None is functionally useless.

This change ensures DefGroupStyle::None is elided whenever possible during def parsing, This slightly simplifies the generator code but mostly means we don't have to add new code paths for groups with no style, which allows us to start generating actual (usable) structs for these syntax types!