### PR TITLE
csskit_proc_macro: Refine generating subtypes

### DIFF
--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
@@ -15,23 +15,23 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-enum SingleFoo<'a> {
+enum SingleFoo {
     Foo(::css_parse::T![Ident]),
     Bar(crate::Bar),
 }
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for SingleFoo<'a> {
+impl<'a> ::css_parse::Peek<'a> for SingleFoo {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::Bar>::peek(p, c)
     }
 }
 #[automatically_derived]
-impl<'a> ::css_parse::Parse<'a> for SingleFoo<'a> {
+impl<'a> ::css_parse::Parse<'a> for SingleFoo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        match p.parse_if_peek::<SingleFooKeywords>()? {
-            Some(SingleFooKeywords::Foo(ident)) => {
+        match p.parse_if_peek::<FooKeywords>()? {
+            Some(FooKeywords::Foo(ident)) => {
                 return Ok(Self::Foo(ident));
             }
             None => {}
@@ -51,14 +51,12 @@ impl<'a> ::css_parse::Parse<'a> for SingleFoo<'a> {
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-struct Foo<'a>(
-    pub ::css_parse::CommaSeparated<'a, (::css_parse::T![Ident], crate::Bar)>,
-);
+struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::SingleFoo>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
         use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::Bar>::peek(p, c)
+        <crate::SingleFoo>::peek(p, c)
     }
 }
 #[automatically_derived]


### PR DESCRIPTION
https://github.com/csskit/csskit/pull/273 was a bit eagerly merged. The generated code didn't build because of a few
issues:

 - The Multiplier match generating `Single<Type>` wasn't created for peek/definition so only parse referenced
   `Single<Type>`. These have now been added meaning peek/definition actually generate the right code.

 - The subtype inherited generics, which isn't really sensible as they might not rely on them - instead now generics
	 are generated for the subtypes by checking `requires_allocator_lifetime`.
