### PR TITLE
 css_ast: Add contain keywords for width/height/etc 

### DIFF
--- a/crates/css_ast/src/values/sizing/impls.rs
+++ b/crates/css_ast/src/values/sizing/impls.rs
@@ -39,6 +39,8 @@ mod tests {
 		assert_parse!(WidthStyleValue, "fit-content");
 		assert_parse!(WidthStyleValue, "fit-content(20rem)");
 		assert_parse!(WidthStyleValue, "fit-content(0)");
+		assert_parse!(WidthStyleValue, "stretch");
+		assert_parse!(WidthStyleValue, "contain");
 
 		assert_parse!(AspectRatioStyleValue, "auto 1/5");
 		assert_parse!(AspectRatioStyleValue, "auto 1/2");

--- a/crates/css_ast/src/values/sizing/mod.rs
+++ b/crates/css_ast/src/values/sizing/mod.rs
@@ -11,12 +11,12 @@ use impls::*;
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content
+/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
 /// ```
 ///
 // https://drafts.csswg.org/css-sizing-4/#width
 #[value(
-	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content "
+	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
 #[initial("auto")]
 #[applies_to("all elements except non-replaced inlines")]
@@ -36,12 +36,12 @@ pub enum WidthStyleValue {}
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content
+/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
 /// ```
 ///
 // https://drafts.csswg.org/css-sizing-4/#height
 #[value(
-	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content "
+	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
 #[initial("auto")]
 #[applies_to("all elements except non-replaced inlines")]
@@ -61,12 +61,12 @@ pub enum HeightStyleValue {}
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content
+/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
 /// ```
 ///
 // https://drafts.csswg.org/css-sizing-4/#min-width
 #[value(
-	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content "
+	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
 #[initial("auto")]
 #[applies_to("all elements that accept width or height")]
@@ -86,12 +86,12 @@ pub enum MinWidthStyleValue {}
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content
+/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
 /// ```
 ///
 // https://drafts.csswg.org/css-sizing-4/#min-height
 #[value(
-	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content "
+	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
 #[initial("auto")]
 #[applies_to("all elements that accept width or height")]
@@ -111,12 +111,12 @@ pub enum MinHeightStyleValue {}
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content
+/// none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
 /// ```
 ///
 // https://drafts.csswg.org/css-sizing-4/#max-width
 #[value(
-	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content "
+	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
 #[initial("none")]
 #[applies_to("all elements that accept width or height")]
@@ -136,12 +136,12 @@ pub enum MaxWidthStyleValue {}
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content
+/// none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
 /// ```
 ///
 // https://drafts.csswg.org/css-sizing-4/#max-height
 #[value(
-	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content "
+	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
 #[initial("none")]
 #[applies_to("all elements that accept width or height")]

--- a/tasks/generate-values/mod.ts
+++ b/tasks/generate-values/mod.ts
@@ -556,12 +556,12 @@ const valueExtensions = new Map([
 	[
 		"sizing",
 		{
-			width: " | stretch | fit-content",
-			"max-width": " | stretch | fit-content",
-			"min-width": " | stretch | fit-content",
-			height: " | stretch | fit-content",
-			"max-height": " | stretch | fit-content",
-			"min-height": " | stretch | fit-content",
+			width: " | stretch | fit-content | contain",
+			"max-width": " | stretch | fit-content | contain",
+			"min-width": " | stretch | fit-content | contain",
+			height: " | stretch | fit-content | contain",
+			"max-height": " | stretch | fit-content | contain",
+			"min-height": " | stretch | fit-content | contain",
 		},
 	],
 ]);


### PR DESCRIPTION
This new keyword was added to https://drafts.csswg.org/css-sizing-4/#sizing-values at some point, so we should ensure
it's reflected in our grammars. This also adds tests to keep us honest.