### PR TITLE
Implement combined types NumberPercentage, NumberLength, NumberLengthOrAuto.

### DIFF
--- a/crates/css_ast/src/values/text/mod.rs
+++ b/crates/css_ast/src/values/text/mod.rs
@@ -77,7 +77,7 @@ use impls::*;
 #[caniuse("https://caniuse.com/css3-tabsize")]
 #[baseline(widely)]
 #[versions(chrome:42,chrome_android:42,edge:79,firefox:91,firefox_android:91,safari:13.1,safari_ios:13.4)]
-pub enum TabSizeStyleValue {}
+pub struct TabSizeStyleValue;
 
 /// Represents the style value for `word-break` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-break).
 ///

--- a/crates/css_ast/src/values/viewport/mod.rs
+++ b/crates/css_ast/src/values/viewport/mod.rs
@@ -27,4 +27,4 @@ use impls::*;
 #[caniuse("https://caniuse.com/css-zoom")]
 #[baseline(newly)]
 #[versions(chrome:1,chrome_android:18,edge:12,firefox:126,firefox_android:126,safari:3.1,safari_ios:3)]
-pub enum ZoomStyleValue {}
+pub struct ZoomStyleValue;

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -78,6 +78,9 @@ impl ToFieldName for DefType {
 			Self::LengthPercentage(_) => "LengthPercentage".into(),
 			Self::LengthPercentageOrAuto(_) => "LengthPercentageOrAuto".into(),
 			Self::LengthPercentageOrFlex(_) => "LengthPercentageOrFlex".into(),
+			Self::NumberLength(_) => "NumberLength".into(),
+			Self::NumberPercentage(_) => "NumberPercentage".into(),
+			Self::NumberLengthOrAuto(_) => "NumberLengthOrAuto".into(),
 			Self::Percentage(_) => "Percentage".into(),
 			Self::Decibel(_) => "Decibel".into(),
 			Self::Angle(_) => "Angle".into(),
@@ -194,6 +197,9 @@ impl ToType for DefType {
 			Self::LengthPercentage(_) => quote! { crate::LengthPercentage },
 			Self::LengthPercentageOrAuto(_) => quote! { crate::LengthPercentageOrAuto },
 			Self::LengthPercentageOrFlex(_) => quote! { crate::LengthPercentageOrFlex },
+			Self::NumberLength(_) => quote! { crate::NumberLength },
+			Self::NumberPercentage(_) => quote! { crate::NumberPercentage },
+			Self::NumberLengthOrAuto(_) => quote! { crate::NumberLengthOrAuto },
 			Self::Percentage(_) => quote! { ::css_parse::T![Dimension::%] },
 			Self::Decibel(_) => quote! { ::css_parse::T![Dimension::Db] },
 			Self::Angle(_) => quote! { crate::Angle },
@@ -1132,6 +1138,9 @@ impl DefType {
 			Self::Length(c)
 			| Self::LengthPercentage(c)
 			| Self::Percentage(c)
+			| Self::NumberPercentage(c)
+			| Self::NumberLength(c)
+			| Self::NumberLengthOrAuto(c)
 			| Self::Decibel(c)
 			| Self::Angle(c)
 			| Self::Time(c)

--- a/tasks/generate-values/mod.ts
+++ b/tasks/generate-values/mod.ts
@@ -807,8 +807,12 @@ async function getSpec(name: string, index: Record<string, number[]>) {
 			.replace(/<[^>]+>/g, "")
 			.replace(/\[[^\[\]]*\]/g, "")
 			.trim();
-		const isTypeOrAuto = /^(auto \| <(length|time)(?:[^\|]+)|<(length|time)(?:[^\|]+)> \| auto)$/.test(table.value);
-		const hasTopLevelAlternative = /(?<!\|)\|(?!\|)/.test(justTopLevels) && !isTypeOrAuto;
+		const isCombinedType = /^<(length|time|number|percentage)(?:[^\|]+) \| <(length|time|number|percentage)(?:[^\|]+)>$/.test(table.value);
+		console.log(table.value, isCombinedType);
+		const isTypeOrAuto = /^auto \| <(length|time|number)(?:[^\|]+)$|^<(length|time|number)(?:[^\|]+)> \| auto$/.test(
+			table.value,
+		);
+		const hasTopLevelAlternative = /(?<!\|)\|(?!\|)/.test(justTopLevels) && !isCombinedType && !isTypeOrAuto;
 		if (enums?.has(table.name) && structs?.has(table.name)) {
 			throw new Error(
 				`${table.name} was in both the enumOverrides table and the structOverrides table. It should not be in both.`,


### PR DESCRIPTION
Many types are based on a combination of Length/Percentage/Number, such as:

- `<length> | auto`
- `<length> | <percentage>`
- `<number> | <percentage>`
- `<number> | <percentage> | auto`

For many of these types we - and CSS - flattens them into more convenient types such as `<length-percentage>`. Some,
however, are not.

This change finds more of these types and collapses them into such combined-types, namely:

- `<number> | <percentage>`
- `<number> | <length>`
- `<number> | <length> | auto`

This should unlock more properties for us to enable.
