### PR TITLE
csskit_proc_macro: Remove DefGroupStyle::Range/OneMustOccur, use Def::Multiplier instead

### DIFF
--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -207,9 +207,10 @@ fn def_optimizes_length_or_auto_to_lengthorauto_type() {
 	assert_eq!(to_valuedef! { <length [1,]> | auto }, Def::Type(DefType::LengthOrAuto(DefRange::RangeFrom(1.))));
 	assert_eq!(
 		to_valuedef! { [ auto | <length-percentage> ]{1,4} },
-		Def::Group(
+		Def::Multiplier(
 			Box::new(Def::Type(DefType::LengthPercentageOrAuto(DefRange::None))),
-			DefGroupStyle::Range(DefRange::Range(1.0..4.0))
+			DefMultiplierSeparator::None,
+			DefRange::Range(1.0..4.0)
 		)
 	);
 }
@@ -378,7 +379,7 @@ fn def_builds_complex_combination_1() {
 		to_valuedef! { [ inset? && <length>{2,} && <color>? ]# | none },
 		Def::Combinator(
 			vec![
-				Def::Group(
+				Def::Multiplier(
 					Box::new(Def::Combinator(
 						vec![
 							Def::Optional(Box::new(Def::Ident(DefIdent("inset".into())))),
@@ -391,7 +392,8 @@ fn def_builds_complex_combination_1() {
 						],
 						DefCombinatorStyle::AllMustOccur,
 					)),
-					DefGroupStyle::OneOrMore,
+					DefMultiplierSeparator::Commas,
+					DefRange::RangeFrom(1.),
 				),
 				Def::Ident(DefIdent("none".into())),
 			],


### PR DESCRIPTION
The implementation of Def originally stuck quite close to css-values' [component value modifiers][1], but as we get
close to covering the whole grammar, things become more readily apparent, such as the work to optimise away groups done
in https://github.com/csskit/csskit/pull/243 - which tried to make it so that DefGroupStyle::None was never a case in
the generated code. Another such win is also possible - the DefGroupStyle::OneOrMore and DefGroupStyle::Range are
(effectively) semantically identical to Multiplier of OneOrMoreCommaSeparated and Multiplier with a Range.

So this change removes the DefGroupStyle::OneOrMore and DefGroupStyle::Range variants, and instead during definition
parse time those groups will be converted into the respective Multiplier values. The result of this should be that
generator code no longer needs to worry about Groups (apart from the OneMustOccur group) and instead the Multiplier
branches can cover these cases.

[1]: https://drafts.csswg.org/css-values-4/#component-combinators
