### PR TITLE
css_parse: implement singular function_set, Into::T![Function]

### DIFF
--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -474,7 +474,48 @@ macro_rules! function_set {
 				}
 			}
 		}
-	}
+
+		impl<'a> From<$name> for $crate::token_macros::Function {
+			fn from(value: $name) -> Self {
+				match value {
+					$($name::$variant(t) => t,)+
+				}
+			}
+		}
+	};
+
+	($(#[$meta:meta])* $vis:vis struct $name: ident $str: tt) => {
+		$(#[$meta])*
+		#[derive(::csskit_derives::IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+		$vis struct $name($crate::T![Function]);
+
+		impl $crate::ToCursors for $name {
+			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
+				s.append((*self).into());
+			}
+		}
+
+		impl<'a> $crate::Peek<'a> for $name {
+			fn peek(p: &$crate::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+				<$crate::T![Function]>::peek(p, c) && p.eq_ignore_ascii_case(c, $str)
+			}
+		}
+
+		impl<'a> $crate::Build<'a> for $name {
+			fn build(p: &$crate::Parser<'a>, c: ::css_lexer::Cursor) -> Self {
+				use $crate::Peek;
+				debug_assert!(Self::peek(p, c));
+				Self(<$crate::T![Function]>::build(p, c))
+			}
+		}
+
+		impl<'a> From<$name> for $crate::token_macros::Function {
+			fn from(value: $name) -> Self {
+				value.0
+			}
+		}
+	};
 }
 
 /// A macro for defining an enum which captures a token with [Kind::AtKeyword][css_lexer::Kind::AtKeyword] that matches one of


### PR DESCRIPTION
While https://github.com/csskit/csskit/pull/250 introduced Function<'a, FT, T> where FT is Into::<T![Function]>,
function_set! wouldn't produce enums which were Into::<T![Function]>, so this adds that, and while we're here it adds a
singular form of function_set, just like atkeyword_set and keyword_set have.
