### PR TITLE
css_ast: Implement BorderImageOutsetStyleValue, ScaleStyleValue

### DIFF
--- a/crates/css_ast/src/values/backgrounds/impls.rs
+++ b/crates/css_ast/src/values/backgrounds/impls.rs
@@ -4,7 +4,7 @@ pub(crate) use csskit_proc_macro::*;
 #[cfg(test)]
 mod tests {
 	use super::super::*;
-	use css_parse::assert_parse;
+	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
 	fn size_test() {
@@ -20,7 +20,7 @@ mod tests {
 		assert_eq!(std::mem::size_of::<BorderImageSourceStyleValue>(), 216);
 		// assert_eq!(std::mem::size_of::<BorderImageSliceStyleValue>(), 1);
 		// assert_eq!(std::mem::size_of::<BorderImageWidthStyleValue>(), 1);
-		// assert_eq!(std::mem::size_of::<BorderImageOutsetStyleValue>(), 1);
+		assert_eq!(std::mem::size_of::<BorderImageOutsetStyleValue>(), 64);
 		assert_eq!(std::mem::size_of::<BorderImageRepeatStyleValue>(), 28);
 		// assert_eq!(std::mem::size_of::<BorderImageStyleValue>(), 1);
 		assert_eq!(std::mem::size_of::<BackgroundRepeatXStyleValue>(), 32);
@@ -37,7 +37,16 @@ mod tests {
 	fn test_writes() {
 		assert_parse!(BackgroundRepeatStyleValue, "repeat-x");
 		assert_parse!(BackgroundRepeatStyleValue, "space round");
+		assert_parse!(BorderImageOutsetStyleValue, "10");
+		assert_parse!(BorderImageOutsetStyleValue, "10px");
+		assert_parse!(BorderImageOutsetStyleValue, "10px 10rem 10q 10em");
+		assert_parse!(BorderImageOutsetStyleValue, "10 1ric 10 10");
 		assert_parse!(BorderImageRepeatStyleValue, "stretch");
 		assert_parse!(BorderImageRepeatStyleValue, "stretch stretch");
+	}
+
+	#[test]
+	fn test_errors() {
+		assert_parse_error!(BorderImageOutsetStyleValue, "-10");
 	}
 }

--- a/crates/css_ast/src/values/backgrounds/mod.rs
+++ b/crates/css_ast/src/values/backgrounds/mod.rs
@@ -290,28 +290,28 @@ pub enum BorderImageSourceStyleValue<'a> {}
 // #[versions(Unknown)]
 // pub struct BorderImageWidthStyleValue;
 
-// /// Represents the style value for `border-image-outset` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#border-image-outset).
-// ///
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ <length [0,∞]> | <number [0,∞]> ]{1,4}
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-backgrounds-4/#border-image-outset
-// #[value(" [ <length [0,∞]> | <number [0,∞]> ]{1,4} ")]
-// #[initial("0")]
-// #[applies_to("All elements, except internal table elements when border-collapse is collapse")]
-// #[inherited("no")]
-// #[percentages("n/a")]
-// #[canonical_order("per grammar")]
-// #[animation_type("by computed value")]
-// #[popularity(Unknown)]
-// #[caniuse(Unknown)]
-// #[baseline(Unknown)]
-// #[versions(Unknown)]
-// pub struct BorderImageOutsetStyleValue;
+/// Represents the style value for `border-image-outset` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#border-image-outset).
+///
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// [ <length [0,∞]> | <number [0,∞]> ]{1,4}
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#border-image-outset
+#[value(" [ <length [0,∞]> | <number [0,∞]> ]{1,4} ")]
+#[initial("0")]
+#[applies_to("All elements, except internal table elements when border-collapse is collapse")]
+#[inherited("no")]
+#[percentages("n/a")]
+#[canonical_order("per grammar")]
+#[animation_type("by computed value")]
+#[popularity(Unknown)]
+#[caniuse(Unknown)]
+#[baseline(Unknown)]
+#[versions(Unknown)]
+pub struct BorderImageOutsetStyleValue;
 
 /// Represents the style value for `border-image-repeat` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#border-image-repeat).
 ///

--- a/crates/css_ast/src/values/transforms/impls.rs
+++ b/crates/css_ast/src/values/transforms/impls.rs
@@ -1,2 +1,42 @@
 pub(crate) use crate::traits::StyleValue;
 pub(crate) use csskit_proc_macro::*;
+
+#[cfg(test)]
+mod tests {
+	use super::super::*;
+	use css_parse::{assert_parse, assert_parse_error};
+
+	#[test]
+	fn size_test() {
+		assert_eq!(std::mem::size_of::<TransformStyleValue>(), 32);
+		// assert_eq!(std::mem::size_of::<TransformOriginStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<TransformBoxStyleValue>(), 16);
+		// assert_eq!(std::mem::size_of::<TranslateStyleValue>(), 16);
+		// assert_eq!(std::mem::size_of::<RotateStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<ScaleStyleValue>(), 48);
+		assert_eq!(std::mem::size_of::<TransformStyleStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<PerspectiveStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<PerspectiveOriginStyleValue>(), 64);
+		assert_eq!(std::mem::size_of::<BackfaceVisibilityStyleValue>(), 16);
+	}
+
+	#[test]
+	fn test_writes() {
+		assert_parse!(TransformStyleValue, "none");
+		assert_parse!(TransformStyleValue, "scale(1)");
+		assert_parse!(TransformBoxStyleValue, "fill-box");
+		assert_parse!(ScaleStyleValue, "none");
+		assert_parse!(ScaleStyleValue, "1%");
+		assert_parse!(ScaleStyleValue, "1 2 3");
+		assert_parse!(ScaleStyleValue, "1.7 50%");
+		assert_parse!(TransformStyleStyleValue, "flat");
+		assert_parse!(PerspectiveOriginStyleValue, "1px");
+		assert_parse!(BackfaceVisibilityStyleValue, "visible");
+	}
+
+	#[test]
+	fn test_errors() {
+		assert_parse_error!(TransformStyleValue, "auto");
+		assert_parse_error!(ScaleStyleValue, "none none");
+	}
+}

--- a/crates/css_ast/src/values/transforms/mod.rs
+++ b/crates/css_ast/src/values/transforms/mod.rs
@@ -124,28 +124,28 @@ pub enum TransformBoxStyleValue {}
 // #[versions(Unknown)]
 // pub enum RotateStyleValue {}
 
-// /// Represents the style value for `scale` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#scale).
-// ///
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [ <number> | <percentage> ]{1,3}
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-transforms-2/#scale
-// #[value(" none | [ <number> | <percentage> ]{1,3} ")]
-// #[initial("none")]
-// #[applies_to("transformable elements")]
-// #[inherited("no")]
-// #[percentages("n/a")]
-// #[canonical_order("per grammar")]
-// #[animation_type("by computed value, but see below for none")]
-// #[popularity(Unknown)]
-// #[caniuse(Unknown)]
-// #[baseline(Unknown)]
-// #[versions(Unknown)]
-// pub enum ScaleStyleValue {}
+/// Represents the style value for `scale` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#scale).
+///
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | [ <number> | <percentage> ]{1,3}
+/// ```
+///
+// https://drafts.csswg.org/css-transforms-2/#scale
+#[value(" none | [ <number> | <percentage> ]{1,3} ")]
+#[initial("none")]
+#[applies_to("transformable elements")]
+#[inherited("no")]
+#[percentages("n/a")]
+#[canonical_order("per grammar")]
+#[animation_type("by computed value, but see below for none")]
+#[popularity(Unknown)]
+#[caniuse(Unknown)]
+#[baseline(Unknown)]
+#[versions(Unknown)]
+pub enum ScaleStyleValue {}
 
 /// Represents the style value for `transform-style` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-style).
 ///

--- a/tasks/generate-values/mod.ts
+++ b/tasks/generate-values/mod.ts
@@ -92,9 +92,6 @@ const todoPropertiesThatWillBeCommentedOut = new Map([
 			// <'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>
 			"border-image",
 
-			// [ <length [0,∞]> | <number [0,∞]> ]{1,4}
-			"border-image-outset",
-
 			// [<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?
 			"border-image-slice",
 
@@ -488,9 +485,6 @@ const todoPropertiesThatWillBeCommentedOut = new Map([
 		new Set([
 			// none | <angle> | [ x | y | z | <number>{3} ] && <angle>
 			"rotate",
-
-			// none | [ <number> | <percentage> ]{1,3}
-			"scale",
 
 			// [ left | center | right | top | bottom | <length-percentage> ] |   [ left | center | right | <length-percentage> ]  [ top | center | bottom | <length-percentage> ] <length>? |  [ [ center | left | right ] && [ center | top | bottom ] ] <length>?
 			"transform-origin",


### PR DESCRIPTION
Thanks to https://github.com/csskit/csskit/pull/307 these can now be unlocked.
