### PR TITLE
csskit_proc_macro: split out optimization pass of Def parsing, optimize more

### DIFF
--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -205,12 +205,20 @@ fn def_builds_group_of_types_and_keywords() {
 fn def_optimizes_length_or_auto_to_lengthorauto_type() {
 	assert_eq!(to_valuedef! { auto | <length> }, Def::Type(DefType::LengthOrAuto(DefRange::None)));
 	assert_eq!(to_valuedef! { <length [1,]> | auto }, Def::Type(DefType::LengthOrAuto(DefRange::RangeFrom(1.))));
+}
+
+#[test]
+fn def_optimizes_length_or_auto_range_to_ordered_combinator_lengthorauto_type() {
 	assert_eq!(
 		to_valuedef! { [ auto | <length-percentage> ]{1,4} },
-		Def::Multiplier(
-			Box::new(Def::Type(DefType::LengthPercentageOrAuto(DefRange::None))),
-			DefMultiplierSeparator::None,
-			DefRange::Range(1.0..4.0)
+		Def::Combinator(
+			vec![
+				Def::Type(DefType::LengthPercentageOrAuto(DefRange::None)),
+				Def::Optional(Box::new(Def::Type(DefType::LengthPercentageOrAuto(DefRange::None)))),
+				Def::Optional(Box::new(Def::Type(DefType::LengthPercentageOrAuto(DefRange::None)))),
+				Def::Optional(Box::new(Def::Type(DefType::LengthPercentageOrAuto(DefRange::None)))),
+			],
+			DefCombinatorStyle::Ordered
 		)
 	);
 }


### PR DESCRIPTION
Following up from https://github.com/csskit/csskit/pull/256, a syntax like `[ auto | length ]{1,2}` could be optimised
as a Multiplier of LengthOrAutos, but we can go a step further and optimize it to a Combinator of [LengthOrAuto,
Optional<LengthOrAuto>]. We already do this throughout the parsing phase when other Multipliers are generated, but
https://github.com/csskit/csskit/pull/256 introduced a new callsite where a Multiplier could be generated.

This change optimizes that new case, but rather than repeating code it takes the opportunity to pull out the
optimization steps into a separate function which can be repeatedly called to help minimise the depth of a parse tree.
Practically speaking this really only benefits this case for now, but this gives us an easy place to further add
optimisations without having to entangle them further in the parse steps.
