### PR TITLE
csskit_proc_macro: Refine generation for bounded multiplier of keywords

### DIFF
--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
@@ -2,9 +2,7 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(
-    pub enum FooKeywords { None : "none", Some : "some", None : "none", Some : "some", }
-);
+::css_parse::keyword_set!(pub enum FooKeywords { None : "none", Some : "some", });
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -29,8 +27,8 @@ impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        let val0 = FooKeywords::parse(p);
-        let val1 = FooKeywords::parse(p);
+        let val0 = p.parse::<FooKeywords>()?.into();
+        let val1 = p.parse_if_peek::<FooKeywords>()?.map(|kw| kw.into());
         Ok(Self(val0, val1))
     }
 }


### PR DESCRIPTION
Once again https://github.com/csskit/csskit/pull/286 was merged a little too hastily, as it didn't quite produce proper
code. This fixes the issues with it.
