### PR TITLE
css_ast/css_parse: Add new methods to DeclarationValue.

### DIFF
--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -94,16 +94,40 @@ impl<'a> DeclarationValue<'a> for StyleValue<'a> {
 		PropertyId::peek(p, c)
 	}
 
+	fn is_unknown(&self) -> bool {
+		matches!(self, Self::Unknown(_))
+	}
+
+	fn is_initial(&self) -> bool {
+		matches!(self, Self::Initial(_))
+	}
+
+	fn is_inherit(&self) -> bool {
+		matches!(self, Self::Inherit(_))
+	}
+
+	fn is_unset(&self) -> bool {
+		matches!(self, Self::Unset(_))
+	}
+
+	fn is_revert(&self) -> bool {
+		matches!(self, Self::Revert(_))
+	}
+
+	fn is_revert_layer(&self) -> bool {
+		matches!(self, Self::RevertLayer(_))
+	}
+
+	fn needs_computing(&self) -> bool {
+		matches!(self, Self::Computed(_))
+	}
+
 	fn parse_custom_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> ParserResult<Self> {
 		p.parse::<Custom>().map(Self::Custom)
 	}
 
 	fn parse_computed_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> ParserResult<Self> {
 		p.parse::<Computed>().map(Self::Computed)
-	}
-
-	fn parse_unknown_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> ParserResult<Self> {
-		p.parse::<Unknown>().map(Self::Unknown)
 	}
 
 	fn parse_specified_declaration_value(p: &mut Parser<'a>, name: Cursor) -> ParserResult<Self> {
@@ -125,12 +149,8 @@ impl<'a> DeclarationValue<'a> for StyleValue<'a> {
 		apply_properties!(parse_declaration_value)
 	}
 
-	fn is_unknown(&self) -> bool {
-		matches!(self, Self::Unknown(_))
-	}
-
-	fn needs_computing(&self) -> bool {
-		matches!(self, Self::Computed(_))
+	fn parse_unknown_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> ParserResult<Self> {
+		p.parse::<Unknown>().map(Self::Unknown)
 	}
 }
 

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -48,16 +48,36 @@ impl<'a> DeclarationValue<'a> for FontFaceRuleStyleValue<'a> {
 		FontFaceRulePropertyId::peek(p, c)
 	}
 
-	fn parse_declaration_value(p: &mut Parser<'a>, name: Cursor) -> ParserResult<Self> {
-		Ok(Self(StyleValue::parse_declaration_value(p, name)?))
-	}
-
 	fn is_unknown(&self) -> bool {
 		self.0.is_unknown()
 	}
 
+	fn is_initial(&self) -> bool {
+		self.0.is_initial()
+	}
+
+	fn is_inherit(&self) -> bool {
+		self.0.is_inherit()
+	}
+
+	fn is_unset(&self) -> bool {
+		self.0.is_unset()
+	}
+
+	fn is_revert(&self) -> bool {
+		self.0.is_revert()
+	}
+
+	fn is_revert_layer(&self) -> bool {
+		self.0.is_revert_layer()
+	}
+
 	fn needs_computing(&self) -> bool {
 		self.0.needs_computing()
+	}
+
+	fn parse_declaration_value(p: &mut Parser<'a>, name: Cursor) -> ParserResult<Self> {
+		Ok(Self(StyleValue::parse_declaration_value(p, name)?))
 	}
 }
 

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -58,6 +58,34 @@ impl<'a> DeclarationValue<'a> for PropertyRuleValue<'a> {
 		PropertyRulePropertyId::peek(p, c)
 	}
 
+	fn is_unknown(&self) -> bool {
+		matches!(self, Self::Unknown(_))
+	}
+
+	fn is_initial(&self) -> bool {
+		false
+	}
+
+	fn is_inherit(&self) -> bool {
+		false
+	}
+
+	fn is_unset(&self) -> bool {
+		false
+	}
+
+	fn is_revert(&self) -> bool {
+		false
+	}
+
+	fn is_revert_layer(&self) -> bool {
+		false
+	}
+
+	fn needs_computing(&self) -> bool {
+		matches!(self, Self::Unknown(_))
+	}
+
 	fn parse_declaration_value(p: &mut Parser<'a>, c: Cursor) -> ParserResult<Self> {
 		if !PropertyRulePropertyId::peek(p, c) {
 			Ok(Self::Unknown(p.parse::<ComponentValues<'a>>()?))
@@ -68,14 +96,6 @@ impl<'a> DeclarationValue<'a> for PropertyRuleValue<'a> {
 				PropertyRulePropertyId::Syntax(_) => Self::Syntax(p.parse::<SyntaxValue>()?),
 			})
 		}
-	}
-
-	fn is_unknown(&self) -> bool {
-		matches!(self, Self::Unknown(_))
-	}
-
-	fn needs_computing(&self) -> bool {
-		matches!(self, Self::Unknown(_))
 	}
 }
 

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -103,12 +103,32 @@ mod tests {
 	impl<'a> DeclarationValue<'a> for Decl {
 		type ComputedValue = T![Eof];
 
-		fn parse_specified_declaration_value(p: &mut Parser<'a>, _: Cursor) -> Result<Self> {
-			p.parse::<T![Ident]>().map(Self)
+		fn is_initial(&self) -> bool {
+			false
+		}
+
+		fn is_inherit(&self) -> bool {
+			false
+		}
+
+		fn is_unset(&self) -> bool {
+			false
+		}
+
+		fn is_revert(&self) -> bool {
+			false
+		}
+
+		fn is_revert_layer(&self) -> bool {
+			false
 		}
 
 		fn needs_computing(&self) -> bool {
 			false
+		}
+
+		fn parse_specified_declaration_value(p: &mut Parser<'a>, _: Cursor) -> Result<Self> {
+			p.parse::<T![Ident]>().map(Self)
 		}
 	}
 	impl ToCursors for Decl {

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -42,11 +42,31 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
 impl<'a> DeclarationValue<'a> for ComponentValues<'a> {
 	type ComputedValue = ComponentValues<'a>;
 
-	fn parse_custom_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
-		Self::parse(p)
+	fn is_initial(&self) -> bool {
+		false
 	}
 
-	fn parse_unknown_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
+	fn is_inherit(&self) -> bool {
+		false
+	}
+
+	fn is_unset(&self) -> bool {
+		false
+	}
+
+	fn is_revert(&self) -> bool {
+		false
+	}
+
+	fn is_revert_layer(&self) -> bool {
+		false
+	}
+
+	fn needs_computing(&self) -> bool {
+		false
+	}
+
+	fn parse_custom_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		Self::parse(p)
 	}
 
@@ -54,8 +74,8 @@ impl<'a> DeclarationValue<'a> for ComponentValues<'a> {
 		Self::parse(p)
 	}
 
-	fn needs_computing(&self) -> bool {
-		false
+	fn parse_unknown_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
+		Self::parse(p)
 	}
 }
 

--- a/crates/css_parse/src/syntax/declaration.rs
+++ b/crates/css_parse/src/syntax/declaration.rs
@@ -76,12 +76,32 @@ mod tests {
 	impl<'a> DeclarationValue<'a> for Decl {
 		type ComputedValue = T![Eof];
 
-		fn parse_specified_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
-			p.parse::<T![Ident]>().map(Self)
+		fn is_initial(&self) -> bool {
+			false
+		}
+
+		fn is_inherit(&self) -> bool {
+			false
+		}
+
+		fn is_unset(&self) -> bool {
+			false
+		}
+
+		fn is_revert(&self) -> bool {
+			false
+		}
+
+		fn is_revert_layer(&self) -> bool {
+			false
 		}
 
 		fn needs_computing(&self) -> bool {
 			false
+		}
+
+		fn parse_specified_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
+			p.parse::<T![Ident]>().map(Self)
 		}
 	}
 	impl ToCursors for Decl {

--- a/crates/css_parse/src/syntax/qualified_rule.rs
+++ b/crates/css_parse/src/syntax/qualified_rule.rs
@@ -122,12 +122,32 @@ mod tests {
 	impl<'a> DeclarationValue<'a> for Decl {
 		type ComputedValue = T![Eof];
 
-		fn parse_specified_declaration_value(p: &mut Parser<'a>, _: Cursor) -> Result<Self> {
-			p.parse::<T![Ident]>().map(Self)
+		fn is_initial(&self) -> bool {
+			false
+		}
+
+		fn is_inherit(&self) -> bool {
+			false
+		}
+
+		fn is_unset(&self) -> bool {
+			false
+		}
+
+		fn is_revert(&self) -> bool {
+			false
+		}
+
+		fn is_revert_layer(&self) -> bool {
+			false
 		}
 
 		fn needs_computing(&self) -> bool {
 			false
+		}
+
+		fn parse_specified_declaration_value(p: &mut Parser<'a>, _: Cursor) -> Result<Self> {
+			p.parse::<T![Ident]>().map(Self)
 		}
 	}
 	impl ToCursors for Decl {

--- a/crates/css_parse/src/traits/declaration_value.rs
+++ b/crates/css_parse/src/traits/declaration_value.rs
@@ -36,6 +36,36 @@ pub trait DeclarationValue<'a>: Sized + ToCursors + ToSpan {
 		false
 	}
 
+	/// Determines if the parsed Self was parsed as the "initial" keyword.
+	///
+	/// If implementing a set of declarations where the "initial" keyword is accepted this method can be used to signal
+	/// that to upstream consumers of this trait.
+	fn is_initial(&self) -> bool;
+
+	/// Determines if the parsed Self was parsed as the "inherit" keyword.
+	///
+	/// If implementing a set of declarations where the "inherit" keyword is accepted this method can be used to signal
+	/// that to upstream consumers of this trait.
+	fn is_inherit(&self) -> bool;
+
+	/// Determines if the parsed Self was parsed as the "unset" keyword.
+	///
+	/// If implementing a set of declarations where the "unset" keyword is accepted this method can be used to signal
+	/// that to upstream consumers of this trait.
+	fn is_unset(&self) -> bool;
+
+	/// Determines if the parsed Self was parsed as the "revert" keyword.
+	///
+	/// If implementing a set of declarations where the "revert" keyword is accepted this method can be used to signal
+	/// that to upstream consumers of this trait.
+	fn is_revert(&self) -> bool;
+
+	/// Determines if the parsed Self was parsed as the "revert" keyword.
+	///
+	/// If implementing a set of declarations where the "revert" keyword is accepted this method can be used to signal
+	/// that to upstream consumers of this trait.
+	fn is_revert_layer(&self) -> bool;
+
 	/// Determines if the parsed Self is not a valid literal production of the grammar, and instead some of its
 	/// constituent parts will need additional computation to reify into a known value.
 	///


### PR DESCRIPTION
This change adds the following methods to DeclarationValue:

-	is_initial - to check if a DeclarationValue is the "initial" keyword
-	is_inherit - to check if the DeclarationValue is the "inherit" keyword
-	is_unset - to check if the DeclarationValue is the "unset" keyword
-	is_revert - to check if the DeclarationValue is the "revert" keyword
-	is_revert_layer - to check if the DeclarationValue is the "revert-layer" keyword

These will be useful in writing transforms and lints.
