### PR TITLE
css_ast: Fixup Resolution unit

### DIFF
--- a/crates/css_ast/src/units/resolution.rs
+++ b/crates/css_ast/src/units/resolution.rs
@@ -1,17 +1,18 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
-use csskit_derives::{IntoCursor, ToCursors};
+use css_lexer::{Cursor, DimensionUnit};
+use css_parse::{Build, Parser, T};
+use csskit_derives::{IntoCursor, Peek, ToCursors};
 
 // const DPPX_IN: f32 = 96.0;
 // const DPPX_CM: f32 = DPPX_IN / 2.54;
 
 // https://drafts.csswg.org/css-values/#resolution
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Resolution {
 	Dpi(T![Dimension::Dpi]),
 	Dpcm(T![Dimension::Dpcm]),
 	Dppx(T![Dimension::Dppx]),
+	X(T![Dimension::X]),
 }
 
 impl From<Resolution> for f32 {
@@ -20,22 +21,18 @@ impl From<Resolution> for f32 {
 			Resolution::Dpi(r) => r.into(),
 			Resolution::Dpcm(r) => r.into(),
 			Resolution::Dppx(r) => r.into(),
+			Resolution::X(r) => r.into(),
 		}
-	}
-}
-
-impl<'a> Peek<'a> for Resolution {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		<T![Dimension]>::peek(p, c) && matches!(p.parse_str_lower(c), "dpi" | "dpcm" | "dppx")
 	}
 }
 
 impl<'a> Build<'a> for Resolution {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
-		match p.parse_str_lower(c) {
-			"dpi" => Self::Dpi(<T![Dimension::Dpi]>::build(p, c)),
-			"dpcm" => Self::Dpcm(<T![Dimension::Dpcm]>::build(p, c)),
-			"dppx" => Self::Dppx(<T![Dimension::Dppx]>::build(p, c)),
+		match c.token().dimension_unit() {
+			DimensionUnit::Dpi => Self::Dpi(<T![Dimension::Dpi]>::build(p, c)),
+			DimensionUnit::Dpcm => Self::Dpcm(<T![Dimension::Dpcm]>::build(p, c)),
+			DimensionUnit::Dppx => Self::Dppx(<T![Dimension::Dppx]>::build(p, c)),
+			DimensionUnit::X => Self::X(<T![Dimension::X]>::build(p, c)),
 			_ => unreachable!(),
 		}
 	}
@@ -54,5 +51,6 @@ mod tests {
 	#[test]
 	fn test_writes() {
 		assert_parse!(Resolution, "1dppx");
+		assert_parse!(Resolution, "1x");
 	}
 }


### PR DESCRIPTION
The resolution unit was missing the X variant, and used the suboptimal way to determine the unit.

This change uses the DimensionUnit to determine the variant, which is more efficient, and allows us to simply derive
Peek. It also adds the X variant.
