### PR TITLE
Avoid css_lexer dep in downstream traits, clean up generic structs.

### DIFF
--- a/crates/css_ast/src/functions/attr_function.rs
+++ b/crates/css_ast/src/functions/attr_function.rs
@@ -1,6 +1,6 @@
-use css_lexer::Cursor;
 use css_parse::{
-	ComponentValues, Function, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set, keyword_set,
+	ComponentValues, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set,
+	keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 

--- a/crates/css_ast/src/functions/color_function.rs
+++ b/crates/css_ast/src/functions/color_function.rs
@@ -1,6 +1,5 @@
 use crate::units::Angle;
-use css_lexer::Cursor;
-use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
+use css_parse::{Build, Cursor, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
 use csskit_derives::{IntoCursor, ToCursors, ToSpan, Visitable};
 
 function_set!(

--- a/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
+++ b/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
@@ -1,5 +1,6 @@
-use css_lexer::Cursor;
-use css_parse::{CommaSeparated, Function, Parse, Parser, Result as ParserResult, T, diagnostics, function_set};
+use css_parse::{
+	CommaSeparated, Cursor, Function, Parse, Parser, Result as ParserResult, T, diagnostics, function_set,
+};
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
 function_set!(pub struct DynamicRangeLimitMixFunctionName "dynamic-range-limit-mix");

--- a/crates/css_ast/src/functions/easing_functions.rs
+++ b/crates/css_ast/src/functions/easing_functions.rs
@@ -1,6 +1,5 @@
-use css_lexer::Cursor;
 use css_parse::{
-	Build, CommaSeparated, Function, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set,
+	Build, CommaSeparated, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set,
 	keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};

--- a/crates/css_ast/src/functions/stripes_function.rs
+++ b/crates/css_ast/src/functions/stripes_function.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{CommaSeparated, Function, Parse, Parser, Peek, Result as ParserResult, function_set};
+use css_parse::{CommaSeparated, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, function_set};
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
 use crate::{types::Color, units::LengthPercentageOrFlex};

--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -24,8 +24,7 @@ pub use units::*;
 pub use values::*;
 pub use visit::*;
 
-use css_lexer::{Span, ToSpan};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, diagnostics};
+use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan, diagnostics};
 
 pub use css_parse::{Declaration, DeclarationValue};
 

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -1,7 +1,7 @@
 use crate::values;
-use css_lexer::{Cursor, KindSet};
 use css_parse::{
-	Build, ComponentValues, DeclarationValue, Parser, Peek, Result as ParserResult, State, T, keyword_set,
+	Build, ComponentValues, Cursor, DeclarationValue, KindSet, Parser, Peek, Result as ParserResult, State, T,
+	keyword_set,
 };
 use csskit_derives::{Parse, ToCursors, ToSpan, Visitable};
 use std::{fmt::Debug, hash::Hash};

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
+use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, diagnostics};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-syntax-3/#charset-rule

--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -1,8 +1,7 @@
 use crate::{StyleValue, Visit, VisitMut, Visitable as VisitableTrait, VisitableMut, types::Ratio, units::Length};
 use bumpalo::collections::Vec;
-use css_lexer::Cursor;
 use css_parse::{
-	ConditionKeyword, Declaration, FeatureConditionList, Parse, Parser, Peek, RangedFeatureKeyword,
+	ConditionKeyword, Cursor, Declaration, FeatureConditionList, Parse, Parser, Peek, RangedFeatureKeyword,
 	Result as ParserResult, discrete_feature, keyword_set, ranged_feature,
 };
 use csskit_derives::{ToCursors, ToSpan, Visitable};

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -1,9 +1,8 @@
 use crate::{Visit, VisitMut, Visitable as VisitableTrait, VisitableMut, stylesheet::Rule};
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, Kind};
 use css_parse::{
-	AtRule, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Peek, PreludeList, Result as ParserResult,
-	RuleList, T, atkeyword_set, diagnostics, keyword_set,
+	AtRule, Build, ConditionKeyword, Cursor, FeatureConditionList, Kind, Parse, Parser, Peek, PreludeList,
+	Result as ParserResult, RuleList, T, atkeyword_set, diagnostics, keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 use csskit_proc_macro::visit;
@@ -17,7 +16,7 @@ atkeyword_set!(pub struct AtContainerKeyword "container");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct ContainerRule<'a>(AtRule<'a, AtContainerKeyword, ContainerConditionList<'a>, ContainerRulesBlock<'a>>);
+pub struct ContainerRule<'a>(AtRule<AtContainerKeyword, ContainerConditionList<'a>, ContainerRulesBlock<'a>>);
 
 #[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -11,7 +11,7 @@ atkeyword_set!(struct AtDocumentKeyword "document");
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct DocumentRule<'a>(AtRule<'a, AtDocumentKeyword, DocumentMatcherList<'a>, DocumentRuleBlock<'a>>);
+pub struct DocumentRule<'a>(AtRule<AtDocumentKeyword, DocumentMatcherList<'a>, DocumentRuleBlock<'a>>);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -1,8 +1,7 @@
 use crate::{Computed, StyleValue};
-use css_lexer::Cursor;
 use css_parse::{
-	AtRule, DeclarationList, DeclarationValue, NoPreludeAllowed, Parser, Peek, Result as ParserResult, atkeyword_set,
-	keyword_set,
+	AtRule, Cursor, DeclarationList, DeclarationValue, NoPreludeAllowed, Parser, Peek, Result as ParserResult,
+	atkeyword_set, keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -12,7 +11,7 @@ atkeyword_set!(struct AtFontFaceKeyword "font-face");
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct FontFaceRule<'a>(AtRule<'a, AtFontFaceKeyword, NoPreludeAllowed, FontFaceRuleBlock<'a>>);
+pub struct FontFaceRule<'a>(AtRule<AtFontFaceKeyword, NoPreludeAllowed, FontFaceRuleBlock<'a>>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -1,8 +1,7 @@
 use crate::StyleValue;
-use css_lexer::{Cursor, ToSpan};
 use css_parse::{
-	AtRule, CommaSeparated, NoBlockAllowed, Parse, Parser, Peek, QualifiedRule, Result as ParserResult, RuleList, T,
-	atkeyword_set, diagnostics, keyword_set,
+	AtRule, CommaSeparated, Cursor, NoBlockAllowed, Parse, Parser, Peek, QualifiedRule, Result as ParserResult,
+	RuleList, T, ToSpan, atkeyword_set, diagnostics, keyword_set,
 };
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -12,7 +11,7 @@ atkeyword_set!(struct AtKeyframesKeyword "keyframes");
 #[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct KeyframesRule<'a>(AtRule<'a, AtKeyframesKeyword, KeyframesName, KeyframesRuleBlock<'a>>);
+pub struct KeyframesRule<'a>(AtRule<AtKeyframesKeyword, KeyframesName, KeyframesRuleBlock<'a>>);
 
 #[derive(Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -10,7 +10,7 @@ atkeyword_set!(struct AtLayerKeyword "layer");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct LayerRule<'a>(AtRule<'a, AtLayerKeyword, LayerNameList<'a>, Option<LayerRuleBlock<'a>>>);
+pub struct LayerRule<'a>(AtRule<AtLayerKeyword, LayerNameList<'a>, Option<LayerRuleBlock<'a>>>);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/media/features/hack.rs
+++ b/crates/css_ast/src/rules/media/features/hack.rs
@@ -1,5 +1,4 @@
-use css_lexer::{Cursor, ToSpan};
-use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics};
+use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, ToSpan, diagnostics};
 use csskit_derives::{ToCursors, ToSpan};
 
 #[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -1,8 +1,7 @@
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, Kind, KindSet};
 use css_parse::{
-	AtRule, Block, Build, ConditionKeyword, FeatureConditionList, Parse, Parser, Peek, PreludeList,
-	Result as ParserResult, T, atkeyword_set, diagnostics, keyword_set,
+	AtRule, Block, Build, ConditionKeyword, Cursor, FeatureConditionList, Kind, KindSet, Parse, Parser, Peek,
+	PreludeList, Result as ParserResult, T, atkeyword_set, diagnostics, keyword_set,
 };
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -17,7 +16,7 @@ atkeyword_set!(struct AtMediaKeyword "media");
 #[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
 #[visit(self)]
-pub struct MediaRule<'a>(AtRule<'a, AtMediaKeyword, MediaQueryList<'a>, MediaRuleBlock<'a>>);
+pub struct MediaRule<'a>(AtRule<AtMediaKeyword, MediaQueryList<'a>, MediaRuleBlock<'a>>);
 
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -7,7 +7,7 @@ atkeyword_set!(struct AtMozDocumentKeyword "-moz-document");
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct MozDocumentRule<'a>(AtRule<'a, AtMozDocumentKeyword, DocumentMatcherList<'a>, DocumentRuleBlock<'a>>);
+pub struct MozDocumentRule<'a>(AtRule<AtMozDocumentKeyword, DocumentMatcherList<'a>, DocumentRuleBlock<'a>>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -3,10 +3,9 @@ use crate::{
 	specificity::{Specificity, ToSpecificity},
 };
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, Kind, KindSet};
 use css_parse::{
-	AtRule, Block, Build, DeclarationList, NoPreludeAllowed, Parse, Parser, Peek, Result as ParserResult, T,
-	atkeyword_set, keyword_set, syntax::CommaSeparated,
+	AtRule, Block, Build, Cursor, DeclarationList, Kind, KindSet, NoPreludeAllowed, Parse, Parser, Peek,
+	Result as ParserResult, T, atkeyword_set, keyword_set, syntax::CommaSeparated,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -17,7 +16,7 @@ atkeyword_set!(struct AtPageKeyword "page");
 #[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct PageRule<'a>(AtRule<'a, AtPageKeyword, Option<PageSelectorList<'a>>, PageRuleBlock<'a>>);
+pub struct PageRule<'a>(AtRule<AtPageKeyword, Option<PageSelectorList<'a>>, PageRuleBlock<'a>>);
 
 #[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -130,7 +129,7 @@ atkeyword_set!(
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct MarginRule<'a>(AtRule<'a, AtMarginRuleKeywords, NoPreludeAllowed, MarginRuleBlock<'a>>);
+pub struct MarginRule<'a>(AtRule<AtMarginRuleKeywords, NoPreludeAllowed, MarginRuleBlock<'a>>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -1,6 +1,5 @@
-use css_lexer::Cursor;
 use css_parse::{
-	AtRule, Build, DeclarationList, DeclarationValue, Parser, Peek, Result as ParserResult, T, atkeyword_set,
+	AtRule, Build, Cursor, DeclarationList, DeclarationValue, Parser, Peek, Result as ParserResult, T, atkeyword_set,
 	keyword_set, syntax::ComponentValues,
 };
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
@@ -14,7 +13,7 @@ atkeyword_set!(pub struct AtPropertyKeyword "property");
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct PropertyRule<'a>(pub AtRule<'a, AtPropertyKeyword, PropertyPrelude, PropertyRuleBlock<'a>>);
+pub struct PropertyRule<'a>(pub AtRule<AtPropertyKeyword, PropertyPrelude, PropertyRuleBlock<'a>>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -2,9 +2,8 @@ use crate::{
 	StyleValue, Visit, VisitMut, Visitable as VisitableTrait, VisitableMut, selector::ComplexSelector, stylesheet::Rule,
 };
 use bumpalo::collections::Vec;
-use css_lexer::Cursor;
 use css_parse::{
-	AtRule, Build, ComponentValues, ConditionKeyword, Declaration, FeatureConditionList, Parse, Parser,
+	AtRule, Build, ComponentValues, ConditionKeyword, Cursor, Declaration, FeatureConditionList, Parse, Parser,
 	Result as ParserResult, RuleList, T, atkeyword_set, diagnostics, function_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
@@ -45,7 +44,7 @@ atkeyword_set!(struct AtSupportsKeyword "supports");
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct SupportsRule<'a>(AtRule<'a, AtSupportsKeyword, SupportsCondition<'a>, SupportsRuleBlock<'a>>);
+pub struct SupportsRule<'a>(AtRule<AtSupportsKeyword, SupportsCondition<'a>, SupportsRuleBlock<'a>>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -8,7 +8,7 @@ atkeyword_set!(struct AtWebkitKeyframesKeyword "-webkit-keyframes");
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
-pub struct WebkitKeyframesRule<'a>(AtRule<'a, AtWebkitKeyframesKeyword, KeyframesName, KeyframesRuleBlock<'a>>);
+pub struct WebkitKeyframesRule<'a>(AtRule<AtWebkitKeyframesKeyword, KeyframesName, KeyframesRuleBlock<'a>>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -1,5 +1,4 @@
-use css_lexer::{Cursor, KindSet};
-use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
+use css_parse::{Build, Cursor, KindSet, Parse, Parser, Peek, Result as ParserResult, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan, Visitable};
 
 use super::NamespacePrefix;

--- a/crates/css_ast/src/selector/class.rs
+++ b/crates/css_ast/src/selector/class.rs
@@ -1,5 +1,4 @@
-use css_lexer::{Cursor, Kind};
-use css_parse::{Parse, Parser, Peek, Result as ParserResult, T};
+use css_parse::{Cursor, Kind, Parse, Parser, Peek, Result as ParserResult, T};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 #[derive(ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -1,6 +1,7 @@
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, KindSet};
-use css_parse::{Build, CommaSeparated, Parse, Parser, Result as ParserResult, T, function_set, keyword_set};
+use css_parse::{
+	Build, CommaSeparated, Cursor, KindSet, Parse, Parser, Result as ParserResult, T, function_set, keyword_set,
+};
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
 use super::{ForgivingSelector, Nth, RelativeSelector, SelectorList};

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -1,7 +1,6 @@
 use bumpalo::collections::Vec;
-use css_lexer::Cursor;
 use css_parse::{
-	Build, CompoundSelector as CompoundSelectorTrait, Parse, Parser, Result as ParserResult,
+	Build, CompoundSelector as CompoundSelectorTrait, Cursor, Parse, Parser, Result as ParserResult,
 	SelectorComponent as SelectorComponentTrait, T, syntax::CommaSeparated,
 };
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};

--- a/crates/css_ast/src/selector/moz.rs
+++ b/crates/css_ast/src/selector/moz.rs
@@ -1,6 +1,5 @@
-use css_lexer::Cursor;
 use css_parse::{
-	Build, Parse, Parser, Result as ParserResult, T, diagnostics, function_set, pseudo_class, pseudo_element,
+	Build, Cursor, Parse, Parser, Result as ParserResult, T, diagnostics, function_set, pseudo_class, pseudo_element,
 	syntax::CommaSeparated,
 };
 use csskit_derives::{ToCursors, Visitable};

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,5 +1,4 @@
-use css_lexer::{Cursor, KindSet};
-use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
+use css_parse::{Build, Cursor, KindSet, Parse, Parser, Peek, Result as ParserResult, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan, Visitable};
 
 use super::Tag;

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -1,5 +1,7 @@
-use css_lexer::{Cursor, Kind, KindSet, Span, ToSpan};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics, keyword_set};
+use css_parse::{
+	Cursor, CursorSink, Kind, KindSet, Parse, Parser, Peek, Result as ParserResult, Span, T, ToCursors, ToSpan,
+	diagnostics, keyword_set,
+};
 use csskit_derives::Visitable;
 
 use crate::units::CSSInt;

--- a/crates/css_ast/src/selector/pseudo_element.rs
+++ b/crates/css_ast/src/selector/pseudo_element.rs
@@ -1,5 +1,4 @@
-use css_lexer::KindSet;
-use css_parse::{Build, Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set, pseudo_class};
+use css_parse::{Build, KindSet, Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set, pseudo_class};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 use super::{moz::MozPseudoElement, ms::MsPseudoElement, o::OPseudoElement, webkit::WebkitPseudoElement};

--- a/crates/css_ast/src/selector/tag.rs
+++ b/crates/css_ast/src/selector/tag.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T, keyword_set};
+use css_parse::{Build, Cursor, Parser, Peek, T, keyword_set};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 #[derive(ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/selector/webkit.rs
+++ b/crates/css_ast/src/selector/webkit.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics, pseudo_class, pseudo_element};
+use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, diagnostics, pseudo_class, pseudo_element};
 use csskit_derives::{ToCursors, Visitable};
 
 use super::CompoundSelector;

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -1,7 +1,6 @@
 use crate::{StyleValue, selector::SelectorList};
-use css_lexer::Cursor;
 use css_parse::{
-	Parse, Parser, QualifiedRule, Result as ParserResult, RuleVariants, atkeyword_set, syntax::BadDeclaration,
+	Cursor, Parse, Parser, QualifiedRule, Result as ParserResult, RuleVariants, atkeyword_set, syntax::BadDeclaration,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 use csskit_proc_macro::visit;

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -1,7 +1,6 @@
 use bumpalo::collections::Vec;
-use css_lexer::Cursor;
 use css_parse::{
-	AtRule, Build, ComponentValues, Parse, Parser, Peek, QualifiedRule, Result as ParserResult, RuleVariants,
+	AtRule, Build, ComponentValues, Cursor, Parse, Parser, Peek, QualifiedRule, Result as ParserResult, RuleVariants,
 	StyleSheet as StyleSheetTrait, T, atkeyword_set, diagnostics,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
@@ -66,7 +65,7 @@ macro_rules! apply_rules {
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct UnknownAtRule<'a>(AtRule<'a, T![AtKeyword], ComponentValues<'a>, ComponentValues<'a>>);
+pub struct UnknownAtRule<'a>(AtRule<T![AtKeyword], ComponentValues<'a>, ComponentValues<'a>>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/types/animateable_feature.rs
+++ b/crates/css_ast/src/types/animateable_feature.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, T};
+use css_parse::{Build, Cursor, Parser, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors, Visitable};
 
 // https://drafts.csswg.org/css-will-change-1/#typedef-animateable-feature

--- a/crates/css_ast/src/types/auto_line_color_list.rs
+++ b/crates/css_ast/src/types/auto_line_color_list.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/auto_line_style_list.rs
+++ b/crates/css_ast/src/types/auto_line_style_list.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/auto_line_width_list.rs
+++ b/crates/css_ast/src/types/auto_line_width_list.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/autospace.rs
+++ b/crates/css_ast/src/types/autospace.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/basic_shape_rect.rs
+++ b/crates/css_ast/src/types/basic_shape_rect.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -2,8 +2,7 @@ mod named;
 mod system;
 
 use crate::ColorFunction;
-use css_lexer::Cursor;
-use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
+use css_parse::{Build, Cursor, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 pub use named::*;

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -1,8 +1,7 @@
 #![allow(warnings)]
 use bumpalo::collections::Vec;
-use css_lexer::Cursor;
 use css_parse::{
-	Build, Function, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set, keyword_set,
+	Build, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set, keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 

--- a/crates/css_ast/src/types/corner_shape_value.rs
+++ b/crates/css_ast/src/types/corner_shape_value.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parse, Peek, Result as ParserResult, T, keyword_set};
+use css_parse::{Cursor, Parse, Peek, Result as ParserResult, T, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 use crate::SuperellipseFunction;

--- a/crates/css_ast/src/types/counter_style.rs
+++ b/crates/css_ast/src/types/counter_style.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parser, Peek, T, keyword_set};
+use css_parse::{Cursor, Parser, Peek, T, keyword_set};
 use csskit_derives::{Parse, ToCursors, ToSpan, Visitable};
 
 use crate::SymbolsFunction;

--- a/crates/css_ast/src/types/font_weight_absolute.rs
+++ b/crates/css_ast/src/types/font_weight_absolute.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
+use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 use crate::CSSInt;

--- a/crates/css_ast/src/types/gap_auto_rule_list.rs
+++ b/crates/css_ast/src/types/gap_auto_rule_list.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/gap_rule_list.rs
+++ b/crates/css_ast/src/types/gap_rule_list.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/grid_line.rs
+++ b/crates/css_ast/src/types/grid_line.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set, parse_optionals};
+use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set, parse_optionals};
 use csskit_derives::{Peek, ToCursors, ToSpan};
 
 use crate::{PositiveNonZeroInt, Visitable};

--- a/crates/css_ast/src/types/line_color_list.rs
+++ b/crates/css_ast/src/types/line_color_list.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/line_style_list.rs
+++ b/crates/css_ast/src/types/line_style_list.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/line_width_list.rs
+++ b/crates/css_ast/src/types/line_width_list.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/opacity_value.rs
+++ b/crates/css_ast/src/types/opacity_value.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 #[derive(IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -1,5 +1,4 @@
-use css_lexer::{Cursor, Kind, Token};
-use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
+use css_parse::{Build, Cursor, Kind, Parse, Parser, Peek, Result as ParserResult, T, Token, diagnostics, keyword_set};
 use csskit_derives::{IntoCursor, ToCursors, ToSpan, Visitable};
 
 use crate::units::LengthPercentage;

--- a/crates/css_ast/src/types/position_area.rs
+++ b/crates/css_ast/src/types/position_area.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
+use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-anchor-position-1/#typedef-position-area

--- a/crates/css_ast/src/types/positive_non_zero_int.rs
+++ b/crates/css_ast/src/types/positive_non_zero_int.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Result as ParserResult, diagnostics};
+use css_parse::{Cursor, Parse, Parser, Result as ParserResult, diagnostics};
 use csskit_derives::{Peek, ToCursors, ToSpan};
 
 use crate::{CSSInt, Unit};

--- a/crates/css_ast/src/types/repeat_style.rs
+++ b/crates/css_ast/src/types/repeat_style.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
+use css_parse::{Build, Cursor, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 /// <https://drafts.csswg.org/css-backgrounds-4/#background-repeat>

--- a/crates/css_ast/src/types/shadow.rs
+++ b/crates/css_ast/src/types/shadow.rs
@@ -1,7 +1,6 @@
 use crate::types::Color;
 use crate::units::{Length, Unit};
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
+use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-backgrounds-3/#typedef-shadow

--- a/crates/css_ast/src/types/single_animation_iteration_count.rs
+++ b/crates/css_ast/src/types/single_animation_iteration_count.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
+use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 use crate::units::CSSFloat;

--- a/crates/css_ast/src/types/single_animation_trigger.rs
+++ b/crates/css_ast/src/types/single_animation_trigger.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/single_transition.rs
+++ b/crates/css_ast/src/types/single_transition.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Peek, Result as ParserResult, parse_optionals};
+use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, parse_optionals};
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
 use crate::{EasingFunction, NoneKeyword, SingleTransitionProperty, Time, TransitionBehaviorValue};

--- a/crates/css_ast/src/types/single_transition_property.rs
+++ b/crates/css_ast/src/types/single_transition_property.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 use csskit_derives::{Peek, ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-transitions-1/#single-transition-property

--- a/crates/css_ast/src/types/spread_shadow.rs
+++ b/crates/css_ast/src/types/spread_shadow.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/text_edge.rs
+++ b/crates/css_ast/src/types/text_edge.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/track_size.rs
+++ b/crates/css_ast/src/types/track_size.rs
@@ -1,6 +1,5 @@
 #![allow(warnings)]
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
 
 use crate::Todo;
 

--- a/crates/css_ast/src/types/url.rs
+++ b/crates/css_ast/src/types/url.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, function_set};
+use css_parse::{Build, Cursor, Parse, Parser, Peek, Result as ParserResult, T, function_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 /// <https://drafts.csswg.org/css-values-4/#url-value>

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -1,5 +1,4 @@
-use css_lexer::{Cursor, DimensionUnit};
-use css_parse::{Build, Parser, T};
+use css_parse::{Build, Cursor, DimensionUnit, Parser, T};
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 
 // const DEG_GRAD: f32 = 0.9;

--- a/crates/css_ast/src/units/custom.rs
+++ b/crates/css_ast/src/units/custom.rs
@@ -1,5 +1,4 @@
-use css_lexer::{Cursor, DimensionUnit};
-use css_parse::{Build, Parser, Peek, T};
+use css_parse::{Build, Cursor, DimensionUnit, Parser, Peek, T};
 use csskit_derives::{IntoCursor, ToCursors};
 
 #[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/units/flex.rs
+++ b/crates/css_ast/src/units/flex.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 // https://www.w3.org/TR/css-grid-2/#typedef-flex

--- a/crates/css_ast/src/units/float.rs
+++ b/crates/css_ast/src/units/float.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T};
 use csskit_derives::{IntoCursor, ToCursors};
 
 #[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/units/frequency.rs
+++ b/crates/css_ast/src/units/frequency.rs
@@ -1,5 +1,4 @@
-use css_lexer::{Cursor, DimensionUnit};
-use css_parse::{Build, Parser, T};
+use css_parse::{Build, Cursor, DimensionUnit, Parser, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors};
 
 // https://drafts.csswg.org/css-values/#resolution

--- a/crates/css_ast/src/units/int.rs
+++ b/crates/css_ast/src/units/int.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 #[derive(IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors, Visitable};
 
 use super::Flex;

--- a/crates/css_ast/src/units/line_width.rs
+++ b/crates/css_ast/src/units/line_width.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T, keyword_set};
+use css_parse::{Build, Cursor, Parser, Peek, T, keyword_set};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 use super::Length;

--- a/crates/css_ast/src/units/number.rs
+++ b/crates/css_ast/src/units/number.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T, keyword_set};
+use css_parse::{Build, Cursor, Parser, Peek, T, keyword_set};
 use csskit_derives::{IntoCursor, Peek, ToCursors};
 
 keyword_set!(enum InfinityKeyword {

--- a/crates/css_ast/src/units/resolution.rs
+++ b/crates/css_ast/src/units/resolution.rs
@@ -1,5 +1,4 @@
-use css_lexer::{Cursor, DimensionUnit};
-use css_parse::{Build, Parser, T};
+use css_parse::{Build, Cursor, DimensionUnit, Parser, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors};
 
 // const DPPX_IN: f32 = 96.0;

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -1,5 +1,4 @@
-use css_lexer::Cursor;
-use css_parse::{Build, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 // https://drafts.csswg.org/css-values/#resolution

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -169,11 +169,11 @@ where
 	}
 }
 
-impl<'a, AT, P, B> VisitableMut for AtRule<'a, AT, P, B>
+impl<AT, P, B> VisitableMut for AtRule<AT, P, B>
 where
-	AT: Peek<'a> + Parse<'a> + Into<token_macros::AtKeyword>,
-	P: VisitableMut + Parse<'a> + ToCursors + ToSpan,
-	B: VisitableMut + Parse<'a> + ToCursors + ToSpan,
+	AT: Into<token_macros::AtKeyword>,
+	P: VisitableMut,
+	B: VisitableMut,
 {
 	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
 		self.prelude.accept_mut(v);
@@ -181,11 +181,11 @@ where
 	}
 }
 
-impl<'a, AT, P, B> Visitable for AtRule<'a, AT, P, B>
+impl<AT, P, B> Visitable for AtRule<AT, P, B>
 where
-	AT: Peek<'a> + Parse<'a> + Into<token_macros::AtKeyword>,
-	P: Visitable + Parse<'a> + ToCursors + ToSpan,
-	B: Visitable + Parse<'a> + ToCursors + ToSpan,
+	AT: Into<token_macros::AtKeyword>,
+	P: Visitable,
+	B: Visitable,
 {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		self.prelude.accept(v);

--- a/crates/css_parse/src/cursor_compact_write_sink.rs
+++ b/crates/css_parse/src/cursor_compact_write_sink.rs
@@ -1,6 +1,5 @@
-use crate::{CursorSink, SourceCursor, SourceCursorSink};
+use crate::{Cursor, CursorSink, Kind, KindSet, QuoteStyle, SourceCursor, SourceCursorSink, Token};
 use core::fmt::{Result, Write};
-use css_lexer::{Cursor, Kind, KindSet, QuoteStyle, Token};
 
 /// This is a [CursorSink] that wraps a Writer (`impl fmt::Write`) and on each [CursorSink::append()] call, will write
 /// the contents of the cursor [Cursor] given into the given Writer - using the given `&'a str` as the original source.

--- a/crates/css_parse/src/cursor_overlay_sink.rs
+++ b/crates/css_parse/src/cursor_overlay_sink.rs
@@ -1,6 +1,8 @@
-use crate::{CursorSink, CursorToSourceCursorSink, ParserReturn, SourceCursor, SourceCursorSink, ToCursors};
+use crate::{
+	Cursor, CursorSink, CursorToSourceCursorSink, ParserReturn, SourceCursor, SourceCursorSink, SourceOffset, Span,
+	ToCursors, ToSpan,
+};
 use bumpalo::{Bump, collections::Vec};
-use css_lexer::{Cursor, SourceOffset, Span, ToSpan};
 use std::collections::BTreeMap;
 
 #[derive(Debug)]
@@ -85,9 +87,8 @@ impl<'a, T: SourceCursorSink<'a>> CursorSink for CursorOverlaySink<'a, T> {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::{ComponentValue, CursorPrettyWriteSink, CursorWriteSink, T, ToCursors, parse};
+	use crate::{ComponentValue, CursorPrettyWriteSink, CursorWriteSink, QuoteStyle, T, ToCursors, ToSpan, parse};
 	use bumpalo::{Bump, collections::Vec};
-	use css_lexer::{QuoteStyle, ToSpan};
 
 	#[test]
 	fn test_basic() {

--- a/crates/css_parse/src/cursor_pretty_write_sink.rs
+++ b/crates/css_parse/src/cursor_pretty_write_sink.rs
@@ -1,6 +1,5 @@
-use crate::{CursorSink, SourceCursor, SourceCursorSink};
+use crate::{Cursor, CursorSink, Kind, KindSet, QuoteStyle, SourceCursor, SourceCursorSink, Token, Whitespace};
 use core::fmt::{Result, Write};
-use css_lexer::{Cursor, Kind, KindSet, QuoteStyle, Token, Whitespace};
 
 /// This is a [CursorSink] that wraps a Writer (`impl fmt::Write`) and on each [CursorSink::append()] call, will write
 /// the contents of the cursor [Cursor] given into the given Writer - using the given `&'a str` as the original source.

--- a/crates/css_parse/src/cursor_write_sink.rs
+++ b/crates/css_parse/src/cursor_write_sink.rs
@@ -1,6 +1,5 @@
-use crate::{CursorSink, SourceCursor, SourceCursorSink};
+use crate::{Cursor, CursorSink, SourceCursor, SourceCursorSink, Token};
 use core::fmt::{Result, Write};
-use css_lexer::{Cursor, Token};
 
 /// This is a [CursorSink] that wraps a Writer (`impl fmt::Write`) and on each [CursorSink::append()] call, will write
 /// the contents of the cursor [Cursor] given into the given Writer - using the given `&'a str` as the original source.

--- a/crates/css_parse/src/diagnostics.rs
+++ b/crates/css_parse/src/diagnostics.rs
@@ -1,4 +1,4 @@
-use css_lexer::{Cursor, Kind, Span};
+use crate::{Cursor, Kind, Span};
 use miette::{self, Diagnostic};
 use thiserror::{self, Error};
 

--- a/crates/css_parse/src/feature.rs
+++ b/crates/css_parse/src/feature.rs
@@ -8,16 +8,18 @@ use bitmask_enum::bitmask;
 /// # Example
 ///
 /// ```
-/// use css_lexer::*;
+/// use css_parse::*;
+/// use bumpalo::Bump;
+/// let bump = Bump::default();
 /// let features = Feature::SingleLineComments | Feature::SeparateWhitespace;
-/// let mut lexer = Lexer::new_with_features("// foo", features);
+/// let mut parser = Parser::new_with_features(&bump, "// foo", features);
 /// ```
 #[bitmask(u8)]
 pub enum Feature {
 	/// This flag is forwarded to the [Lexer][css_lexer::Lexer] which, when enabled, will treat single line comments as valid
 	/// Comment tokens. If it encounters two consecutative SOLIDUS characters (`//`), it will return a
-	/// [Token][css_lexer::Token] with [Kind::Comment][css_lexer::Kind::Comment]. For more information about exactly what
-	/// happens here at the lexer level, consult the [css_lexer::Feature::SingleLineComments] feature.
+	/// [Token][crate::Token] with [Kind::Comment][crate::Kind::Comment]. For more information about exactly what
+	/// happens here at the lexer level, consult the [crate::Feature::SingleLineComments] feature.
 	///
 	/// This flag doesn't cause any changes in logic on the [Parser][crate::Parser]; comments will be collected in the
 	/// trivia tokens Vec as normal.
@@ -25,7 +27,7 @@ pub enum Feature {
 
 	/// This flag is forwarded to the [Lexer][css_lexer::Lexer] which, when enabled, will treat diffetent whitespace kinds as
 	/// descrete. For more information about exactly what happens here at the lexer level, consult the
-	/// [css_lexer::Feature::SeparateWhitespace] feature.
+	/// [crate::Feature::SeparateWhitespace] feature.
 	///
 	/// This flag doesn't cause any changes in logic on the [Parser][crate::Parser]; whitespace is typically collected in
 	/// the trivia Vec. AST nodes which call [Parser::set_skip()][crate::Parser::set_skip] to parse whitespace sensitive nodes

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -22,7 +22,7 @@
 //! various base tokens (such as dimensions, and operators). These can be referred to via the [T!] macro, and each [T!]
 //! implements the necessary traits to be parsed as an AST node. For example [T![DashedIdent]][token_macros::DashedIdent]
 //! represents a CSS ident with two leading dashes, and can be parsed and decomposted into its constituent
-//! [Token][css_lexer::Token] (or [Cursor][css_lexer::Cursor] or [Span][css_lexer::Span]).
+//! [Token][Token] (or [Cursor][Cursor] or [Span][Span]).
 //!
 //! Additionally some generic structs are available to implement the general-purpose parts of [CSS Syntax][1], such as
 //! [ComponentValues][syntax::ComponentValues]. More on that below in the section titled
@@ -104,11 +104,11 @@
 //! [Peek::peek] should only look ahead the smallest number of tokens to confidently know that it can begin parsing,
 //! rather than looking ahead a large number of tokens. For the most part peeking 1 or two tokens should be sufficient.
 //! An easy implementation for [Peek] is to simply set the [Peek::PEEK_KINDSET] const, which the provided
-//! implementation of [Peek::peek()] will use to check the cursor matches this [KindSet][css_lexer::KindSet].
+//! implementation of [Peek::peek()] will use to check the cursor matches this [KindSet][KindSet].
 //!
 //! ```
 //! use css_parse::*;
-//! use css_lexer::{Kind, KindSet};
+//! use {Kind, KindSet};
 //! enum LengthOrAuto {
 //!   Length(T![Dimension]), // A Dimension, like `px`
 //!   Auto(T![Ident]),       // The Ident of `auto`
@@ -122,15 +122,14 @@
 //!
 //! If a node represents just a single token, for example a keyword, then it can implement the [Build] trait instead of
 //! [Parse]. If it implements [Build] and [Peek], it gets [Parse] for free. The [Build] trait is given an _immutable_
-//! reference to the [Parser], and the single [Cursor][css_lexer::Cursor] it intends to build, and should simply return
-//! `Self`, wrapping the [Cursor][css_lexer::Cursor]. The [Peek] trait should accurately and completely determines if
-//! the Node is able to be built from the given [Cursor][css_lexer::Cursor], therefore making [Build] infallable;
+//! reference to the [Parser], and the single [Cursor][Cursor] it intends to build, and should simply return
+//! `Self`, wrapping the [Cursor][Cursor]. The [Peek] trait should accurately and completely determines if
+//! the Node is able to be built from the given [Cursor][Cursor], therefore making [Build] infallable;
 //! [Build] can skip any of the checks that [Peek] already did, but may still need to branch if it is an enum of
 //! variants:
 //!
 //! ```
 //! use css_parse::*;
-//! use css_lexer::{Cursor, Kind, KindSet};
 //! enum LengthOrAuto {
 //!   Length(T![Dimension]), // A Dimension, like `px`
 //!   Auto(T![Ident]),       // The Ident of `auto`
@@ -273,6 +272,11 @@
 //! assert_parse!(MyProperty, "width:1px");
 //! ```
 
+// Re-export commonly used components from css_lexer:
+pub use css_lexer::{
+	Cursor, DimensionUnit, Kind, KindSet, PairWise, QuoteStyle, SourceOffset, Span, ToSpan, Token, Whitespace,
+};
+
 mod comparison;
 mod cursor_compact_write_sink;
 mod cursor_overlay_sink;
@@ -290,7 +294,7 @@ pub mod syntax;
 /// Test macros available if built with `features = ["testing"]`
 #[cfg(any(feature = "testing", test))]
 pub mod test_helpers;
-/// Various macros that expand to AST nodes that wrap [Tokens][css_lexer::Token].
+/// Various macros that expand to AST nodes that wrap [Tokens][Token].
 pub mod token_macros;
 mod traits;
 

--- a/crates/css_parse/src/macros/optionals.rs
+++ b/crates/css_parse/src/macros/optionals.rs
@@ -1,5 +1,4 @@
-use crate::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors};
-use css_lexer::{Span, ToSpan};
+use crate::{CursorSink, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan};
 
 macro_rules! impl_optionals {
 	($($name:ident, ($($T:ident),+))+) => {
@@ -82,7 +81,7 @@ macro_rules! parse_optionals {
 
 			if $($name.is_none())&&+ {
 				use $crate::{diagnostics, T};
-				let c: css_lexer::Cursor = $p.parse::<T![Any]>()?.into();
+				let c: $crate::Cursor = $p.parse::<T![Any]>()?.into();
 				Err(diagnostics::Unexpected(c.into(), c.into()))?
 			}
 

--- a/crates/css_parse/src/macros/pseudo_element.rs
+++ b/crates/css_parse/src/macros/pseudo_element.rs
@@ -1,8 +1,8 @@
 /// A macro for defining pseudo elements.
 ///
 /// This makes it much easier to define a pseudo element, which would otherwise need to define a
-/// [keyword_set][crate::keyword_set] or similar, in order to build up the two [Cursors][css_lexer::Cursor] required to
-/// parse. Parsing is also a little bit delicate, as the two [Cursors][css_lexer::Cursor] must appear next to each
+/// [keyword_set][crate::keyword_set] or similar, in order to build up the two [Cursors][crate::Cursor] required to
+/// parse. Parsing is also a little bit delicate, as the two [Cursors][crate::Cursor] must appear next to each
 /// other - no whitespace nor comments can be present betwixt the colon and ident.
 ///
 /// # Example
@@ -39,12 +39,12 @@ macro_rules! pseudo_element {
 		}
 
 		impl<'a> $crate::Peek<'a> for $name {
-			fn peek(p: &$crate::Parser<'a>, c: css_lexer::Cursor) -> bool {
+			fn peek(p: &$crate::Parser<'a>, c: $crate::Cursor) -> bool {
 				let c2 = p.peek_n(2);
 				let c3 = p.peek_n(3);
-				c == ::css_lexer::Kind::Colon
-				&& c2 == ::css_lexer::Kind::Colon
-				&& c3 == ::css_lexer::Kind::Ident
+				c == $crate::Kind::Colon
+				&& c2 == $crate::Kind::Colon
+				&& c3 == $crate::Kind::Ident
 				&& Self::MAP.get(&p.parse_str_lower(c3)).is_some()
 			}
 		}
@@ -52,7 +52,7 @@ macro_rules! pseudo_element {
 		impl<'a> $crate::Parse<'a> for $name {
 			fn parse(p: &mut $crate::Parser<'a>) -> $crate::Result<Self> {
 				let colons = p.parse::<$crate::T![::]>()?;
-				let skip = p.set_skip(::css_lexer::KindSet::NONE);
+				let skip = p.set_skip($crate::KindSet::NONE);
 				let ident = p.parse::<$crate::T![Ident]>();
 				p.set_skip(skip);
 				let ident = ident?;
@@ -61,7 +61,7 @@ macro_rules! pseudo_element {
 						$(Self::$variant(_, _) => Ok(Self::$variant(colons, ident)),)+
 					}
 				} else {
-					use ::css_lexer::ToSpan;
+					use $crate::ToSpan;
 					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.to_span()))?
 				}
 			}
@@ -78,8 +78,8 @@ macro_rules! pseudo_element {
 			}
 		}
 
-		impl ::css_lexer::ToSpan for $name {
-			fn to_span(&self) -> ::css_lexer::Span {
+		impl $crate::ToSpan for $name {
+			fn to_span(&self) -> $crate::Span {
 				match self {
 					$($name::$variant(a, b) => a.to_span() + b.to_span(),)+
 				}

--- a/crates/css_parse/src/parser.rs
+++ b/crates/css_parse/src/parser.rs
@@ -1,10 +1,10 @@
 use crate::{
-	Feature, ParserCheckpoint, ParserReturn, Result, ToCursors, diagnostics,
+	Cursor, Feature, Kind, KindSet, ParserCheckpoint, ParserReturn, Result, SourceOffset, Span, ToCursors, diagnostics,
 	traits::{Parse, Peek},
 };
 use bitmask_enum::bitmask;
 use bumpalo::Bump;
-use css_lexer::{Cursor, Kind, KindSet, Lexer, SourceOffset, Span};
+use css_lexer::Lexer;
 use miette::Error;
 use std::mem::take;
 
@@ -283,7 +283,7 @@ impl<'a> Parser<'a> {
 			debug_assert!(last_cursor != c, "Detected a next loop, {c:?} was fetched twice");
 		}
 		#[cfg(debug_assertions)]
-		if c == css_lexer::Kind::Eof {
+		if c == Kind::Eof {
 			self.last_cursor = None;
 		} else {
 			self.last_cursor = Some(c);

--- a/crates/css_parse/src/parser_checkpoint.rs
+++ b/crates/css_parse/src/parser_checkpoint.rs
@@ -1,4 +1,4 @@
-use css_lexer::{Cursor, Kind, Span, ToSpan, Token};
+use crate::{Cursor, Kind, Span, ToSpan, Token};
 
 /// Represents a point during the [Parser's][crate::Parser] lifecycle; retaining state that can then be rewound.
 ///

--- a/crates/css_parse/src/parser_return.rs
+++ b/crates/css_parse/src/parser_return.rs
@@ -1,5 +1,4 @@
-use crate::{CursorSink, Error, ToCursors};
-use css_lexer::Cursor;
+use crate::{Cursor, CursorSink, Error, ToCursors};
 
 #[derive(Debug)]
 pub struct ParserReturn<'a, T>

--- a/crates/css_parse/src/syntax/bad_declaration.rs
+++ b/crates/css_parse/src/syntax/bad_declaration.rs
@@ -1,6 +1,7 @@
-use crate::{CursorSink, Parse, Parser, Result as ParserResult, State, T, ToCursors, syntax::ComponentValue};
+use crate::{
+	CursorSink, Parse, Parser, Result as ParserResult, Span, State, T, ToCursors, ToSpan, syntax::ComponentValue,
+};
 use bumpalo::collections::Vec;
-use css_lexer::{Span, ToSpan};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_parse/src/syntax/bang_important.rs
+++ b/crates/css_parse/src/syntax/bang_important.rs
@@ -1,6 +1,4 @@
-use crate::{CursorSink, Parse, Parser, Peek, Result, T, ToCursors, diagnostics};
-use css_lexer::{Cursor, Kind, ToSpan};
-use csskit_derives::ToSpan;
+use crate::{Cursor, CursorSink, Kind, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan, diagnostics};
 
 /// Represents a two tokens, the first being [Kind::Delim] where the char is `!`, and the second being an `Ident` with
 /// the value `important`. [CSS defines this as]:
@@ -15,12 +13,12 @@ use csskit_derives::ToSpan;
 ///  │├─ "!" ─ <ws*> ─ <ident-token "important"> ─ <ws*> ─┤│
 /// ```
 ///
-/// `<ws*>` is any number of `<whitespace-token>`s, defined as [Kind::Whitespace][css_lexer::Kind::Whitespace]. This is
+/// `<ws*>` is any number of `<whitespace-token>`s, defined as [Kind::Whitespace][Kind::Whitespace]. This is
 /// automatically skipped by default in the [Parser] anyway.
 ///
 /// [1]: https://drafts.csswg.org/css-syntax-3/#!important-diagram
 ///
-#[derive(ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct BangImportant {
 	pub bang: T![!],
@@ -53,5 +51,11 @@ impl ToCursors for BangImportant {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		s.append(self.bang.into());
 		s.append(self.important.into());
+	}
+}
+
+impl ToSpan for BangImportant {
+	fn to_span(&self) -> Span {
+		self.bang.to_span() + self.important.to_span()
 	}
 }

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -1,14 +1,12 @@
 use crate::{
-	CursorSink, Parse, Parser, Peek, Result as ParserResult, State, T, ToCursors, diagnostics,
-	syntax::{FunctionBlock, SimpleBlock},
+	Cursor, CursorSink, FunctionBlock, Kind, KindSet, Parse, Parser, Peek, Result as ParserResult, SimpleBlock, Span,
+	State, T, ToCursors, ToSpan, diagnostics,
 };
-use css_lexer::{Cursor, Kind, KindSet};
-use csskit_derives::ToSpan;
 
 // https://drafts.csswg.org/css-syntax-3/#consume-component-value
 // A compatible "Token" per CSS grammar, subsetted to the tokens possibly
 // rendered by ComponentValue (so no pairwise, function tokens, etc).
-#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 pub enum ComponentValue<'a> {
 	SimpleBlock(SimpleBlock<'a>),
@@ -109,6 +107,27 @@ impl<'a> ToCursors for ComponentValue<'a> {
 			Self::Colon(t) => ToCursors::to_cursors(t, s),
 			Self::Semicolon(t) => ToCursors::to_cursors(t, s),
 			Self::Comma(t) => ToCursors::to_cursors(t, s),
+		}
+	}
+}
+
+impl<'a> ToSpan for ComponentValue<'a> {
+	fn to_span(&self) -> Span {
+		match self {
+			Self::SimpleBlock(t) => t.to_span(),
+			Self::Function(t) => t.to_span(),
+			Self::Ident(t) => t.to_span(),
+			Self::AtKeyword(t) => t.to_span(),
+			Self::Hash(t) => t.to_span(),
+			Self::String(t) => t.to_span(),
+			Self::Url(t) => t.to_span(),
+			Self::Delim(t) => t.to_span(),
+			Self::Number(t) => t.to_span(),
+			Self::Dimension(t) => t.to_span(),
+			Self::Whitespace(t) => t.to_span(),
+			Self::Colon(t) => t.to_span(),
+			Self::Semicolon(t) => t.to_span(),
+			Self::Comma(t) => t.to_span(),
 		}
 	}
 }

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -1,12 +1,10 @@
-use crate::{CursorSink, DeclarationValue, Parse, Parser, Peek, Result, ToCursors};
+use crate::{Cursor, CursorSink, DeclarationValue, Parse, Parser, Peek, Result, Span, ToCursors, ToSpan};
 use bumpalo::collections::Vec;
-use css_lexer::Cursor;
-use csskit_derives::ToSpan;
 
 use super::ComponentValue;
 
 // https://drafts.csswg.org/css-syntax-3/#consume-list-of-components
-#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct ComponentValues<'a> {
 	values: Vec<'a, ComponentValue<'a>>,
@@ -81,9 +79,13 @@ impl<'a> DeclarationValue<'a> for ComponentValues<'a> {
 
 impl<'a> ToCursors for ComponentValues<'a> {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
-		for value in &self.values {
-			ToCursors::to_cursors(value, s)
-		}
+		ToCursors::to_cursors(&self.values, s)
+	}
+}
+
+impl<'a> ToSpan for ComponentValues<'a> {
+	fn to_span(&self) -> Span {
+		self.values.to_span()
 	}
 }
 

--- a/crates/css_parse/src/syntax/function.rs
+++ b/crates/css_parse/src/syntax/function.rs
@@ -1,5 +1,4 @@
-use crate::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, token_macros};
-use css_lexer::{Cursor, ToSpan};
+use crate::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan, token_macros};
 use std::marker::PhantomData;
 
 /// This struct provides the generic `function()` grammar that parses a [function block][1] where the interior function
@@ -21,7 +20,6 @@ use std::marker::PhantomData;
 ///
 /// ```
 /// use css_parse::*;
-/// use css_lexer::*;
 ///
 /// /// A grammar like `test(foo)`
 /// #[derive(Debug)]
@@ -97,7 +95,7 @@ where
 	FT: Into<token_macros::Function>,
 	T: ToSpan,
 {
-	fn to_span(&self) -> css_lexer::Span {
+	fn to_span(&self) -> Span {
 		self.name.to_span() + self.parameters.to_span() + self.close.to_span()
 	}
 }

--- a/crates/css_parse/src/syntax/function_block.rs
+++ b/crates/css_parse/src/syntax/function_block.rs
@@ -1,7 +1,8 @@
-use crate::{ComponentValues, CursorSink, Function, Parse, Parser, Result as ParserResult, ToCursors, token_macros};
-use csskit_derives::ToSpan;
+use crate::{
+	ComponentValues, CursorSink, Function, Parse, Parser, Result as ParserResult, Span, ToCursors, ToSpan, token_macros,
+};
 
-#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct FunctionBlock<'a>(Function<token_macros::Function, ComponentValues<'a>>);
 
@@ -15,6 +16,12 @@ impl<'a> Parse<'a> for FunctionBlock<'a> {
 impl<'a> ToCursors for FunctionBlock<'a> {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		ToCursors::to_cursors(&self.0, s);
+	}
+}
+
+impl<'a> ToSpan for FunctionBlock<'a> {
+	fn to_span(&self) -> Span {
+		self.0.to_span()
 	}
 }
 

--- a/crates/css_parse/src/syntax/no_block_allowed.rs
+++ b/crates/css_parse/src/syntax/no_block_allowed.rs
@@ -1,12 +1,11 @@
-use crate::{CursorSink, Parse, Parser, Peek, Result, T, ToCursors, diagnostics};
-use csskit_derives::ToSpan;
+use crate::{Cursor, CursorSink, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan, diagnostics};
 
 /// A struct to provide to [AtRule][crate::AtRule] to disallow blocks.
 ///
 /// Sometimes [AtRules][crate::syntax::AtRule] do not have a block - for example `@charset`, `@import`. In those case, assigning
 /// this struct to the `Block` can be useful to ensure that the [AtRule][crate::syntax::AtRule] appropriately errors if it enters the
 /// Block parsing context. This captures the `;` token that may optionally end a "statement-style" at-rule.
-#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct NoBlockAllowed(Option<T![;]>);
 
@@ -24,7 +23,7 @@ impl<'a> Parse<'a> for NoBlockAllowed {
 }
 
 impl<'a> Peek<'a> for NoBlockAllowed {
-	fn peek(_: &Parser<'a>, _: css_lexer::Cursor) -> bool {
+	fn peek(_: &Parser<'a>, _: Cursor) -> bool {
 		false
 	}
 }
@@ -34,5 +33,11 @@ impl ToCursors for NoBlockAllowed {
 		if let Some(semicolon) = self.0 {
 			s.append(semicolon.into());
 		}
+	}
+}
+
+impl ToSpan for NoBlockAllowed {
+	fn to_span(&self) -> Span {
+		self.0.to_span()
 	}
 }

--- a/crates/css_parse/src/syntax/no_prelude_allowed.rs
+++ b/crates/css_parse/src/syntax/no_prelude_allowed.rs
@@ -1,5 +1,4 @@
-use crate::{CursorSink, Parse, Parser, Peek, Result, T, ToCursors, diagnostics};
-use css_lexer::{Span, ToSpan};
+use crate::{Cursor, CursorSink, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan, diagnostics};
 
 /// A struct to provide to [AtRule][crate::AtRule] to disallow preludes.
 ///
@@ -22,7 +21,7 @@ impl<'a> Parse<'a> for NoPreludeAllowed {
 }
 
 impl<'a> Peek<'a> for NoPreludeAllowed {
-	fn peek(_: &Parser<'a>, _: css_lexer::Cursor) -> bool {
+	fn peek(_: &Parser<'a>, _: Cursor) -> bool {
 		false
 	}
 }
@@ -34,7 +33,7 @@ impl ToCursors for NoPreludeAllowed {
 }
 
 impl ToSpan for NoPreludeAllowed {
-	fn to_span(&self) -> css_lexer::Span {
+	fn to_span(&self) -> Span {
 		Span::ZERO
 	}
 }

--- a/crates/css_parse/src/syntax/property.rs
+++ b/crates/css_parse/src/syntax/property.rs
@@ -1,6 +1,5 @@
 use crate::{CursorSink, DeclarationValue, Parse, Parser, Peek, Result as ParserResult, T, ToCursors};
 use bumpalo::collections::{Vec, vec::IntoIter};
-use css_lexer::{Cursor, Kind, KindSet, Span, ToSpan};
 
 /// This is a generic type that can be used for AST nodes representing a [Declaration][1], aka "property".
 ///

--- a/crates/css_parse/src/syntax/rule_list.rs
+++ b/crates/css_parse/src/syntax/rule_list.rs
@@ -1,7 +1,5 @@
-use crate::{CursorSink, Parse, Parser, Peek, Result, T, ToCursors, token_macros};
+use crate::{Cursor, CursorSink, Parse, Parser, Peek, Result, T, ToCursors, ToSpan, token_macros};
 use bumpalo::collections::Vec;
-use css_lexer::ToSpan;
-use csskit_derives::ToSpan;
 
 /// A struct representing an AST node block that only accepts child "Rules". This is defined as:
 ///
@@ -19,27 +17,21 @@ use csskit_derives::ToSpan;
 ///
 /// [1]: https://drafts.csswg.org/css-syntax-3/#typedef-at-rule-list
 /// [2]: https://drafts.csswg.org/css-syntax-3/#typedef-qualified-rule-list
-#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
-pub struct RuleList<'a, R>
-where
-	R: Parse<'a> + ToCursors + ToSpan,
-{
+pub struct RuleList<'a, R> {
 	pub open_curly: token_macros::LeftCurly,
 	pub rules: Vec<'a, R>,
 	pub close_curly: Option<token_macros::RightCurly>,
 }
 
-impl<'a, R> Peek<'a> for RuleList<'a, R>
-where
-	R: Parse<'a> + ToCursors + ToSpan,
-{
-	fn peek(p: &Parser<'a>, c: css_lexer::Cursor) -> bool {
+impl<'a, R> Peek<'a> for RuleList<'a, R> {
+	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
 		<token_macros::LeftCurly>::peek(p, c)
 	}
 }
 
-impl<'a, R: Parse<'a> + ToCursors + ToSpan> Parse<'a> for RuleList<'a, R> {
+impl<'a, R: Parse<'a>> Parse<'a> for RuleList<'a, R> {
 	fn parse(p: &mut Parser<'a>) -> Result<Self> {
 		let open_curly = p.parse::<T!['{']>()?;
 		let mut rules = Vec::new_in(p.bump());
@@ -57,13 +49,17 @@ impl<'a, R: Parse<'a> + ToCursors + ToSpan> Parse<'a> for RuleList<'a, R> {
 	}
 }
 
-impl<'a, R> ToCursors for RuleList<'a, R>
-where
-	R: Parse<'a> + ToCursors + ToSpan,
-{
+impl<'a, R: ToCursors> ToCursors for RuleList<'a, R> {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		ToCursors::to_cursors(&self.open_curly, s);
 		ToCursors::to_cursors(&self.rules, s);
 		ToCursors::to_cursors(&self.close_curly, s);
+	}
+}
+
+impl<'a, R: ToSpan> ToSpan for RuleList<'a, R> {
+	fn to_span(&self) -> css_lexer::Span {
+		self.open_curly.to_span()
+			+ if let Some(close) = self.close_curly { close.to_span() } else { self.rules.to_span() }
 	}
 }

--- a/crates/css_parse/src/syntax/simple_block.rs
+++ b/crates/css_parse/src/syntax/simple_block.rs
@@ -1,8 +1,8 @@
-use crate::{CursorSink, Parse, Parser, Result as ParserResult, T, ToCursors, syntax::ComponentValues};
-use css_lexer::KindSet;
-use csskit_derives::ToSpan;
+use crate::{
+	CursorSink, KindSet, Parse, Parser, Result as ParserResult, Span, T, ToCursors, ToSpan, syntax::ComponentValues,
+};
 
-#[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 pub struct SimpleBlock<'a> {
 	pub open: T![PairWiseStart],
@@ -30,6 +30,12 @@ impl<'a> ToCursors for SimpleBlock<'a> {
 		ToCursors::to_cursors(&self.open, s);
 		ToCursors::to_cursors(&self.values, s);
 		ToCursors::to_cursors(&self.close, s);
+	}
+}
+
+impl<'a> ToSpan for SimpleBlock<'a> {
+	fn to_span(&self) -> Span {
+		self.open.to_span() + if let Some(close) = self.close { close.to_span() } else { self.values.to_span() }
 	}
 }
 

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -136,7 +136,7 @@ macro_rules! assert_parse_span {
 		let result = parser.parse::<$ty>();
 		match result {
 			Ok(result) => {
-				use ::css_lexer::ToSpan;
+				use $crate::ToSpan;
 				let span = result.to_span();
 				let actual = format!("\n{}{}\n{}{}\n", indent, source_text, indent, "^".repeat(span.len() as usize));
 				if expected.trim() != actual.trim() {

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -1,4 +1,4 @@
-use css_lexer::Cursor;
+use crate::Cursor;
 
 use crate::{Parser, Result, T, diagnostics};
 
@@ -75,7 +75,6 @@ pub trait BooleanFeature<'a>: Sized {
 ///
 /// ```
 /// use css_parse::*;
-/// use css_lexer::{Token, Kind};
 /// use bumpalo::Bump;
 ///
 /// // Define the Boolean Feature.

--- a/crates/css_parse/src/traits/build.rs
+++ b/crates/css_parse/src/traits/build.rs
@@ -1,6 +1,4 @@
-use css_lexer::Cursor;
-
-use crate::Parser;
+use crate::{Cursor, Parser};
 
 /// This trait allows AST nodes to construct themselves from a single Cursor from the [Parser].
 ///

--- a/crates/css_parse/src/traits/cursor_sink.rs
+++ b/crates/css_parse/src/traits/cursor_sink.rs
@@ -1,5 +1,5 @@
+use crate::{Cursor, Span, ToSpan, Token};
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, ToSpan, Token};
 use std::fmt::{Result, Write};
 
 /// This trait provides the generic `impl` that [ToCursors][crate::ToCursors] can use. This provides just enough API
@@ -16,7 +16,7 @@ pub struct SourceCursor<'a> {
 }
 
 impl<'a> ToSpan for SourceCursor<'a> {
-	fn to_span(&self) -> css_lexer::Span {
+	fn to_span(&self) -> Span {
 		self.cursor.to_span()
 	}
 }

--- a/crates/css_parse/src/traits/cursor_source.rs
+++ b/crates/css_parse/src/traits/cursor_source.rs
@@ -1,4 +1,4 @@
-use css_lexer::Cursor;
+use crate::Cursor;
 
 /// This trait provides the generic `impl` that [ToCursors][crate::ToCursors] can use. This provides just enough API
 /// surface for nodes to put the cursors they represent into some buffer which can later be read, the details of which

--- a/crates/css_parse/src/traits/declaration_value.rs
+++ b/crates/css_parse/src/traits/declaration_value.rs
@@ -1,9 +1,8 @@
-use crate::{Parser, Peek, Result, T, ToCursors, diagnostics};
-use css_lexer::{Cursor, KindSet, ToSpan};
+use crate::{Cursor, KindSet, Parser, Peek, Result, T, diagnostics};
 
 /// A trait that can be used for AST nodes representing a Declaration's Value. It offers some
 /// convenience functions for handling such values.
-pub trait DeclarationValue<'a>: Sized + ToCursors + ToSpan {
+pub trait DeclarationValue<'a>: Sized {
 	type ComputedValue: Peek<'a>;
 
 	/// Determines if the given [Cursor] represents a valid [Ident][crate::token_macros::Ident] matching a known property

--- a/crates/css_parse/src/traits/discrete_feature.rs
+++ b/crates/css_parse/src/traits/discrete_feature.rs
@@ -1,4 +1,4 @@
-use css_lexer::Cursor;
+use crate::Cursor;
 
 use crate::{Parser, Result, T, diagnostics};
 
@@ -77,7 +77,6 @@ pub trait DiscreteFeature<'a>: Sized {
 ///
 /// ```
 /// use css_parse::*;
-/// use css_lexer::{Token, Kind};
 /// use bumpalo::Bump;
 ///
 /// keyword_set!(

--- a/crates/css_parse/src/traits/lists/prelude_list.rs
+++ b/crates/css_parse/src/traits/lists/prelude_list.rs
@@ -1,6 +1,5 @@
-use crate::{Parse, Parser, Result};
+use crate::{KindSet, Parse, Parser, Result};
 use bumpalo::collections::Vec;
-use css_lexer::KindSet;
 
 pub trait PreludeList<'a>: Sized + Parse<'a> {
 	type PreludeItem: Parse<'a>;

--- a/crates/css_parse/src/traits/parse.rs
+++ b/crates/css_parse/src/traits/parse.rs
@@ -3,7 +3,7 @@ use bumpalo::collections::Vec;
 
 /// This trait allows AST nodes to construct themselves from a mutable [Parser] instance.
 ///
-/// Nodes that implement this trait are entitled to consume any number of [Cursors][css_lexer::Cursor] from [Parser] in
+/// Nodes that implement this trait are entitled to consume any number of [Cursors][crate::Cursor] from [Parser] in
 /// order to construct themselves. They may also consume some amount of tokens and still return an [Err] - there is no
 /// need to try and reset the [Parser] state on failure ([Parser::try_parse()] exists for this reason).
 ///
@@ -14,7 +14,7 @@ use bumpalo::collections::Vec;
 /// Any node implementing [Parse::parse()] gets [Parse::try_parse()] for free. It's unlikely that nodes can come up with
 /// a more efficient algorithm than the provided one, so it is not worth re-implementing [Parse::try_parse()].
 ///
-/// If a Node can construct itself from a single [Cursor][css_lexer::Cursor] it should instead implement
+/// If a Node can construct itself from a single [Cursor][crate::Cursor] it should instead implement
 /// [Peek][crate::Peek] and [Build][crate::Build], which will provide [Parse] for free.
 pub trait Parse<'a>: Sized {
 	fn parse(p: &mut Parser<'a>) -> Result<Self>;

--- a/crates/css_parse/src/traits/peek.rs
+++ b/crates/css_parse/src/traits/peek.rs
@@ -1,4 +1,4 @@
-use css_lexer::{Cursor, KindSet};
+use crate::{Cursor, KindSet};
 
 use crate::Parser;
 
@@ -15,7 +15,7 @@ use crate::Parser;
 /// Calling `peek_n(2)` will return the [Cursor] after the provided one `peek_n(3)` will return the second [Cursor]
 /// after, and so on.
 ///
-/// For simple implementations it may be sufficient to just check the [Kind][css_lexer::Kind] of the given [Cursor].
+/// For simple implementations it may be sufficient to just check the [Kind][crate::Kind] of the given [Cursor].
 /// Rather than implementing [Peek::peek()], supplying [Peek::PEEK_KINDSET] and relying on the provided [Peek::peek()]
 /// method will work well.
 ///
@@ -28,7 +28,7 @@ use crate::Parser;
 /// [`Parser::peek<T>()`]. [`Parser::parse_if_peek<T>()`] also exists to conveniently parse a Node if it passes the peek
 /// test.
 ///
-/// If a Node can construct itself from a single [Cursor][css_lexer::Cursor] it should also implement
+/// If a Node can construct itself from a single [Cursor][Cursor] it should also implement
 /// [Build][crate::Build], then it will get [Parse][crate::Parse] for free.
 pub trait Peek<'a>: Sized {
 	const PEEK_KINDSET: KindSet = KindSet::ANY;

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -163,7 +163,6 @@ pub trait RangedFeature<'a>: Sized {
 ///
 /// ```
 /// use css_parse::*;
-/// use css_lexer::{Token, Kind};
 /// use bumpalo::Bump;
 ///
 /// // Defined the "FeatureName"

--- a/crates/css_parse/src/traits/rule_variants.rs
+++ b/crates/css_parse/src/traits/rule_variants.rs
@@ -1,5 +1,4 @@
-use crate::{BadDeclaration, Parser, Peek, Result, State, T, ToCursors, diagnostics};
-use css_lexer::{Cursor, ToSpan};
+use crate::{BadDeclaration, Cursor, Parser, Peek, Result, State, T, ToCursors, ToSpan, diagnostics};
 
 /// A trait that can be used for AST nodes representing a Declaration's Value. It offers some
 /// convenience functions for handling such values.

--- a/crates/css_parse/src/traits/selectors.rs
+++ b/crates/css_parse/src/traits/selectors.rs
@@ -1,7 +1,5 @@
+use crate::{Build, Cursor, Kind, KindSet, Parse, Parser, Peek, Result, diagnostics};
 use bumpalo::collections::Vec;
-use css_lexer::{Kind, KindSet};
-
-use crate::{Build, Parse, Parser, Peek, Result, diagnostics};
 
 pub trait CompoundSelector<'a>: Sized + Parse<'a> {
 	// SelectorComponent represents a Selector, or Combinator.
@@ -158,7 +156,7 @@ where
 {
 	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Hash, Kind::Ident, Kind::Delim, Kind::Colon, Kind::LeftSquare]);
 
-	fn peek(_: &Parser<'a>, c: css_lexer::Cursor) -> bool {
+	fn peek(_: &Parser<'a>, c: Cursor) -> bool {
 		c == Self::PEEK_KINDSET
 	}
 }

--- a/crates/css_parse/src/traits/style_sheet.rs
+++ b/crates/css_parse/src/traits/style_sheet.rs
@@ -1,6 +1,5 @@
-use crate::{Parse, Parser, Result, T};
+use crate::{Kind, Parse, Parser, Result, T};
 use bumpalo::collections::Vec;
-use css_lexer::Kind;
 
 /// This trait provides an implementation for parsing a [StyleSheet][1].
 ///

--- a/crates/css_parse/src/traits/to_cursors.rs
+++ b/crates/css_parse/src/traits/to_cursors.rs
@@ -1,12 +1,12 @@
 use crate::CursorSink;
 use bumpalo::collections::Vec;
 
-/// This trait allows AST nodes to decompose themselves back into a set of (ordered) [Cursors][css_lexer::Cursor].
+/// This trait allows AST nodes to decompose themselves back into a set of (ordered) [Cursors][crate::Cursor].
 ///
 /// This trait is useful to implement because downstream operations can use it to reconstruct source text from Nodes,
 /// including after mutating Nodes, such as transforming them (e.g. minification or formatting).
 ///
-/// Nodes that implement this trait should call `s.append()` in the order that those [Cursors][css_lexer::Cursor] were parsed,
+/// Nodes that implement this trait should call `s.append()` in the order that those [Cursors][crate::Cursor] were parsed,
 /// unless there's a good reason not to. Some good reasons not to:
 ///
 ///  - The specification supplies a specific grammar order.

--- a/crates/csskit_derives/src/into_cursor.rs
+++ b/crates/csskit_derives/src/into_cursor.rs
@@ -41,23 +41,23 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	};
 	quote! {
 		#[automatically_derived]
-		impl #impl_generics From<#ident #type_generics> for ::css_lexer::Cursor #where_clause {
-			fn from(value: #ident) -> ::css_lexer::Cursor {
+		impl #impl_generics From<#ident #type_generics> for ::css_parse::Cursor #where_clause {
+			fn from(value: #ident) -> ::css_parse::Cursor {
 				#body
 			}
 		}
 
 		#[automatically_derived]
-		impl #impl_generics From<#ident #type_generics> for ::css_lexer::Token #where_clause {
-			fn from(value: #ident) -> ::css_lexer::Token {
-				Into::<::css_lexer::Cursor>::into(value).token()
+		impl #impl_generics From<#ident #type_generics> for ::css_parse::Token #where_clause {
+			fn from(value: #ident) -> ::css_parse::Token {
+				Into::<::css_parse::Cursor>::into(value).token()
 			}
 		}
 
 		#[automatically_derived]
-		impl #impl_generics ::css_lexer::ToSpan for #ident #type_generics #where_clause {
-			fn to_span(&self) -> ::css_lexer::Span {
-				Into::<::css_lexer::Cursor>::into(*self).span()
+		impl #impl_generics ::css_parse::ToSpan for #ident #type_generics #where_clause {
+			fn to_span(&self) -> ::css_parse::Span {
+				Into::<::css_parse::Cursor>::into(*self).span()
 			}
 		}
 

--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -33,7 +33,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	quote! {
 		#[automatically_derived]
 		impl #impl_generics ::css_parse::Peek<'a> for #ident #type_generics #where_clause {
-			fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+			fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
 				use ::css_parse::{Peek};
 				#body
 			}

--- a/crates/csskit_derives/src/to_span.rs
+++ b/crates/csskit_derives/src/to_span.rs
@@ -110,9 +110,9 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	};
 	quote! {
 		#[automatically_derived]
-		impl #impl_generics ::css_lexer::ToSpan for #ident #type_generics #where_clause {
-			fn to_span(&self) -> ::css_lexer::Span {
-				use ::css_lexer::{Span, ToSpan};
+		impl #impl_generics ::css_parse::ToSpan for #ident #type_generics #where_clause {
+			fn to_span(&self) -> ::css_parse::Span {
+				use ::css_parse::{Span, ToSpan};
 				#body
 			}
 		}

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -343,7 +343,7 @@ impl Def {
 		quote! {
 			#[automatically_derived]
 			impl #impl_generics ::css_parse::Peek<'a> for #ident #type_generics #where_clause {
-				fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+				fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
 					use ::css_parse::Peek;
 					#steps
 				}
@@ -438,7 +438,7 @@ impl Def {
 								let dim_name: &str = (*dim).into();
 								let dim_ident = format_ident!("{}", dim_name.to_pascal_case());
 								dimension_literals.push(quote! {
-									(#v, ::css_lexer::DimensionUnit::#dim_ident) => { return Ok(Self::#variant_name(tk)); }
+									(#v, ::css_parse::DimensionUnit::#dim_ident) => { return Ok(Self::#variant_name(tk)); }
 								});
 							}
 							_ => todo!(),
@@ -477,20 +477,20 @@ impl Def {
 				};
 
 				let mut error = quote! {
-					let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+					let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
 					Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
 				};
 
 				if keyword_if.is_some() && lit_if.is_none() {
 					error = quote! {
-						let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+						let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
 						Err(::css_parse::diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
 					}
 				}
 
 				if keyword_if.is_none() && lit_if.is_some() {
 					error = quote! {
-						let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+						let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
 						Err(::css_parse::diagnostics::UnexpectedLiteral(p.parse_str(c).into(), c.into()))?
 					}
 				}
@@ -565,7 +565,7 @@ impl Def {
 							Some(quote! {
 								Some(#keyword_set_ident::#keyword_variant(ident)) => {
 									if val.#member_name.is_some() {
-										use ::css_lexer::ToSpan;
+										use ::css_parse::ToSpan;
 										Err(::css_parse::diagnostics::Unexpected(ident.into(), c.to_span()))?
 									}
 									val.#member_name = Some(ident);
@@ -598,7 +598,7 @@ impl Def {
 							break;
 					}
 					if #(val.#members.is_none())&&* {
-							let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+							let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
 							Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
 					}
 					Ok(val)
@@ -1016,7 +1016,7 @@ impl GenerateParseImpl for Def {
 									} else {
 										Some(quote! {
 											if result.len() < #min {
-												let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+												let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
 												Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
 											}
 										})
@@ -1025,7 +1025,7 @@ impl GenerateParseImpl for Def {
 								let max_check = max.map(|max| {
 									quote! {
 										if result.len() > #max {
-											let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+											let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
 											Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
 										}
 									}
@@ -1078,7 +1078,7 @@ impl GenerateParseImpl for Def {
 									let min_check = min.map(|min| {
 										quote! {
 											if i < #min {
-												let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+												let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
 												Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
 											}
 										}
@@ -1225,19 +1225,19 @@ impl GenerateParseImpl for DefType {
 			DefRange::RangeTo(end) => quote! {
 			let valf32: f32 = ty.into();
 					if #end < valf32 {
-						return Err(::css_parse::diagnostics::NumberTooLarge(#end, ::css_lexer::Span::new(start, p.offset())))?
+						return Err(::css_parse::diagnostics::NumberTooLarge(#end, ::css_parse::Span::new(start, p.offset())))?
 					}
 				},
 			DefRange::Range(Range { start, end }) => quote! {
 			let valf32: f32 = ty.into();
 					if !(#start..=#end).contains(&valf32) {
-						return Err(::css_parse::diagnostics::NumberOutOfBounds(valf32, format!("{}..{}", #start, #end), ::css_lexer::Span::new(start, p.offset())))?
+						return Err(::css_parse::diagnostics::NumberOutOfBounds(valf32, format!("{}..{}", #start, #end), ::css_parse::Span::new(start, p.offset())))?
 					}
 				},
 			DefRange::RangeFrom(start) => quote! {
 			let valf32: f32 = ty.into();
 					if #start > valf32 {
-						return Err(::css_parse::diagnostics::NumberTooSmall(#start, ::css_lexer::Span::new(start, p.offset())))?
+						return Err(::css_parse::diagnostics::NumberTooSmall(#start, ::css_parse::Span::new(start, p.offset())))?
 					}
 				},
 			DefRange::None => quote! {},
@@ -1266,7 +1266,7 @@ impl GenerateParseImpl for DefIdent {
 		(
 			quote! {
 				let ident = p.parse::<#ty>()?;
-				let c: ::css_lexer::Cursor = ident.into();
+				let c: ::css_parse::Cursor = ident.into();
 				if !p.eq_ignore_ascii_case(c, #name) {
 					Err(::css_parse::diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
 				}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::Length>::peek(p, c) || <::css_parse::T![Ident]>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
@@ -27,7 +27,7 @@ struct Foo<'a>(
 );
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
@@ -22,7 +22,7 @@ struct Foo(
 );
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::AnimateableFeature>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
@@ -21,7 +21,7 @@ struct Foo<'a>(
 );
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::BorderTopColorStyleValue<'a>>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
@@ -31,7 +31,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::Color>::peek(p, c)
             || <::css_parse::T![Ident]>::peek(p, c)
@@ -51,7 +51,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         let combo1 = p.parse_if_peek::<crate::Color>()?;
         let combo2 = {
             let ident = p.parse::<::css_parse::T![Ident]>()?;
-            let c: ::css_lexer::Cursor = ident.into();
+            let c: ::css_parse::Cursor = ident.into();
             if !p.eq_ignore_ascii_case(c, "bar") {
                 Err(
                     ::css_parse::diagnostics::UnexpectedIdent(

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
@@ -29,7 +29,7 @@ struct Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c)
     }
@@ -49,7 +49,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             match p.parse_if_peek::<FooKeywords>()? {
                 Some(FooKeywords::Foo(ident)) => {
                     if val.foo.is_some() {
-                        use ::css_lexer::ToSpan;
+                        use ::css_parse::ToSpan;
                         Err(
                             ::css_parse::diagnostics::Unexpected(
                                 ident.into(),
@@ -62,7 +62,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 }
                 Some(FooKeywords::Bar(ident)) => {
                     if val.bar.is_some() {
-                        use ::css_lexer::ToSpan;
+                        use ::css_parse::ToSpan;
                         Err(
                             ::css_parse::diagnostics::Unexpected(
                                 ident.into(),
@@ -75,7 +75,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 }
                 Some(FooKeywords::Baz(ident)) => {
                     if val.baz.is_some() {
-                        use ::css_lexer::ToSpan;
+                        use ::css_parse::ToSpan;
                         Err(
                             ::css_parse::diagnostics::Unexpected(
                                 ident.into(),
@@ -91,7 +91,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             break;
         }
         if val.foo.is_none() && val.bar.is_none() && val.baz.is_none() {
-            let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+            let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
             Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
         }
         Ok(val)

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::Color>::peek(p, c)
             || <::css_parse::T![Ident]>::peek(p, c)
@@ -45,7 +45,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         let combo0 = p.parse_if_peek::<crate::Color>()?;
         let combo1 = {
             let ident = p.parse::<::css_parse::T![Ident]>()?;
-            let c: ::css_lexer::Cursor = ident.into();
+            let c: ::css_parse::Cursor = ident.into();
             if !p.eq_ignore_ascii_case(c, "bar") {
                 Err(
                     ::css_parse::diagnostics::UnexpectedIdent(

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
@@ -26,7 +26,7 @@ struct Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::Bar>::peek(p, c)
     }
@@ -42,7 +42,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             match p.parse_if_peek::<FooKeywords>()? {
                 Some(FooKeywords::Foo(ident)) => {
                     if val.foo.is_some() {
-                        use ::css_lexer::ToSpan;
+                        use ::css_parse::ToSpan;
                         Err(
                             ::css_parse::diagnostics::Unexpected(
                                 ident.into(),
@@ -62,7 +62,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             break;
         }
         if val.foo.is_none() && val.bar.is_none() {
-            let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+            let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
             Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
         }
         Ok(val)

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c)
     }
@@ -43,7 +43,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         }
         let combo0 = {
             let ident = p.parse::<::css_parse::T![Ident]>()?;
-            let c: ::css_lexer::Cursor = ident.into();
+            let c: ::css_parse::Cursor = ident.into();
             if !p.eq_ignore_ascii_case(c, "bar") {
                 Err(
                     ::css_parse::diagnostics::UnexpectedIdent(

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
@@ -22,7 +22,7 @@ struct Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::CaretColorStyleValue>::peek(p, c)
             || <crate::CaretAnimationStyleValue>::peek(p, c)
@@ -64,7 +64,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         if val.caret_color.is_none() && val.caret_animation.is_none()
             && val.caret_shape.is_none()
         {
-            let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+            let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
             Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
         }
         Ok(val)

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::CalcSizeFunction>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -26,7 +26,7 @@ enum Foo<'a> {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::FitContentFunction>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -26,7 +26,7 @@ enum Foo<'a> {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::StylesetFunction>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::LengthPercentage>::peek(p, c)
     }
@@ -48,7 +48,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             return Err(
                 ::css_parse::diagnostics::NumberTooSmall(
                     0f32,
-                    ::css_lexer::Span::new(start, p.offset()),
+                    ::css_parse::Span::new(start, p.offset()),
                 ),
             )?;
         }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
@@ -21,7 +21,7 @@ enum Foo<'a> {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::Color>::peek(p, c) || <crate::Image1D<'a>>::peek(p, c)
     }
@@ -38,7 +38,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
         if <crate::Image1D<'a>>::peek(p, c) {
             return Ok(Self::Image(p.parse::<crate::Image1D<'a>>()?));
         }
-        let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+        let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
         Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
@@ -26,7 +26,7 @@ enum Foo<'a> {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::AnimateableFeature>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::OverflowPosition>::peek(p, c)
             || <crate::SelfPosition>::peek(p, c)

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
@@ -18,7 +18,7 @@ expression: pretty
 struct Foo(pub Option<crate::Color>, pub Option<crate::Color>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::Color>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c)
     }
@@ -43,7 +43,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         }
         let combo0 = {
             let ident = p.parse::<::css_parse::T![Ident]>()?;
-            let c: ::css_lexer::Cursor = ident.into();
+            let c: ::css_parse::Cursor = ident.into();
             if !p.eq_ignore_ascii_case(c, "oblique") {
                 Err(
                     ::css_parse::diagnostics::UnexpectedIdent(
@@ -63,7 +63,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                     ::css_parse::diagnostics::NumberOutOfBounds(
                         valf32,
                         format!("{}..{}", - 90f32, 90f32),
-                        ::css_lexer::Span::new(start, p.offset()),
+                        ::css_parse::Span::new(start, p.offset()),
                     ),
                 )?;
             }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
@@ -27,7 +27,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::CSSInt>::peek(p, c)
     }
@@ -50,7 +50,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 _ => {}
             }
         }
-        let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+        let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
         Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
@@ -29,7 +29,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::CSSInt>::peek(p, c)
             || <::css_parse::T![Dimension]>::peek(p, c)
@@ -55,13 +55,13 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         }
         if let Some(tk) = p.parse_if_peek::<::css_parse::T![Dimension]>()? {
             match tk.into() {
-                (1f32, ::css_lexer::DimensionUnit::Deg) => {
+                (1f32, ::css_parse::DimensionUnit::Deg) => {
                     return Ok(Self::Literal1deg(tk));
                 }
                 _ => {}
             }
         }
-        let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+        let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
         Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::CustomIdent>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
@@ -31,7 +31,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::FooKeywords>::peek(p, c)
     }
@@ -55,7 +55,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             }
             None => {}
         }
-        let c: ::css_lexer::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+        let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
         Err(::css_parse::diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
@@ -22,7 +22,7 @@ expression: pretty
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::FooKeywords>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::FooKeywords>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
@@ -27,7 +27,7 @@ enum SingleFoo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for SingleFoo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::Bar>::peek(p, c)
     }
@@ -61,7 +61,7 @@ impl<'a> ::css_parse::Parse<'a> for SingleFoo {
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::SingleFoo>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::SingleFoo>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
@@ -22,7 +22,7 @@ expression: pretty
 struct Foo<'a>(pub ::bumpalo::collections::Vec<'a, crate::FooKeywords>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::FooKeywords>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
@@ -18,7 +18,7 @@ expression: pretty
 struct Foo(pub crate::CaretColorStyleValue, pub Option<crate::CaretAnimationStyleValue>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::CaretColorStyleValue>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_one_or_more_commas.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_one_or_more_commas.snap
@@ -18,7 +18,7 @@ expression: pretty
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::AnimateableFeature>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::AnimateableFeature>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
@@ -18,7 +18,7 @@ expression: pretty
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::AnimateableFeature>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::AnimateableFeature>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::Color>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
@@ -18,7 +18,7 @@ expression: pretty
 struct Foo(pub crate::Color, pub crate::Color);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::Color>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
@@ -26,7 +26,7 @@ enum Foo {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::Length>::peek(p, c) || <::css_parse::T![Ident]>::peek(p, c)
     }
@@ -48,7 +48,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             return Err(
                 ::css_parse::diagnostics::NumberTooSmall(
                     1f32,
-                    ::css_lexer::Span::new(start, p.offset()),
+                    ::css_parse::Span::new(start, p.offset()),
                 ),
             )?;
         }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
@@ -18,7 +18,7 @@ expression: pretty
 struct Foo(pub crate::CustomIdent);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::CustomIdent>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
@@ -18,7 +18,7 @@ expression: pretty
 struct Foo(pub crate::CSSInt);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::CSSInt>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
@@ -18,7 +18,7 @@ expression: pretty
 struct Foo<'a>(pub crate::Image<'a>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::Image<'a>>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
@@ -18,7 +18,7 @@ expression: pretty
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::Image<'a>>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::Image<'a>>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
@@ -26,7 +26,7 @@ enum Foo<'a> {
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <::css_parse::T![Ident]>::peek(p, c) || <crate::Length>::peek(p, c)
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
@@ -23,7 +23,7 @@ struct Foo(
 );
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
         <crate::Length>::peek(p, c)
     }


### PR DESCRIPTION
Okay this is a rather large change which does a few simple things, which unravel into the larger change:

- Drop the `css_lexer` crate in `css_ast`'s `Cargo.toml`.
- Fix all the errors resulting from this change, by re-exporting the necessary types from `css_lexer` in `css_parse`.
- Fix all the macros which were accidentally relying on implicit imports.
- Consequently fixup all of the `csskit_proc_macro` & `csskit_derives` to drop using `css_lexer` as an import.
- Additionally, also drop `csskit_derives` from `css_parse` as it cannot import from itself (at least not easily) and
	 it also becomes an implicit dependency for downstream crates.
- Due to the work needed to implement traits like ToSpan for generic structs, I also took the opportunity to tidy up
	said structs to use the minimum requires trait dependencies for each trait impl.
