### PR TITLE
css_parse: implement CursorOverlaySink

### DIFF
--- a/crates/css_parse/src/cursor_overlay_sink.rs
+++ b/crates/css_parse/src/cursor_overlay_sink.rs
@@ -1,0 +1,150 @@
+use crate::{CursorSink, CursorToSourceCursorSink, ParserReturn, SourceCursor, SourceCursorSink, ToCursors};
+use bumpalo::{Bump, collections::Vec};
+use css_lexer::{Cursor, SourceOffset, Span, ToSpan};
+use std::collections::BTreeMap;
+
+#[derive(Debug)]
+pub struct CursorOverlaySet<'a> {
+	bump: &'a Bump,
+	overlays: BTreeMap<SourceOffset, (SourceOffset, Vec<'a, SourceCursor<'a>>)>,
+}
+
+impl<'a> CursorOverlaySet<'a> {
+	pub fn new(bump: &'a Bump) -> Self {
+		Self { bump, overlays: BTreeMap::new() }
+	}
+
+	pub fn insert<T: ToCursors>(&mut self, span: Span, parser_return: ParserReturn<'a, T>) {
+		let start = span.start();
+		let end = span.end();
+		let mut cursors = Vec::new_in(self.bump);
+		let mut sink = CursorToSourceCursorSink::new(parser_return.source_text, &mut cursors);
+		parser_return.to_cursors(&mut sink);
+		self.overlays.insert(start, (end, cursors));
+	}
+
+	pub(crate) fn find(&self, end: SourceOffset) -> Option<&(SourceOffset, Vec<'a, SourceCursor<'a>>)> {
+		self.overlays.range(..=end).rev().find(|&(_, &(overlay_end, _))| end < overlay_end).map(|(_, ret)| ret)
+	}
+}
+
+/// This is a [CursorSink] that wraps a [SourceCursorSink], while also taking a [CursorOverlaySet]. As [Cursor]s get
+/// appended into this sink, it will replay those to the underlying [SourceCursorSink] _unless_ a [CursorOverlaySet]
+/// overlaps the [Cursor]'s span, at which point the overlay wil be replayed to the underlying [SourceCursorSink].
+/// This Sink is useful for collecting new Cursors (say from an AST) to overlap (or, say, transform) the underlying base
+/// Cursors (read: AST). In other words, writing over the top of the source.
+///
+/// Other than replaying overlays in place of the underyling cursors, no other modifications are made to the Cursors,
+/// that is up to the base SourceCursorSink, which can apply additional formatting or logic.
+#[derive(Debug)]
+pub struct CursorOverlaySink<'a, T: SourceCursorSink<'a>> {
+	source_text: &'a str,
+	overlays: &'a CursorOverlaySet<'a>,
+	sink: T,
+	processed_overlay_ranges: BTreeMap<SourceOffset, SourceOffset>,
+}
+
+impl<'a, T: SourceCursorSink<'a>> CursorOverlaySink<'a, T> {
+	pub fn new(source_text: &'a str, overlays: &'a CursorOverlaySet<'a>, sink: T) -> Self {
+		Self { source_text, overlays, sink, processed_overlay_ranges: BTreeMap::new() }
+	}
+}
+
+impl<'a, T: SourceCursorSink<'a>> CursorSink for CursorOverlaySink<'a, T> {
+	fn append(&mut self, c: Cursor) {
+		let cursor_start = c.span().start();
+		let cursor_end = c.span().end();
+
+		// Check if this entire cursor falls within an already-processed overlay range
+		// Look for any processed range that starts at or before cursor_start
+		if let Some((&range_start, &range_end)) = self.processed_overlay_ranges.range(..=cursor_start).next_back() {
+			if cursor_start >= range_start && cursor_end <= range_end {
+				// This cursor is entirely within a processed overlay, skip it
+				return;
+			}
+		}
+
+		let mut pos = c.span().start();
+		while pos < c.span().end() {
+			// dbg!(pos, self.overlays.find(pos));
+			if let Some((overlay_end, overlay)) = self.overlays.find(pos) {
+				for c in overlay {
+					self.sink.append(*c);
+				}
+				self.processed_overlay_ranges.insert(pos, *overlay_end);
+				pos = *overlay_end;
+			} else {
+				let c = SourceCursor::from(c, self.source_text);
+				self.sink.append(c);
+				pos = c.to_span().end();
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::{ComponentValue, CursorPrettyWriteSink, CursorWriteSink, Parser, T, ToCursors};
+	use bumpalo::{Bump, collections::Vec};
+	use css_lexer::ToSpan;
+
+	#[test]
+	fn test_basic() {
+		// Parse the original AST
+		let source_text = "black white";
+		let bump = Bump::default();
+		let result = Parser::new(&bump, source_text).parse_entirely::<(T![Ident], T![Ident])>();
+		let output = result.output.unwrap();
+
+		// Build an overlay AST
+		let overtlay_text = "green";
+		let overlay = Parser::new(&bump, overtlay_text).parse_entirely::<T![Ident]>();
+		let mut overlays = CursorOverlaySet::new(&bump);
+		overlays.insert(output.1.to_span(), overlay);
+
+		// Smoosh
+		let mut str = String::new();
+		let mut stream = CursorOverlaySink::new(source_text, &overlays, CursorWriteSink::new(source_text, &mut str));
+		output.to_cursors(&mut stream);
+
+		// str should include overlays
+		assert_eq!(str, "black green");
+	}
+
+	#[test]
+	fn test_with_pretty_writer() {
+		// Parse the original AST
+		let source_text = "foo{use:other;}";
+		let bump = Bump::default();
+		let result = Parser::new(&bump, source_text).parse_entirely::<Vec<'_, ComponentValue>>();
+		let output = result.output.unwrap();
+		let ComponentValue::SimpleBlock(ref block) = output[1] else { panic!("output[1] was not a block") };
+		dbg!(block.to_span(), block.values.to_span());
+
+		// Build an overlay AST
+		let overtlay_text = "inner{foo: bar;}";
+		let overlay = Parser::new(&bump, overtlay_text).parse_entirely::<Vec<'_, ComponentValue>>();
+		let mut overlays = CursorOverlaySet::new(&bump);
+		overlays.insert(dbg!(block.values.to_span()), overlay);
+
+		// Smoosh
+		let mut str = String::new();
+		let mut stream =
+			CursorOverlaySink::new(source_text, &overlays, CursorPrettyWriteSink::new(source_text, &mut str, None));
+		output.to_cursors(&mut stream);
+
+		// str should include overlays
+		assert_eq!(
+			str,
+			r#"
+foo {
+	inner {
+		foo: bar;
+	}
+}
+			"#
+			.trim()
+		);
+	}
+}

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -274,6 +274,7 @@
 //! ```
 
 mod comparison;
+mod cursor_overlay_sink;
 mod cursor_pretty_write_sink;
 mod cursor_write_sink;
 #[doc(hidden)]
@@ -293,6 +294,7 @@ pub mod token_macros;
 mod traits;
 
 pub use comparison::*;
+pub use cursor_overlay_sink::*;
 pub use cursor_pretty_write_sink::*;
 pub use cursor_write_sink::*;
 pub use feature::*;

--- a/crates/css_parse/src/traits/cursor_sink.rs
+++ b/crates/css_parse/src/traits/cursor_sink.rs
@@ -67,7 +67,7 @@ impl<'a> CursorSink for Vec<'a, Cursor> {
 	}
 }
 
-impl<'a> SourceCursorSink<'a> for Vec<'a, SourceCursor<'a>> {
+impl<'a> SourceCursorSink<'a> for &mut Vec<'a, SourceCursor<'a>> {
 	fn append(&mut self, c: SourceCursor<'a>) {
 		// If two adjacent cursors which could not be re-tokenized in the same way if they were written out adjacently occur
 		// then they should be separated by some token.
@@ -97,10 +97,7 @@ impl<'a, T: SourceCursorSink<'a>> CursorSink for CursorToSourceCursorSink<'a, T>
 	}
 }
 
-impl<'a, T> SourceCursorSink<'a> for &mut T
-where
-	T: std::fmt::Write,
-{
+impl<'a> SourceCursorSink<'a> for &mut String {
 	fn append(&mut self, c: SourceCursor<'a>) {
 		let _ = c.write_str(self);
 	}
@@ -127,7 +124,7 @@ mod test {
 	}
 
 	#[test]
-	fn test_source_cursor_sink_for_writer() {
+	fn test_source_cursor_sink_for_string() {
 		let source_text = "black white";
 		let bump = Bump::default();
 		let result = Parser::new(&bump, source_text).parse_entirely::<ComponentValues>();


### PR DESCRIPTION
We need some way to be able to overlay ASTs on top of one another, so we can start applying transforms again. One way to
do this would be to introduce a mechanism for overlaying two CursorSinks on top of one another, or to have an AST be able to be replayed on top of a delegate CursorSink.

This changes introduces CursorOverlaySink: a new CursorSink which takes an underyling SourceCursorSink and feeds it
Cursors that get appended, unless there's an "overlay" - a set of cursors ready to replace the cursors within a given
span. This allows us to take N+1 ASTs and smoosh them together, such that the base AST gets new ASTs pasted over the top
in a way that produces a combined AST.
