### PR TITLE
css_parse: Add SourceCursor, SourceCursorSink, impl SourceCursorSink for fmt::Write

### DIFF
--- a/crates/css_parse/src/traits/cursor_sink.rs
+++ b/crates/css_parse/src/traits/cursor_sink.rs
@@ -1,11 +1,55 @@
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, Token};
+use css_lexer::{Cursor, ToSpan, Token};
+use std::fmt::{Result, Write};
 
 /// This trait provides the generic `impl` that [ToCursors][crate::ToCursors] can use. This provides just enough API
 /// surface for nodes to put the cursors they represent into some buffer which can later be read, the details of which
 /// are elided.
 pub trait CursorSink {
 	fn append(&mut self, c: Cursor);
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct SourceCursor<'a> {
+	cursor: Cursor,
+	source: &'a str,
+}
+
+impl<'a> ToSpan for SourceCursor<'a> {
+	fn to_span(&self) -> css_lexer::Span {
+		self.cursor.to_span()
+	}
+}
+
+impl<'a> SourceCursor<'a> {
+	#[inline(always)]
+	pub fn from(cursor: Cursor, source: &'a str) -> SourceCursor<'a> {
+		Self { cursor, source }
+	}
+
+	#[inline(always)]
+	pub fn write_str(&self, f: &mut impl Write) -> Result {
+		self.cursor.write_str(self.source, f)
+	}
+
+	#[inline(always)]
+	pub const fn cursor(&self) -> Cursor {
+		self.cursor
+	}
+
+	#[inline(always)]
+	pub const fn source(&self) -> &'a str {
+		self.source
+	}
+
+	#[inline(always)]
+	pub const fn token(&self) -> Token {
+		self.cursor.token()
+	}
+}
+
+pub trait SourceCursorSink<'a> {
+	fn append(&mut self, c: SourceCursor<'a>);
 }
 
 const SEPARATOR: Cursor = Cursor::dummy(Token::SPACE);
@@ -20,6 +64,45 @@ impl<'a> CursorSink for Vec<'a, Cursor> {
 			}
 		}
 		self.push(c);
+	}
+}
+
+impl<'a> SourceCursorSink<'a> for Vec<'a, SourceCursor<'a>> {
+	fn append(&mut self, c: SourceCursor<'a>) {
+		// If two adjacent cursors which could not be re-tokenized in the same way if they were written out adjacently occur
+		// then they should be separated by some token.
+		if let Some(last) = self.last() {
+			if last.token().needs_separator_for(c.token()) {
+				self.push(SourceCursor::from(SEPARATOR, ""));
+			}
+		}
+		self.push(c);
+	}
+}
+
+pub struct CursorToSourceCursorSink<'a, T: SourceCursorSink<'a>> {
+	source: &'a str,
+	sink: T,
+}
+
+impl<'a, T: SourceCursorSink<'a>> CursorToSourceCursorSink<'a, T> {
+	pub fn new(source: &'a str, sink: T) -> Self {
+		Self { source, sink }
+	}
+}
+
+impl<'a, T: SourceCursorSink<'a>> CursorSink for CursorToSourceCursorSink<'a, T> {
+	fn append(&mut self, cursor: Cursor) {
+		self.sink.append(SourceCursor::from(cursor, self.source))
+	}
+}
+
+impl<'a, T> SourceCursorSink<'a> for &mut T
+where
+	T: std::fmt::Write,
+{
+	fn append(&mut self, c: SourceCursor<'a>) {
+		let _ = c.write_str(self);
 	}
 }
 
@@ -40,6 +123,17 @@ mod test {
 		for sc in stream {
 			sc.write_str(source_text, &mut str).unwrap();
 		}
+		assert_eq!(str, "black white");
+	}
+
+	#[test]
+	fn test_source_cursor_sink_for_writer() {
+		let source_text = "black white";
+		let bump = Bump::default();
+		let result = Parser::new(&bump, source_text).parse_entirely::<ComponentValues>();
+		let mut str = String::new();
+		let mut transform = CursorToSourceCursorSink::new(source_text, &mut str);
+		result.to_cursors(&mut transform);
 		assert_eq!(str, "black white");
 	}
 }


### PR DESCRIPTION
We have the CusrorFmtSink which acts as a Sink to take in Cursors and write them out to the given fmt::Write object, but
this has a fair bit of incidental complexity:

- CusrorFmtSink needs to be given the Source Text, so it can pull out idents and such.
- It needs to retain and have logic around the last token so that contiguous tokens which create ambiguous single tokens
	can be separated with whitespace.
- Because of this, it can only accept cursors that match the original source text, not new ones (say from a transform).
- This makes it tricky to compose.

These complexities mean it's not very simple, and while it has its purpose, it's kind of the lowest level Sink we can
have. These issues could in theory be resolved if we change how cursors are represented. Cursors are cheap because they are a
u64, and avoiding having to store a `&str` which inflates the size and also has to carry with it a lifetime. Adding
this to a Cursor would increase complexity & size of AST nodes. But it means we lose the source text.

If we _reintroduce_ the source text to a Cursor, we might get a struct like SourceCursor - a struct which holds both the
cursor and a string slice of the original source text. These SourceCursors can be used in places a little more
transitory, where the struct size isn't so important and what _is_ important it getting to the underlying string data,
say, for example, when writing cursors to a fmt::Write.

With the new SourceCursor struct, we can create a CursorToSourceCursorSink which takes Cursors, and a given source text,
and smooshes them into a set of SourceCursors. The SourceCursors can then be used in interesting ways, such as fed
directly into a fmt::Write... but we need some kind of trait to do that.

So we _also_ can implement a SourceCursorSink trait. This is just like CursorSink but rather than append taking a Cursor, it takes a SourceCursor. With this in place, we can now introduce a blanket impl for SourceCursorSink for fmt::Write, and the picture becomes more complete.

So this change introduces those things: SourceCursor - a "fat" cursor with source_text. SourceCursorSink, a CursorSink that appends SourceCursors, and impls SourceCursorSink for fmt::Write, negating much of the need for CursorFmtSink!