### PR TITLE
Implement TimeOrAuto, optimize for it in Defs, and uncomment AnimationDurationStyleValue.

### DIFF
--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -41,6 +41,25 @@ impl<'a> Build<'a> for Time {
 	}
 }
 
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+pub enum TimeOrAuto {
+	Auto(T![Ident]),
+	Time(Time),
+}
+
+impl<'a> Peek<'a> for TimeOrAuto {
+	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
+		Time::peek(p, c) || (<T![Ident]>::peek(p, c) && p.eq_ignore_ascii_case(c, "auto"))
+	}
+}
+
+impl<'a> Build<'a> for TimeOrAuto {
+	fn build(p: &Parser<'a>, c: Cursor) -> Self {
+		if Time::peek(p, c) { Self::Time(Time::build(p, c)) } else { Self::Auto(<T![Ident]>::build(p, c)) }
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/css_ast/src/values/align/mod.rs
+++ b/crates/css_ast/src/values/align/mod.rs
@@ -51,28 +51,28 @@ pub enum AlignContentStyleValue {}
 // #[versions(Unknown)]
 // pub enum JustifyContentStyleValue {}
 
-///// Represents the style value for `place-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-content).
-/////
-/////
-///// The grammar is defined as:
-/////
-///// ```text,ignore
-///// <'align-content'> <'justify-content'>?
-///// ```
-/////
-//// https://drafts.csswg.org/css-align-3/#place-content
-//#[value(" <'align-content'> <'justify-content'>? ")]
-//#[initial("normal")]
-//#[applies_to("block containers, flex containers, and grid containers")]
-//#[inherited("no")]
-//#[percentages("n/a")]
-//#[canonical_order("per grammar")]
-//#[animation_type("discrete")]
-//#[popularity(Unknown)]
-//#[caniuse(Unknown)]
-//#[baseline(Unknown)]
-//#[versions(Unknown)]
-//pub struct PlaceContentStyleValue;
+// /// Represents the style value for `place-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-content).
+// ///
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'align-content'> <'justify-content'>?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-align-3/#place-content
+// #[value(" <'align-content'> <'justify-content'>? ")]
+// #[initial("normal")]
+// #[applies_to("block containers, flex containers, and grid containers")]
+// #[inherited("no")]
+// #[percentages("n/a")]
+// #[canonical_order("per grammar")]
+// #[animation_type("discrete")]
+// #[popularity(Unknown)]
+// #[caniuse(Unknown)]
+// #[baseline(Unknown)]
+// #[versions(Unknown)]
+// pub struct PlaceContentStyleValue;
 
 // /// Represents the style value for `justify-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-self).
 // ///

--- a/crates/css_ast/src/values/animations/mod.rs
+++ b/crates/css_ast/src/values/animations/mod.rs
@@ -28,28 +28,28 @@ use impls::*;
 // #[versions(Unknown)]
 // pub enum AnimationNameStyleValue<'a> {}
 
-// /// Represents the style value for `animation-duration` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-duration).
-// ///
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ auto | <time [0s,∞]> ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-animations-2/#animation-duration
-// #[value(" [ auto | <time [0s,∞]> ]# ")]
-// #[initial("auto")]
-// #[applies_to("all elements")]
-// #[inherited("no")]
-// #[percentages("n/a")]
-// #[canonical_order("per grammar")]
-// #[animation_type("not animatable")]
-// #[popularity(Unknown)]
-// #[caniuse(Unknown)]
-// #[baseline(Unknown)]
-// #[versions(Unknown)]
-// pub enum AnimationDurationStyleValue<'a> {}
+/// Represents the style value for `animation-duration` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-duration).
+///
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// [ auto | <time [0s,∞]> ]#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-duration
+#[value(" [ auto | <time [0s,∞]> ]# ")]
+#[initial("auto")]
+#[applies_to("all elements")]
+#[inherited("no")]
+#[percentages("n/a")]
+#[canonical_order("per grammar")]
+#[animation_type("not animatable")]
+#[popularity(Unknown)]
+#[caniuse(Unknown)]
+#[baseline(Unknown)]
+#[versions(Unknown)]
+pub struct AnimationDurationStyleValue<'a>;
 
 /// Represents the style value for `animation-timing-function` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-timing-function).
 ///

--- a/crates/css_ast/src/values/speech/mod.rs
+++ b/crates/css_ast/src/values/speech/mod.rs
@@ -446,4 +446,4 @@ pub enum VoiceStressStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum VoiceDurationStyleValue {}
+pub struct VoiceDurationStyleValue;

--- a/crates/csskit_proc_macro/src/def.rs
+++ b/crates/csskit_proc_macro/src/def.rs
@@ -78,6 +78,7 @@ pub(crate) enum DefType {
 	Decibel(DefRange),
 	Angle(DefRange),
 	Time(DefRange),
+	TimeOrAuto(DefRange),
 	Resolution(DefRange),
 	Integer(DefRange),
 	Number(DefRange),
@@ -252,6 +253,13 @@ impl Def {
 					{
 						Def::Type(DefType::LengthPercentageOrAuto(r.clone()))
 					}
+					// "<time> | auto" can be simplified to "<time-or-auto>"
+					(Def::Ident(DefIdent(ident)), Def::Type(DefType::Time(r)))
+					| (Def::Type(DefType::Time(r)), Def::Ident(DefIdent(ident)))
+						if ident == "auto" =>
+					{
+						Def::Type(DefType::TimeOrAuto(r.clone()))
+					}
 					_ => self,
 				}
 			}
@@ -332,6 +340,7 @@ impl Parse for DefType {
 			"decibel" => Self::Decibel(checks),
 			"angle" => Self::Angle(checks),
 			"time" => Self::Time(checks),
+			"time-or-auto" => Self::TimeOrAuto(checks),
 			"resolution" => Self::Resolution(checks),
 			"integer" => Self::Integer(checks),
 			"number" => Self::Number(checks),

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -85,6 +85,7 @@ impl ToFieldName for DefType {
 			Self::Decibel(_) => "Decibel".into(),
 			Self::Angle(_) => "Angle".into(),
 			Self::Time(_) => "Time".into(),
+			Self::TimeOrAuto(_) => "TimeOrAuto".into(),
 			Self::Resolution(_) => "Resolution".into(),
 			Self::Integer(_) => "Integer".into(),
 			Self::Number(_) => "Number".into(),
@@ -196,6 +197,7 @@ impl ToType for DefType {
 			Self::Decibel(_) => quote! { ::css_parse::T![Dimension::Db] },
 			Self::Angle(_) => quote! { crate::Angle },
 			Self::Time(_) => quote! { crate::Time },
+			Self::TimeOrAuto(_) => quote! { crate::TimeOrAuto },
 			Self::Resolution(_) => quote! { crate::Resolution },
 			Self::Integer(_) => quote! { crate::CSSInt },
 			Self::Number(_) => quote! { ::css_parse::T![Number] },
@@ -968,6 +970,7 @@ impl GenerateParseImpl for DefType {
 
 		let name = self.to_singular_type();
 		let checks = self.checks();
+
 		let check_code = match checks {
 			DefRange::RangeTo(end) => quote! {
 			let valf32: f32 = ty.into();

--- a/tasks/generate-values/mod.ts
+++ b/tasks/generate-values/mod.ts
@@ -22,7 +22,6 @@ const todoPropertiesThatWillBeCommentedOut = new Map([
 		"animations",
 		new Set([
 			"animation",
-			"animation-duration",
 			"animation-name",
 			"animation-trigger-exit-range",
 			"animation-trigger-exit-range-end",
@@ -126,13 +125,7 @@ const todoPropertiesThatWillBeCommentedOut = new Map([
 	["overscroll", new Set(["overscroll-behavior"])],
 	["regions", new Set(["flow-into"])],
 	["ruby", new Set(["ruby-position"])],
-	[
-		"scroll-snap",
-		new Set([
-			"scroll-snap-align",
-			"scroll-snap-type",
-		]),
-	],
+	["scroll-snap", new Set(["scroll-snap-align", "scroll-snap-type"])],
 	["shapes", new Set(["shape-inside", "shape-outside"])],
 	[
 		"sizing",
@@ -200,6 +193,7 @@ const requiresAllocatorLifetime = new Map([
 // parse so let's just hardcode a list...
 const enumOverrides = new Map([["animation", new Set(["animation-name"])]]);
 const structOverrides = new Map([
+	["animations", new Set(["animation-duration"])],
 	["box", new Set(["margin-top", "margin-right", "margin-bottom", "margin-left"])],
 	["multicol", new Set(["column-width", "column-height"])],
 	[
@@ -231,6 +225,7 @@ const structOverrides = new Map([
 			"scroll-padding-top",
 		]),
 	],
+	["speech", new Set(["voice-duration"])],
 	["text-decor", new Set(["text-underline-offset"])],
 ]);
 


### PR DESCRIPTION
In https://github.com/csskit/csskit/pull/257 we optimized for values like `auto | <length>` to use the LengthOrAuto
struct, but we can also do the same for syntaxes that use `auto | <time>`.

This change introduces a TimeOrAuto enum which is similar to LengthOrAuto. This change also implements the requisite
code paths in def.rs and generate.rs to leverage this new type, which lets us unlock animation-duration!
