### PR TITLE
css_parse: Normalize quote styles in CursorPrettyWriteSink

### DIFF
--- a/crates/css_parse/src/cursor_overlay_sink.rs
+++ b/crates/css_parse/src/cursor_overlay_sink.rs
@@ -87,7 +87,7 @@ mod test {
 	use super::*;
 	use crate::{ComponentValue, CursorPrettyWriteSink, CursorWriteSink, T, ToCursors, parse};
 	use bumpalo::{Bump, collections::Vec};
-	use css_lexer::ToSpan;
+	use css_lexer::{QuoteStyle, ToSpan};
 
 	#[test]
 	fn test_basic() {
@@ -128,8 +128,11 @@ mod test {
 
 		// Smoosh
 		let mut str = String::new();
-		let mut stream =
-			CursorOverlaySink::new(source_text, &overlays, CursorPrettyWriteSink::new(source_text, &mut str, None));
+		let mut stream = CursorOverlaySink::new(
+			source_text,
+			&overlays,
+			CursorPrettyWriteSink::new(source_text, &mut str, None, QuoteStyle::Double),
+		);
 		output.to_cursors(&mut stream);
 
 		// str should include overlays


### PR DESCRIPTION
Using the changes from https://github.com/csskit/csskit/pull/330 this change adds the capability to normalize quotes to
a single style, in the CursorPrettyWriteSink.
