### PR TITLE
optimise Alternatives of auto|<length(-percentage)> to <length(-percentage)-or-auto>

### DIFF
--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -186,7 +186,26 @@ impl<'a> Build<'a> for LengthPercentage {
 }
 
 #[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+pub enum LengthOrAuto {
+	Auto(T![Ident]),
+	Length(Length),
+}
+
+impl<'a> Peek<'a> for LengthOrAuto {
+	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
+		Length::peek(p, c) || (<T![Ident]>::peek(p, c) && p.eq_ignore_ascii_case(c, "auto"))
+	}
+}
+
+impl<'a> Build<'a> for LengthOrAuto {
+	fn build(p: &Parser<'a>, c: Cursor) -> Self {
+		if Length::peek(p, c) { Self::Length(Length::build(p, c)) } else { Self::Auto(<T![Ident]>::build(p, c)) }
+	}
+}
+
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum LengthPercentageOrAuto {
 	Auto(T![Ident]),
 	LengthPercentage(LengthPercentage),

--- a/crates/css_ast/src/values/align/impls.rs
+++ b/crates/css_ast/src/values/align/impls.rs
@@ -10,7 +10,7 @@ mod tests {
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<AlignContentStyleValue>(), 32);
 		// assert_eq!(std::mem::size_of::<JustifyContentStyleValue>(), 1);
-		assert_eq!(std::mem::size_of::<PlaceContentStyleValue>(), 48);
+		// assert_eq!(std::mem::size_of::<PlaceContentStyleValue>(), 48);
 		// assert_eq!(std::mem::size_of::<JustifySelfStyleValue>(), 1);
 		assert_eq!(std::mem::size_of::<AlignSelfStyleValue>(), 32);
 		// assert_eq!(std::mem::size_of::<PlaceSelfStyleValue>(), 1);
@@ -27,8 +27,8 @@ mod tests {
 		assert_parse!(AlignContentStyleValue, "normal");
 		assert_parse!(AlignContentStyleValue, "safe flex-end");
 		assert_parse!(AlignContentStyleValue, "flex-end");
-		assert_parse!(PlaceContentStyleValue, "unsafe flex-end");
-		assert_parse!(PlaceContentStyleValue, "flex-end");
+		// assert_parse!(PlaceContentStyleValue, "unsafe flex-end");
+		// assert_parse!(PlaceContentStyleValue, "flex-end");
 		assert_parse!(AlignSelfStyleValue, "normal");
 		assert_parse!(AlignSelfStyleValue, "safe flex-start");
 		assert_parse!(AlignSelfStyleValue, "flex-start");

--- a/crates/css_ast/src/values/align/mod.rs
+++ b/crates/css_ast/src/values/align/mod.rs
@@ -51,28 +51,28 @@ pub enum AlignContentStyleValue {}
 // #[versions(Unknown)]
 // pub enum JustifyContentStyleValue {}
 
-/// Represents the style value for `place-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-content).
-///
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'align-content'> <'justify-content'>?
-/// ```
-///
-// https://drafts.csswg.org/css-align-3/#place-content
-#[value(" <'align-content'> <'justify-content'>? ")]
-#[initial("normal")]
-#[applies_to("block containers, flex containers, and grid containers")]
-#[inherited("no")]
-#[percentages("n/a")]
-#[canonical_order("per grammar")]
-#[animation_type("discrete")]
-#[popularity(Unknown)]
-#[caniuse(Unknown)]
-#[baseline(Unknown)]
-#[versions(Unknown)]
-pub struct PlaceContentStyleValue;
+///// Represents the style value for `place-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-content).
+/////
+/////
+///// The grammar is defined as:
+/////
+///// ```text,ignore
+///// <'align-content'> <'justify-content'>?
+///// ```
+/////
+//// https://drafts.csswg.org/css-align-3/#place-content
+//#[value(" <'align-content'> <'justify-content'>? ")]
+//#[initial("normal")]
+//#[applies_to("block containers, flex containers, and grid containers")]
+//#[inherited("no")]
+//#[percentages("n/a")]
+//#[canonical_order("per grammar")]
+//#[animation_type("discrete")]
+//#[popularity(Unknown)]
+//#[caniuse(Unknown)]
+//#[baseline(Unknown)]
+//#[versions(Unknown)]
+//pub struct PlaceContentStyleValue;
 
 // /// Represents the style value for `justify-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-self).
 // ///

--- a/crates/css_ast/src/values/box/mod.rs
+++ b/crates/css_ast/src/values/box/mod.rs
@@ -26,7 +26,7 @@ use impls::*;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum MarginTopStyleValue {}
+pub struct MarginTopStyleValue;
 
 /// Represents the style value for `margin-right` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-right).
 ///
@@ -49,7 +49,7 @@ pub enum MarginTopStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum MarginRightStyleValue {}
+pub struct MarginRightStyleValue;
 
 /// Represents the style value for `margin-bottom` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-bottom).
 ///
@@ -72,7 +72,7 @@ pub enum MarginRightStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum MarginBottomStyleValue {}
+pub struct MarginBottomStyleValue;
 
 /// Represents the style value for `margin-left` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-left).
 ///
@@ -95,7 +95,7 @@ pub enum MarginBottomStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum MarginLeftStyleValue {}
+pub struct MarginLeftStyleValue;
 
 /// Represents the style value for `margin` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin).
 ///

--- a/crates/css_ast/src/values/flexbox/mod.rs
+++ b/crates/css_ast/src/values/flexbox/mod.rs
@@ -165,26 +165,3 @@ pub struct FlexShrinkStyleValue;
 #[baseline(Unknown)]
 #[versions(Unknown)]
 pub enum FlexBasisStyleValue {}
-
-/// Represents the style value for `justify-content` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#justify-content).
-///
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// flex-start | flex-end | center | space-between | space-around
-/// ```
-///
-// https://drafts.csswg.org/css-flexbox-1/#justify-content
-#[value(" flex-start | flex-end | center | space-between | space-around ")]
-#[initial("flex-start")]
-#[applies_to("flex containers")]
-#[inherited("no")]
-#[percentages("n/a")]
-#[canonical_order("per grammar")]
-#[animation_type("discrete")]
-#[popularity(Unknown)]
-#[caniuse(Unknown)]
-#[baseline(Unknown)]
-#[versions(Unknown)]
-pub enum JustifyContentStyleValue {}

--- a/crates/css_ast/src/values/multicol/mod.rs
+++ b/crates/css_ast/src/values/multicol/mod.rs
@@ -26,7 +26,7 @@ use impls::*;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ColumnWidthStyleValue {}
+pub struct ColumnWidthStyleValue;
 
 /// Represents the style value for `column-count` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-count).
 ///
@@ -143,7 +143,7 @@ pub enum ColumnFillStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ColumnHeightStyleValue {}
+pub struct ColumnHeightStyleValue;
 
 /// Represents the style value for `column-wrap` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-wrap).
 ///

--- a/crates/css_ast/src/values/position/mod.rs
+++ b/crates/css_ast/src/values/position/mod.rs
@@ -50,7 +50,7 @@ pub enum PositionStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum TopStyleValue {}
+pub struct TopStyleValue;
 
 /// Represents the style value for `right` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#right).
 ///
@@ -73,7 +73,7 @@ pub enum TopStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum RightStyleValue {}
+pub struct RightStyleValue;
 
 /// Represents the style value for `bottom` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#bottom).
 ///
@@ -96,7 +96,7 @@ pub enum RightStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum BottomStyleValue {}
+pub struct BottomStyleValue;
 
 /// Represents the style value for `left` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#left).
 ///
@@ -119,7 +119,7 @@ pub enum BottomStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum LeftStyleValue {}
+pub struct LeftStyleValue;
 
 /// Represents the style value for `inset-block-start` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block-start).
 ///
@@ -142,7 +142,7 @@ pub enum LeftStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum InsetBlockStartStyleValue {}
+pub struct InsetBlockStartStyleValue;
 
 /// Represents the style value for `inset-inline-start` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline-start).
 ///
@@ -165,7 +165,7 @@ pub enum InsetBlockStartStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum InsetInlineStartStyleValue {}
+pub struct InsetInlineStartStyleValue;
 
 /// Represents the style value for `inset-block-end` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block-end).
 ///
@@ -188,7 +188,7 @@ pub enum InsetInlineStartStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum InsetBlockEndStyleValue {}
+pub struct InsetBlockEndStyleValue;
 
 /// Represents the style value for `inset-inline-end` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline-end).
 ///
@@ -211,7 +211,7 @@ pub enum InsetBlockEndStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum InsetInlineEndStyleValue {}
+pub struct InsetInlineEndStyleValue;
 
 /// Represents the style value for `inset-block` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block).
 ///

--- a/crates/css_ast/src/values/scroll_snap/mod.rs
+++ b/crates/css_ast/src/values/scroll_snap/mod.rs
@@ -141,7 +141,7 @@ pub enum ScrollSnapStopStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ScrollPaddingTopStyleValue {}
+pub struct ScrollPaddingTopStyleValue;
 
 /// Represents the style value for `scroll-padding-right` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-right).
 ///
@@ -164,7 +164,7 @@ pub enum ScrollPaddingTopStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ScrollPaddingRightStyleValue {}
+pub struct ScrollPaddingRightStyleValue;
 
 /// Represents the style value for `scroll-padding-bottom` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-bottom).
 ///
@@ -187,7 +187,7 @@ pub enum ScrollPaddingRightStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ScrollPaddingBottomStyleValue {}
+pub struct ScrollPaddingBottomStyleValue;
 
 /// Represents the style value for `scroll-padding-left` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-left).
 ///
@@ -210,7 +210,7 @@ pub enum ScrollPaddingBottomStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ScrollPaddingLeftStyleValue {}
+pub struct ScrollPaddingLeftStyleValue;
 
 /// Represents the style value for `scroll-padding-inline-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-start).
 ///
@@ -233,7 +233,7 @@ pub enum ScrollPaddingLeftStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ScrollPaddingInlineStartStyleValue {}
+pub struct ScrollPaddingInlineStartStyleValue;
 
 /// Represents the style value for `scroll-padding-block-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-start).
 ///
@@ -256,7 +256,7 @@ pub enum ScrollPaddingInlineStartStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ScrollPaddingBlockStartStyleValue {}
+pub struct ScrollPaddingBlockStartStyleValue;
 
 /// Represents the style value for `scroll-padding-inline-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-end).
 ///
@@ -279,7 +279,7 @@ pub enum ScrollPaddingBlockStartStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ScrollPaddingInlineEndStyleValue {}
+pub struct ScrollPaddingInlineEndStyleValue;
 
 /// Represents the style value for `scroll-padding-block-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-end).
 ///
@@ -302,7 +302,7 @@ pub enum ScrollPaddingInlineEndStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum ScrollPaddingBlockEndStyleValue {}
+pub struct ScrollPaddingBlockEndStyleValue;
 
 // /// Represents the style value for `scroll-padding-block` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block).
 // ///

--- a/crates/css_ast/src/values/text_decor/mod.rs
+++ b/crates/css_ast/src/values/text_decor/mod.rs
@@ -286,7 +286,7 @@ pub enum TextDecorationThicknessStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(widely)]
 #[versions(chrome:87,chrome_android:87,edge:87,firefox:70,firefox_android:79,safari:12.1,safari_ios:12.2)]
-pub enum TextUnderlineOffsetStyleValue {}
+pub struct TextUnderlineOffsetStyleValue;
 
 /// Represents the style value for `text-decoration-trim` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-trim).
 ///

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_mini.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_mini.snap
@@ -19962,11 +19962,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "SpaceBetween": {
-                "kind": "Ident",
-                "offset": 11104,
-                "len": 13
-              }
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 11103,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 11104,
+                  "len": 13
+                }
+              ]
             },
             "important": null,
             "semicolon": {
@@ -24280,11 +24287,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "Center": {
-                "kind": "Ident",
-                "offset": 13966,
-                "len": 6
-              }
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 13965,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 13966,
+                  "len": 6
+                }
+              ]
             },
             "important": null,
             "semicolon": {
@@ -56291,11 +56305,18 @@ expression: result.output.unwrap()
               "len": 1
             },
             "value": {
-              "SpaceBetween": {
-                "kind": "Ident",
-                "offset": 30316,
-                "len": 13
-              }
+              "values": [
+                {
+                  "kind": "Whitespace",
+                  "offset": 30315,
+                  "len": 1
+                },
+                {
+                  "kind": "Ident",
+                  "offset": 30316,
+                  "len": 13
+                }
+              ]
             },
             "important": null,
             "semicolon": {

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -78,7 +78,9 @@ impl ToFieldName for DefType {
 	fn to_variant_name(&self, size_hint: usize) -> Ident {
 		let str: String = match self {
 			Self::Length(_) => "Length".into(),
+			Self::LengthOrAuto(_) => "LengthOrAuto".into(),
 			Self::LengthPercentage(_) => "LengthPercentage".into(),
+			Self::LengthPercentageOrAuto(_) => "LengthPercentageOrAuto".into(),
 			Self::Percentage(_) => "Percentage".into(),
 			Self::Decibel(_) => "Decibel".into(),
 			Self::Angle(_) => "Angle".into(),
@@ -187,7 +189,9 @@ impl ToType for DefType {
 	fn to_types(&self) -> Box<dyn Iterator<Item = TokenStream> + '_> {
 		let type_name = match self {
 			Self::Length(_) => quote! { crate::Length },
+			Self::LengthOrAuto(_) => quote! { crate::LengthOrAuto },
 			Self::LengthPercentage(_) => quote! { crate::LengthPercentage },
+			Self::LengthPercentageOrAuto(_) => quote! { crate::LengthPercentageOrAuto },
 			Self::Percentage(_) => quote! { ::css_parse::T![Dimension::%] },
 			Self::Decibel(_) => quote! { ::css_parse::T![Dimension::Db] },
 			Self::Angle(_) => quote! { crate::Angle },

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -193,12 +193,25 @@ fn def_builds_combinator_with_correct_precedence3() {
 #[test]
 fn def_builds_group_of_types_and_keywords() {
 	assert_eq!(
-		to_valuedef! { <length [1,]> | auto },
+		to_valuedef! { <length [1,]> | foo },
 		Def::Combinator(
-			vec![Def::Type(DefType::Length(DefRange::RangeFrom(1.))), Def::Ident(DefIdent("auto".into()))],
+			vec![Def::Type(DefType::Length(DefRange::RangeFrom(1.))), Def::Ident(DefIdent("foo".into()))],
 			DefCombinatorStyle::Alternatives,
 		)
 	)
+}
+
+#[test]
+fn def_optimizes_length_or_auto_to_lengthorauto_type() {
+	assert_eq!(to_valuedef! { auto | <length> }, Def::Type(DefType::LengthOrAuto(DefRange::None)));
+	assert_eq!(to_valuedef! { <length [1,]> | auto }, Def::Type(DefType::LengthOrAuto(DefRange::RangeFrom(1.))));
+	assert_eq!(
+		to_valuedef! { [ auto | <length-percentage> ]{1,4} },
+		Def::Group(
+			Box::new(Def::Type(DefType::LengthPercentageOrAuto(DefRange::None))),
+			DefGroupStyle::Range(DefRange::Range(1.0..4.0))
+		)
+	);
 }
 
 #[test]
@@ -314,9 +327,9 @@ fn def_builds_multiplier_of_small_range_as_ordered_combinator3() {
 #[test]
 fn def_elides_group_over_single_type() {
 	assert_eq!(
-		to_valuedef! { auto | [ <length> ] },
+		to_valuedef! { foo | [ <length> ] },
 		Def::Combinator(
-			vec![Def::Ident(DefIdent("auto".into())), Def::Type(DefType::Length(DefRange::None)),],
+			vec![Def::Ident(DefIdent("foo".into())), Def::Type(DefType::Length(DefRange::None)),],
 			DefCombinatorStyle::Alternatives
 		)
 	)


### PR DESCRIPTION
Syntax such as `auto | <length>` appears in quite a few values, enough for us to have already created the `LengthOrAuto`
and `LengthPercentageOrAuto` types which simplify this. However def.rs/generate.rs have not supported these types
traditionally.

This change alters def.rs to support these types, by checking for these specific cases - a combinator of alternatives
with a length of 2 where one alternative is the `auto` ident and the other is either `<length>` or `<length-percentage>`. This is a very specific optimisation but one that can be somewhat broadly applied, so is worth implementing.
