### PR TITLE
csskit_proc_macro: Generate sub-types where applicable

### DIFF
--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
@@ -1,0 +1,70 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(pub enum FooKeywords { Foo : "foo", });
+#[derive(
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::ToCursors,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+enum SingleFoo<'a> {
+    Foo(::css_parse::T![Ident]),
+    Bar(crate::Bar),
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for SingleFoo<'a> {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+        use ::css_parse::Peek;
+        <::css_parse::T![Ident]>::peek(p, c) || <crate::Bar>::peek(p, c)
+    }
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for SingleFoo<'a> {
+    fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
+        use ::css_parse::{Parse, Peek};
+        match p.parse_if_peek::<SingleFooKeywords>()? {
+            Some(SingleFooKeywords::Foo(ident)) => {
+                return Ok(Self::Foo(ident));
+            }
+            None => {}
+        };
+        Ok(Self::Bar(p.parse::<crate::Bar>()?))
+    }
+}
+#[derive(
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::ToCursors,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+struct Foo<'a>(
+    pub ::css_parse::CommaSeparated<'a, (::css_parse::T![Ident], crate::Bar)>,
+);
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+        use ::css_parse::Peek;
+        <::css_parse::T![Ident]>::peek(p, c) || <crate::Bar>::peek(p, c)
+    }
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
+    fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
+        use ::css_parse::{Parse, Peek};
+        return Ok(Self(p.parse::<::css_parse::CommaSeparated<'a, crate::SingleFoo>>()?));
+    }
+}

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -693,6 +693,13 @@ fn multiplier_with_comma_separated_keywords() {
 }
 
 #[test]
+fn multiplier_with_comma_separated_type() {
+	let syntax = to_valuedef! { [ foo | <bar> ]# };
+	let data = to_deriveinput! { struct Foo<'a> {} };
+	assert_snapshot!(syntax, data, "multiplier_with_comma_separated_types");
+}
+
+#[test]
 fn group_with_optional_leader() {
 	let syntax = to_valuedef! { normal | [ <overflow-position>? <self-position> ] };
 	let data = to_deriveinput! { enum Foo {} };

--- a/crates/csskit_proc_macro/src/value.rs
+++ b/crates/csskit_proc_macro/src/value.rs
@@ -37,12 +37,12 @@ pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 			return Error::new(ident.span(), "cannot create from_syntax on Union").into_compile_error();
 		}
 	}
-	let keyword_def = defs.generate_keyword_set(ident);
+	let additonal_defs = defs.generate_additional_types(vis, ident, &ast.generics);
 	let def = defs.generate_definition(vis, ident, &ast.generics);
 	let peek_impl = defs.generate_peek_trait_implementation(ident, &ast.generics);
 	let parse_impl = defs.generate_parse_trait_implementation(ident, &ast.generics);
 	quote! {
-		#keyword_def
+		#additonal_defs
 
 		#(#attrs)*
 		#[derive(::csskit_derives::ToSpan, ::csskit_derives::ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
Many style values are a multiple of some combinator, where the easiest way to generate the value would be to use a
subtype. Some grammars explicitly do this, for example `<single-animation>#`, while others are more implicit, e.g.
`[ none | <keyframes-name> ]#`. For these multipliers, we can generate the additional sub-types during the proc macro
phase, much like we do with the `*Keywords` structs.

This change introduces a `generate_additional_types` method to `Def`, which takes the existing `generate_keyword_set`
function and enhances it, adding sub-types where needed. Also complemented with a snapshot test which looks like it's
generating the right code!

With this change a grammar like `[ none | <keyframes-name> ]#` on a struct like `AnimationName` will generate a new
type of `SingleAnimationName` with a grammar of `none | <keyfrmas-name>`. The generation for `AnimationName` is then
trivial as it becomes a `CommaSeparated<SingleAnimationName>`.
