### PR TITLE
css_lexer: Ensure Span::DUMMY can be used without being added to

### DIFF
--- a/crates/css_lexer/src/span.rs
+++ b/crates/css_lexer/src/span.rs
@@ -73,6 +73,12 @@ impl Span {
 impl Add for Span {
 	type Output = Self;
 	fn add(self, rhs: Self) -> Self::Output {
+		if rhs == Span::DUMMY {
+			return self;
+		}
+		if self == Span::DUMMY {
+			return rhs;
+		}
 		let start = if self.start < rhs.start { self.start } else { rhs.start };
 		let end = if self.end > rhs.end { self.end } else { rhs.end };
 		Self { start, end }
@@ -182,13 +188,13 @@ impl_tuple!(11: A, B, C, D, E, F, G, H, I, J, K, L);
 
 impl<T: ToSpan> ToSpan for Option<T> {
 	fn to_span(&self) -> Span {
-		self.as_ref().map_or(Span::ZERO, |t| t.to_span())
+		self.as_ref().map_or(Span::DUMMY, |t| t.to_span())
 	}
 }
 
 impl<T> ToSpan for PhantomData<T> {
 	fn to_span(&self) -> Span {
-		Span::ZERO
+		Span::DUMMY
 	}
 }
 
@@ -201,6 +207,18 @@ pub trait ToSpan {
 impl ToSpan for Span {
 	fn to_span(&self) -> Span {
 		*self
+	}
+}
+
+impl<T: ToSpan> ToSpan for &T {
+	fn to_span(&self) -> Span {
+		(**self).to_span()
+	}
+}
+
+impl<T: ToSpan> ToSpan for &mut T {
+	fn to_span(&self) -> Span {
+		(**self).to_span()
 	}
 }
 


### PR DESCRIPTION
Many types can end up having no Span (e.g. an Option), but using Span::ZERO meant that their start character was always
0, and when added to other spans, it would remain `0`. For example a `(Option<T![Ident]>, T![Ident])` was guaranteed to
have a span of `0` which is not correct.

This change alters the desired sentinel type for these empty spans to be DUMMY. This resolves the issue of spans
_starting_ at `0` but means spans _end_ at `u32::MAX` which is equally undesirable. Consequently this also changes `add()` to ensure that if `Span::DUMMY` is passed as one of the operands, it'll simply return the other operand, avoiding ever adding a DUMMY to another span.

This should resolve many Span issues across the codebase.
