### PR TITLE
css_ast: Implement BorderImageRepeatStyleValue

### DIFF
--- a/crates/css_ast/src/values/backgrounds/impls.rs
+++ b/crates/css_ast/src/values/backgrounds/impls.rs
@@ -21,7 +21,7 @@ mod tests {
 		// assert_eq!(std::mem::size_of::<BorderImageSliceStyleValue>(), 1);
 		// assert_eq!(std::mem::size_of::<BorderImageWidthStyleValue>(), 1);
 		// assert_eq!(std::mem::size_of::<BorderImageOutsetStyleValue>(), 1);
-		// assert_eq!(std::mem::size_of::<BorderImageRepeatStyleValue>(), 1);
+		assert_eq!(std::mem::size_of::<BorderImageRepeatStyleValue>(), 28);
 		// assert_eq!(std::mem::size_of::<BorderImageStyleValue>(), 1);
 		assert_eq!(std::mem::size_of::<BackgroundRepeatXStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<BackgroundRepeatYStyleValue>(), 32);
@@ -37,5 +37,7 @@ mod tests {
 	fn test_writes() {
 		assert_parse!(BackgroundRepeatStyleValue, "repeat-x");
 		assert_parse!(BackgroundRepeatStyleValue, "space round");
+		assert_parse!(BorderImageRepeatStyleValue, "stretch");
+		assert_parse!(BorderImageRepeatStyleValue, "stretch stretch");
 	}
 }

--- a/crates/css_ast/src/values/backgrounds/mod.rs
+++ b/crates/css_ast/src/values/backgrounds/mod.rs
@@ -313,28 +313,28 @@ pub enum BorderImageSourceStyleValue<'a> {}
 // #[versions(Unknown)]
 // pub struct BorderImageOutsetStyleValue;
 
-// /// Represents the style value for `border-image-repeat` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#border-image-repeat).
-// ///
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ stretch | repeat | round | space ]{1,2}
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-backgrounds-4/#border-image-repeat
-// #[value(" [ stretch | repeat | round | space ]{1,2} ")]
-// #[initial("stretch")]
-// #[applies_to("All elements, except internal table elements when border-collapse is collapse")]
-// #[inherited("no")]
-// #[percentages("n/a")]
-// #[canonical_order("per grammar")]
-// #[animation_type("discrete")]
-// #[popularity(Unknown)]
-// #[caniuse(Unknown)]
-// #[baseline(Unknown)]
-// #[versions(Unknown)]
-// pub struct BorderImageRepeatStyleValue;
+/// Represents the style value for `border-image-repeat` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#border-image-repeat).
+///
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// [ stretch | repeat | round | space ]{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#border-image-repeat
+#[value(" [ stretch | repeat | round | space ]{1,2} ")]
+#[initial("stretch")]
+#[applies_to("All elements, except internal table elements when border-collapse is collapse")]
+#[inherited("no")]
+#[percentages("n/a")]
+#[canonical_order("per grammar")]
+#[animation_type("discrete")]
+#[popularity(Unknown)]
+#[caniuse(Unknown)]
+#[baseline(Unknown)]
+#[versions(Unknown)]
+pub struct BorderImageRepeatStyleValue;
 
 // /// Represents the style value for `border-image` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#border-image).
 // ///

--- a/tasks/generate-values/mod.ts
+++ b/tasks/generate-values/mod.ts
@@ -101,9 +101,6 @@ const todoPropertiesThatWillBeCommentedOut = new Map([
 			// [ <length [0,∞]> | <number [0,∞]> ]{1,4}
 			"border-image-outset",
 
-			// [ stretch | repeat | round | space ]{1,2}
-			"border-image-repeat",
-
 			// [<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?
 			"border-image-slice",
 


### PR DESCRIPTION
Now https://github.com/csskit/csskit/pull/286 (and https://github.com/csskit/csskit/pull/287) are in we can trivially
unlock BorderImageRepeatStyleValue.
