### PR TITLE
csskit_proc_macro: Ensure DefRange of Range is inclusive.

### DIFF
--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -1012,7 +1012,7 @@ impl GenerateParseImpl for DefType {
 				},
 			DefRange::Range(Range { start, end }) => quote! {
 			let valf32: f32 = ty.into();
-					if !(#start..#end).contains(&valf32) {
+					if !(#start..=#end).contains(&valf32) {
 						return Err(::css_parse::diagnostics::NumberOutOfBounds(valf32, format!("{}..{}", #start, #end), ::css_lexer::Span::new(start, p.offset())))?
 					}
 				},

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -53,7 +53,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             let start = p.offset();
             let ty = p.parse::<crate::Angle>()?;
             let valf32: f32 = ty.into();
-            if !(-90f32..90f32).contains(&valf32) {
+            if !(-90f32..=90f32).contains(&valf32) {
                 return Err(
                     ::css_parse::diagnostics::NumberOutOfBounds(
                         valf32,


### PR DESCRIPTION
https://drafts.csswg.org/css-values-4/#numeric-ranges defines the numeric range validations as _inclusive_, meaning the
check should use Rust's `X..=Y` notation, not `X..Y` (half-open).

This change adds the `=` to the generator, and updates the snapshot accordingly.