### PR TITLE
css_ast: move justify content and align items out of flex

### DIFF
--- a/crates/css_ast/src/values/flexbox/impls.rs
+++ b/crates/css_ast/src/values/flexbox/impls.rs
@@ -15,8 +15,6 @@ mod tests {
 		assert_eq!(std::mem::size_of::<FlexGrowStyleValue>(), 12);
 		assert_eq!(std::mem::size_of::<FlexShrinkStyleValue>(), 12);
 		assert_eq!(std::mem::size_of::<FlexBasisStyleValue>(), 44);
-		assert_eq!(std::mem::size_of::<JustifyContentStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<AlignItemsStyleValue>(), 16);
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/flexbox/mod.rs
+++ b/crates/css_ast/src/values/flexbox/mod.rs
@@ -188,26 +188,3 @@ pub enum FlexBasisStyleValue {}
 #[baseline(Unknown)]
 #[versions(Unknown)]
 pub enum JustifyContentStyleValue {}
-
-/// Represents the style value for `align-items` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#align-items).
-///
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// flex-start | flex-end | center | baseline | stretch
-/// ```
-///
-// https://drafts.csswg.org/css-flexbox-1/#align-items
-#[value(" flex-start | flex-end | center | baseline | stretch ")]
-#[initial("stretch")]
-#[applies_to("flex containers")]
-#[inherited("no")]
-#[percentages("n/a")]
-#[canonical_order("per grammar")]
-#[animation_type("discrete")]
-#[popularity(Unknown)]
-#[caniuse(Unknown)]
-#[baseline(Unknown)]
-#[versions(Unknown)]
-pub enum AlignItemsStyleValue {}

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_mini.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_mini.snap
@@ -24142,11 +24142,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "Center": {
-                "kind": "Ident",
-                "offset": 13939,
-                "len": 6
-              }
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 13938,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 13939,
+                  "len": 6
+                }
+              ]
             },
             "important": null,
             "semicolon": {
@@ -24505,11 +24512,18 @@ expression: result.output.unwrap()
                     "len": 1
                   },
                   "value": {
-                    "Stretch": {
-                      "kind": "Ident",
-                      "offset": 14142,
-                      "len": 7
-                    }
+                    "values": [
+                      {
+                        "kind": "Whitespace",
+                        "offset": 14141,
+                        "len": 1
+                      },
+                      {
+                        "kind": "Ident",
+                        "offset": 14142,
+                        "len": 7
+                      }
+                    ]
                   },
                   "important": null,
                   "semicolon": {
@@ -24656,11 +24670,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "Stretch": {
-                "kind": "Ident",
-                "offset": 14242,
-                "len": 7
-              }
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 14241,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 14242,
+                  "len": 7
+                }
+              ]
             },
             "important": null,
             "semicolon": {

--- a/tasks/generate-values/mod.ts
+++ b/tasks/generate-values/mod.ts
@@ -316,7 +316,7 @@ const ignore = new Map([
 	["multicol", new Set(["column-rule", "column-rule-width", "column-rule-color", "column-rule-style"])],
 	// https://drafts.csswg.org/css-flexbox-1/
 	// Moved some align properties to [CSS-ALIGN-3].
-	["flexbox", new Set(["align-content", "align-self"])],
+	["flexbox", new Set(["align-content", "align-items", "align-self", "justify-content"])],
 ]);
 
 const runtimeCache = new Map();


### PR DESCRIPTION
The flex spec only defines `flex-*` related rules. Rules like align-items and justify-content are no longer part of it
(as they can be used for non flex containers).

This change moves these from flex; they instead live in align.