### PR TITLE
css_ast: Add assert_visits! test & some tests

### DIFF
--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -6,6 +6,8 @@ mod selector;
 mod specificity;
 mod stylerule;
 mod stylesheet;
+#[cfg(test)]
+mod test_helpers;
 mod traits;
 mod types;
 mod units;

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -186,6 +186,7 @@ impl<'a> SelectorComponentTrait<'a> for SelectorComponent<'a> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::assert_visits;
 	use css_parse::assert_parse;
 
 	#[test]
@@ -242,5 +243,25 @@ mod tests {
 			"::-moz-list-bullet::-webkit-scrollbar::-ms-clear:-ms-input-placeholder::-o-scrollbar:-o-prefocus"
 		);
 		assert_parse!(SelectorList, "button:-moz-focusring");
+	}
+
+	#[test]
+	fn test_visits() {
+		assert_visits!(".foo", CompoundSelector, Class);
+		assert_visits!("#bar", CompoundSelector, Id);
+		assert_visits!(".foo", SelectorList, CompoundSelector, Class);
+		assert_visits!(".foo, #bar", SelectorList, CompoundSelector, Class, CompoundSelector, Id);
+		assert_visits!(".foo#bar", CompoundSelector, Class, Id);
+		assert_visits!(".foo.bar", CompoundSelector, Class, Class);
+		assert_visits!(".foo", CompoundSelector, Class);
+		assert_visits!(".foo#bar", CompoundSelector, Class, Id);
+		assert_visits!(".foo", CompoundSelector, Class);
+		assert_visits!("*.foo#bar", CompoundSelector, Wildcard, Class, Id);
+	}
+
+	#[test]
+	#[should_panic]
+	fn test_assert_visits_fails() {
+		assert_visits!(".foo", CompoundSelector, visit_id<Id>);
 	}
 }

--- a/crates/css_ast/src/test_helpers.rs
+++ b/crates/css_ast/src/test_helpers.rs
@@ -1,0 +1,60 @@
+include!(concat!(env!("OUT_DIR"), "/css_apply_visit_methods.rs"));
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct TestVisitor {
+	pub visits: Vec<&'static str>,
+}
+
+macro_rules! visit_mut_trait {
+	( $(
+		$name: ident$(<$life:lifetime>)?($obj: ident$(<$olife:lifetime>)?),
+	)+ ) => {
+		impl $crate::VisitMut for TestVisitor {
+			$(
+				fn $name$(<$life>)?(&mut self, _rule: &mut $crate::$obj$(<$olife>)?) {
+					self.handle_visit(stringify!($obj));
+				}
+			)+
+		}
+	}
+}
+apply_visit_methods!(visit_mut_trait);
+
+impl TestVisitor {
+	fn handle_visit(&mut self, type_name: &'static str) {
+		self.visits.push(type_name);
+	}
+}
+
+#[macro_export]
+macro_rules! assert_visits {
+	($source: expr, $parse_type: ty $(, $visit_type: ty)* $(,)?) => {{
+		use bumpalo::Bump;
+		use css_parse::Parser;
+		use $crate::VisitableMut;
+
+		let allocator = Bump::default();
+		let source_text = $source;
+		let mut parser = Parser::new(&allocator, &source_text);
+		let result = parser.parse_entirely::<$parse_type>();
+		if !result.errors.is_empty() {
+			panic!("\n\nParse {:?} failed. Saw error {:?}", source_text, result.errors[0]);
+		}
+		let mut parsed = result.output.unwrap();
+
+		let mut visitor = $crate::test_helpers::TestVisitor { visits: vec![] };
+		parsed.accept_mut(&mut visitor);
+
+		let actual_visits = visitor.visits.as_slice();
+		let expected_visits = vec![ stringify!($parse_type), $( stringify!($visit_type) ),* ];
+
+		if actual_visits != expected_visits {
+			panic!(
+				"\n\nVisit assertion failed for {:?}:\n\nActual visits: {:?}\nExpected visits: {:?}",
+				source_text,
+				actual_visits,
+				expected_visits,
+			);
+		}
+	}};
+}

--- a/crates/css_ast/src/types/bg_size.rs
+++ b/crates/css_ast/src/types/bg_size.rs
@@ -40,4 +40,12 @@ mod tests {
 		assert_parse!(BgSize, "auto auto");
 		assert_parse!(BgSize, "12% 10px");
 	}
+
+	#[test]
+	fn test_visits() {
+		use crate::assert_visits;
+		assert_visits!("12%", BgSize, LengthPercentage);
+		assert_visits!("12% 10px", BgSize, LengthPercentage, LengthPercentage);
+		assert_visits!("cover", BgSize);
+	}
 }

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -126,4 +126,15 @@ mod tests {
 		// Using degrees for wrong component in lch
 		assert_parse_error!(Color, "lch(250, 255deg, 255)");
 	}
+
+	#[test]
+	fn test_visits() {
+		use crate::assert_visits;
+		assert_visits!("#fff", Color);
+		assert_visits!("black", Color);
+		assert_visits!("rgb(255 255 255)", Color, ColorFunction);
+		assert_visits!("rgba(255,255,255,0.5)", Color, ColorFunction);
+		assert_visits!("lab(63.673% 51.577 5.811)", Color, ColorFunction);
+		assert_visits!("hwb(740deg 20% 30%/50%)", Color, ColorFunction);
+	}
 }

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -51,6 +51,7 @@ pub enum ContentListItem<'a> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::assert_visits;
 	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
@@ -76,5 +77,15 @@ mod tests {
 		assert_parse!(ContentList, "counters(foo,'bar',decimal)");
 		assert_parse!(ContentList, "leader('.')'foo'counter(section,decimal)");
 		assert_parse!(ContentList, "attr(foo)");
+	}
+
+	#[test]
+	fn test_visits() {
+		assert_visits!("'some string'", ContentList, ContentListItem);
+		assert_visits!("url(dot.gif)", ContentList, ContentListItem, Image, Url);
+		assert_visits!("counter(foo,decimal)", ContentList, ContentListItem, CounterFunction);
+		assert_visits!("'foo' url(bar.gif)", ContentList, ContentListItem, ContentListItem, Image, Url);
+		assert_visits!("string(heading)", ContentList, ContentListItem, StringFunction);
+		assert_visits!("attr(foo)", ContentList, ContentListItem, AttrFunction);
 	}
 }

--- a/crates/css_ast/src/types/cursor_image.rs
+++ b/crates/css_ast/src/types/cursor_image.rs
@@ -44,6 +44,7 @@ impl<'a> Parse<'a> for CursorImage<'a> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::assert_visits;
 	use css_parse::assert_parse;
 
 	#[test]
@@ -55,5 +56,12 @@ mod tests {
 	fn test_writes() {
 		assert_parse!(CursorImage, "url(hyper.cur)");
 		assert_parse!(CursorImage, "url(hyper.png)2 3");
+	}
+
+	#[test]
+	fn test_visits() {
+		assert_visits!("url(hyper.cur)", CursorImage, Url);
+		assert_visits!("url(hyper.png) 2 3", CursorImage, Url);
+		assert_visits!("image-set(url('foo.jpg') 1x)", CursorImage, ImageSetFunction);
 	}
 }

--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -18,6 +18,7 @@ pub enum Image<'a> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::assert_visits;
 	use css_parse::assert_parse;
 
 	#[test]
@@ -30,5 +31,11 @@ mod tests {
 		assert_parse!(Image, "url('foo')");
 		assert_parse!(Image, "url(\"foo\")");
 		assert_parse!(Image, "url(foo)");
+	}
+
+	#[test]
+	fn test_visits() {
+		assert_visits!("url('foo')", Image, Url);
+		assert_visits!("linear-gradient(red, blue)", Image, Gradient, LinearGradientFunction);
 	}
 }

--- a/crates/css_ast/src/types/shadow.rs
+++ b/crates/css_ast/src/types/shadow.rs
@@ -54,6 +54,7 @@ impl<'a> Parse<'a> for Shadow {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::assert_visits;
 	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
@@ -95,5 +96,13 @@ mod tests {
 		assert_parse_error!(Shadow, "10px 20px notinset");
 		assert_parse_error!(Shadow, "10px 20px 5px inset 3px");
 		assert_parse_error!(Shadow, "10px 20px 5px 3px inset extra");
+	}
+
+	#[test]
+	fn test_visits() {
+		assert_visits!("10px 20px", Shadow, Length, Length);
+		assert_visits!("red 10px 20px", Shadow, Color, Length, Length);
+		assert_visits!("10px 20px 5px", Shadow, Length, Length, Length);
+		assert_visits!("blue 10px 20px 5px 3px", Shadow, Color, Length, Length, Length, Length);
 	}
 }

--- a/crates/css_ast/src/types/single_transition.rs
+++ b/crates/css_ast/src/types/single_transition.rs
@@ -34,6 +34,7 @@ impl<'a> Parse<'a> for SingleTransition<'a> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::assert_visits;
 	use css_parse::{assert_parse, assert_parse_error};
 
 	type NoneOrSingleTransitionProperty = NoneOr<SingleTransitionProperty>;
@@ -71,5 +72,13 @@ mod tests {
 	fn test_errors() {
 		assert_parse_error!(SingleTransition, "1deg");
 		assert_parse_error!(SingleTransition, "none none");
+	}
+
+	#[test]
+	fn test_visits() {
+		assert_visits!("1s", SingleTransition, Time);
+		assert_visits!("ease-in", SingleTransition, EasingFunction);
+		assert_visits!("1s 2s", SingleTransition, Time, Time);
+		assert_visits!("1s ease-in 2s", SingleTransition, Time, EasingFunction, Time);
 	}
 }

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -7,11 +7,13 @@ use crate::TransformFunction;
 // <transform-list> = <transform-function>+
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit]
 pub struct TransformList<'a>(pub Vec<'a, TransformFunction>);
 
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::assert_visits;
 	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
@@ -46,5 +48,28 @@ mod tests {
 	fn test_errors() {
 		assert_parse_error!(TransformList, "rotate(45deg) auto");
 		assert_parse_error!(TransformList, "auto rotate(45deg)");
+	}
+
+	#[test]
+	fn test_visits() {
+		assert_visits!("scale(2)", TransformList, TransformFunction, ScaleFunction);
+		assert_visits!(
+			"rotate(45deg) scale(2)",
+			TransformList,
+			TransformFunction,
+			RotateFunction,
+			TransformFunction,
+			ScaleFunction
+		);
+		assert_visits!(
+			"translate(1rem) rotate(90deg) scale(1.5)",
+			TransformList,
+			TransformFunction,
+			TranslateFunction,
+			TransformFunction,
+			RotateFunction,
+			TransformFunction,
+			ScaleFunction
+		);
 	}
 }


### PR DESCRIPTION
Our visit functionality is not suitably tested, which leaves opportunity for holes everywhere.

This changes adds an `assert_visits!` macro which, given a string to parse, and a type to parse against, will visit all
possible visit methods and accumulate the visited types, collecting them into a list which can be compared against the
given arguments. The result of this assertion is an accurate ordered list of all the types visited during a traversal of
the AST.
