### PR TITLE
csskit_proc_macro: Generate structs for multipliers of keywords

### DIFF
--- a/crates/csskit_proc_macro/src/def.rs
+++ b/crates/csskit_proc_macro/src/def.rs
@@ -446,3 +446,9 @@ impl From<DefIdent> for Ident {
 		format_ident!("{}", value.0)
 	}
 }
+
+impl From<Ident> for DefIdent {
+	fn from(value: Ident) -> Self {
+		Self(value.to_string())
+	}
+}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
@@ -28,7 +28,7 @@ enum Foo {
 impl<'a> ::css_parse::Peek<'a> for Foo {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
         use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c)
+        <crate::FooKeywords>::peek(p, c)
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
@@ -1,0 +1,34 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(pub enum FooKeywords { Outset : "outset", Inset : "inset", });
+#[derive(
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::ToCursors,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::FooKeywords>);
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+        use ::css_parse::Peek;
+        <crate::FooKeywords>::peek(p, c)
+    }
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
+    fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
+        use ::css_parse::{Parse, Peek};
+        return Ok(
+            Self(p.parse::<::css_parse::CommaSeparated<'a, crate::FooKeywords>>()?),
+        );
+    }
+}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
@@ -1,0 +1,39 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(pub enum FooKeywords { Outset : "outset", Inset : "inset", });
+#[derive(
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::ToCursors,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+struct Foo<'a>(pub ::bumpalo::collections::Vec<'a, crate::FooKeywords>);
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+        use ::css_parse::Peek;
+        <crate::FooKeywords>::peek(p, c)
+    }
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
+    fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
+        use ::css_parse::{Parse, Peek};
+        let mut items = ::bumpalo::collections::Vec::new_in(p.bump());
+        loop {
+            items.push(p.parse::<crate::FooKeywords>()?);
+            if !p.peek::<crate::FooKeywords>() {
+                break;
+            }
+        }
+        return Ok(Self(items));
+    }
+}

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -679,6 +679,20 @@ fn combinator_optional_keywords_and_types() {
 }
 
 #[test]
+fn multiplier_with_just_keywords() {
+	let syntax = to_valuedef! { [ outset | inset ]+ };
+	let data = to_deriveinput! { struct Foo<'a> {} };
+	assert_snapshot!(syntax, data, "multiplier_with_just_keywords");
+}
+
+#[test]
+fn multiplier_with_comma_separated_keywords() {
+	let syntax = to_valuedef! { [ outset | inset ]# };
+	let data = to_deriveinput! { struct Foo<'a> {} };
+	assert_snapshot!(syntax, data, "multiplier_with_comma_separated_keywords");
+}
+
+#[test]
 fn group_with_optional_leader() {
 	let syntax = to_valuedef! { normal | [ <overflow-position>? <self-position> ] };
 	let data = to_deriveinput! { enum Foo {} };


### PR DESCRIPTION
Some style values are just a multiplier over a keyword set. These can be somewhat easily generated by using the
`FooKeywords` type which we already generate for when there are many keywords.

So this change does that, we can do a little trick by matching for these cases (a multiplier of a combinator of
alternatives where all the alternatives are Idents) and generating a _new_ Def which is a multiplier of the type
`FooKeywords` (where `Foo` is the struct name). This then generates the appropriate parse/peek code.

This should unlock extra values.
