### PR TITLE
css_parse: Add parse! macro

### DIFF
--- a/crates/css_parse/src/cursor_write_sink.rs
+++ b/crates/css_parse/src/cursor_write_sink.rs
@@ -45,18 +45,16 @@ impl<'a, T: Write> SourceCursorSink<'a> for CursorWriteSink<'a, T> {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::{ComponentValues, Parser, ToCursors};
+	use crate::{ComponentValues, ToCursors, parse};
 	use bumpalo::Bump;
 
 	#[test]
 	fn test() {
 		let source_text = "foo{bar:baz();}";
 		let bump = Bump::default();
-		let result = Parser::new(&bump, source_text).parse_entirely::<ComponentValues>();
-		let output = result.output.unwrap();
 		let mut str = String::new();
 		let mut stream = CursorWriteSink::new(source_text, &mut str);
-		output.to_cursors(&mut stream);
+		parse!(in bump &source_text as ComponentValues).output.unwrap().to_cursors(&mut stream);
 		assert_eq!(str, "foo{bar:baz();}");
 	}
 }

--- a/crates/css_parse/src/macros/mod.rs
+++ b/crates/css_parse/src/macros/mod.rs
@@ -1,3 +1,4 @@
+mod parse;
 mod pseudo_class;
 mod pseudo_element;
 

--- a/crates/css_parse/src/macros/parse.rs
+++ b/crates/css_parse/src/macros/parse.rs
@@ -1,0 +1,47 @@
+/// A macro for easily calling the Parser and entirely parsing a string.
+///
+/// # Example
+///
+/// ```
+/// use css_parse::*;
+/// use bumpalo::Bump;
+/// let bump = Bump::default();
+/// parse!(in bump "foo"); // ComponentValues
+///
+/// parse!(in bump "foo" as T![Ident]);
+///
+/// let features = Feature::SingleLineComments;
+/// parse!(in bump with features "//foo");
+///
+/// // Or pass a reference to a str
+/// let source = "//foo";
+/// let features = Feature::SingleLineComments;
+/// parse!(in bump with features &source);
+/// ```
+#[macro_export]
+macro_rules! parse {
+	(in $bump: ident $(with $features: ident)? &$source_text: ident as $ty: ty) => {
+		{
+			let mut p = $crate::Parser::new(&$bump, $source_text)$(.with_features($features))?;
+			p.parse_entirely::<$ty>()
+		}
+	};
+	(in $bump: ident $(with $features: ident)? $str: literal as $ty: ty) => {
+		{
+			let source_text = $str;
+			parse!(in $bump $(with $features)? &source_text as $ty)
+		}
+	};
+	(in $bump: ident $(with $features: ident)? $str: literal) => {
+		{
+			use $crate::ComponentValues;
+			parse!(in $bump $(with $features)? $str as ComponentValues)
+		}
+	};
+	(in $bump: ident $(with $features: ident)? &$str: ident) => {
+		{
+			use $crate::ComponentValues;
+			parse!(in $bump $(with $features)? &$str as ComponentValues)
+		}
+	};
+}

--- a/crates/css_parse/src/parser.rs
+++ b/crates/css_parse/src/parser.rs
@@ -46,6 +46,11 @@ impl<'a> Parser<'a> {
 		Self::new_with_features(bump, source_text, Feature::none())
 	}
 
+	pub fn with_features(mut self, features: Feature) -> Self {
+		self.features = features;
+		self
+	}
+
 	pub fn new_with_features(bump: &'a Bump, source_text: &'a str, features: Feature) -> Self {
 		Self {
 			source_text,

--- a/crates/css_parse/src/traits/cursor_sink.rs
+++ b/crates/css_parse/src/traits/cursor_sink.rs
@@ -106,16 +106,15 @@ impl<'a> SourceCursorSink<'a> for &mut String {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::{ComponentValues, Parser, ToCursors};
+	use crate::{ToCursors, parse};
 	use bumpalo::Bump;
 
 	#[test]
 	fn test_cursor_sink_for_vec() {
 		let source_text = "black white";
 		let bump = Bump::default();
-		let result = Parser::new(&bump, source_text).parse_entirely::<ComponentValues>();
 		let mut stream = Vec::new_in(&bump);
-		result.to_cursors(&mut stream);
+		parse!(in bump &source_text).to_cursors(&mut stream);
 		let mut str = String::new();
 		for sc in stream {
 			sc.write_str(source_text, &mut str).unwrap();
@@ -127,10 +126,9 @@ mod test {
 	fn test_source_cursor_sink_for_string() {
 		let source_text = "black white";
 		let bump = Bump::default();
-		let result = Parser::new(&bump, source_text).parse_entirely::<ComponentValues>();
 		let mut str = String::new();
 		let mut transform = CursorToSourceCursorSink::new(source_text, &mut str);
-		result.to_cursors(&mut transform);
+		parse!(in bump &source_text).to_cursors(&mut transform);
 		assert_eq!(str, "black white");
 	}
 }


### PR DESCRIPTION
Calling parse_entirely involved a little too much ceremony. This change adds a new `parse!` macro which is variadic,
providing sensible defaults (e.g. ComponentValues as the default type), and is a little more expressive.
