### PR TITLE
csskit_proc_macro: Use csskit_derives::Peek instead of custom implementations

### DIFF
--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -26,7 +26,12 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 		}
 
 		Data::Enum(DataEnum { variants, .. }) => {
-			let ty: Vec<_> = variants.iter().map(|variant| variant.fields.iter().next()).dedup().collect();
+			let ty: Vec<_> = variants
+				.iter()
+				.map(|variant| variant.fields.iter().next())
+				.filter_map(|f| f.map(|f| &f.ty))
+				.dedup()
+				.collect();
 			quote! { #(<#ty>::peek(p, c))||* }
 		}
 	};

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_fixed_multiplier.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_fixed_multiplier.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub crate::AutoOr<(crate::Color, crate::Color)>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::AutoOr<(crate::Color, crate::Color)>>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_none.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_none.snap
@@ -7,6 +7,7 @@ expression: pretty
     "auto", None : "none", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -24,13 +25,6 @@ enum Foo {
     Auto(::css_parse::T![Ident]),
     #[visit(skip)]
     None(::css_parse::T![Ident]),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::FooKeywords>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_none_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_none_or_type.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub crate::AutoNoneOr<crate::Length>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::AutoNoneOr<crate::Length>>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_type.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub crate::AutoOr<crate::CustomIdent>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::AutoOr<crate::CustomIdent>>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_type_with_checks.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub crate::AutoOr<crate::Angle>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::AutoOr<crate::Angle>>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bg_image.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bg_image.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo<'a>(pub crate::NoneOr<crate::Image<'a>>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::NoneOr<crate::Image<'a>>>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo {
     Length(crate::Length, Option<crate::Length>),
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::Length>::peek(p, c) || <::css_parse::T![Ident]>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", Bar : "bar", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -25,13 +26,6 @@ struct Foo<'a>(
     #[visit(skip)]
     pub Option<css_parse::T![Ident]>,
 );
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -20,13 +21,6 @@ struct Foo(
     pub Option<crate::AnimateableFeature>,
     pub Option<crate::AnimateableFeature>,
 );
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::AnimateableFeature>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -19,13 +20,6 @@ struct Foo<'a>(
     pub crate::BorderTopColorStyleValue<'a>,
     pub Option<crate::BorderTopColorStyleValue<'a>>,
 );
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::BorderTopColorStyleValue<'a>>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -28,14 +29,6 @@ enum Foo {
         #[visit(skip)]
         ::css_parse::T![Ident],
     ),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::Color>::peek(p, c)
-            || <::css_parse::T![Ident]>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", Bar : "bar", Baz : "baz", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -26,13 +27,6 @@ struct Foo {
     pub bar: Option<::css_parse::T![Ident]>,
     #[visit(skip)]
     pub baz: Option<::css_parse::T![Ident]>,
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,14 +24,6 @@ enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     Bar(Option<crate::Color>, #[visit(skip)] ::css_parse::T![Ident]),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::Color>::peek(p, c)
-            || <::css_parse::T![Ident]>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ struct Foo {
     #[visit(skip)]
     pub foo: Option<::css_parse::T![Ident]>,
     pub bar: Option<crate::Bar>,
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::Bar>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     Bar(#[visit(skip)] ::css_parse::T![Ident], Option<crate::Color>),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -19,15 +20,6 @@ struct Foo {
     pub caret_color: Option<crate::CaretColorStyleValue>,
     pub caret_animation: Option<crate::CaretAnimationStyleValue>,
     pub caret_shape: Option<crate::CaretShapeStyleValue>,
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::CaretColorStyleValue>::peek(p, c)
-            || <crate::CaretAnimationStyleValue>::peek(p, c)
-            || <crate::CaretShapeStyleValue>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     CalcSizeFunction(crate::CalcSizeFunction),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::CalcSizeFunction>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -7,6 +7,7 @@ expression: pretty
     FitContent : "fit-content", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo<'a> {
     #[visit(skip)]
     FitContent(::css_parse::T![Ident]),
     FitContentFunction(crate::FitContentFunction),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::FitContentFunction>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -7,6 +7,7 @@ expression: pretty
     "normal", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo<'a> {
     #[visit(skip)]
     Normal(::css_parse::T![Ident]),
     StylesetFunction(crate::StylesetFunction),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::StylesetFunction>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     LengthPercentage(crate::LengthPercentage),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::LengthPercentage>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -18,13 +19,6 @@ expression: pretty
 enum Foo<'a> {
     Color(crate::Color),
     Image(crate::Image1D<'a>),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::Color>::peek(p, c) || <crate::Image1D<'a>>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo<'a> {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     AnimateableFeatures(::css_parse::CommaSeparated<'a, crate::AnimateableFeature>),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::AnimateableFeature>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
@@ -7,6 +7,7 @@ expression: pretty
     "normal", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,14 +24,6 @@ enum Foo {
     #[visit(skip)]
     Normal(::css_parse::T![Ident]),
     SelfPosition(Option<crate::OverflowPosition>, crate::SelfPosition),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::OverflowPosition>::peek(p, c)
-            || <crate::SelfPosition>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub Option<crate::Color>, pub Option<crate::Color>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::Color>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     Oblique(#[visit(skip)] ::css_parse::T![Ident], Option<crate::Angle>),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
@@ -7,6 +7,7 @@ expression: pretty
     : "keyword", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -24,13 +25,6 @@ enum Foo {
     Keyword(::css_parse::T![Ident]),
     #[visit(skip)]
     Literal2(crate::CSSInt),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::CSSInt>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
@@ -7,6 +7,7 @@ expression: pretty
     : "keyword", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -26,14 +27,6 @@ enum Foo {
     Literal1(crate::CSSInt),
     #[visit(skip)]
     Literal1deg(::css_parse::T![Dimension]),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::CSSInt>::peek(p, c)
-            || <::css_parse::T![Dimension]>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     CustomIdent(crate::CustomIdent),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::CustomIdent>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
@@ -7,6 +7,7 @@ expression: pretty
     "black", White : "white", LineThrough : "line-through", Pink : "pink", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -28,13 +29,6 @@ enum Foo {
     LineThrough(::css_parse::T![Ident]),
     #[visit(skip)]
     Pink(::css_parse::T![Ident]),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::FooKeywords>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
@@ -7,6 +7,7 @@ expression: pretty
     "outset", Inset : "inset", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -20,13 +21,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::FooKeywords>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::FooKeywords>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -26,13 +27,6 @@ enum SingleFoo {
     Bar(crate::Bar),
 }
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for SingleFoo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::Bar>::peek(p, c)
-    }
-}
-#[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for SingleFoo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
@@ -46,6 +40,7 @@ impl<'a> ::css_parse::Parse<'a> for SingleFoo {
     }
 }
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -59,13 +54,6 @@ impl<'a> ::css_parse::Parse<'a> for SingleFoo {
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::SingleFoo>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::SingleFoo>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
@@ -7,6 +7,7 @@ expression: pretty
     "outset", Inset : "inset", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -20,13 +21,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo<'a>(pub ::bumpalo::collections::Vec<'a, crate::FooKeywords>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::FooKeywords>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__none_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__none_or_type.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub crate::NoneOr<crate::CustomIdent>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::NoneOr<crate::CustomIdent>>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub crate::CaretColorStyleValue, pub Option<crate::CaretAnimationStyleValue>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::CaretColorStyleValue>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_one_or_more_commas.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_one_or_more_commas.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::AnimateableFeature>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::AnimateableFeature>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::AnimateableFeature>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::AnimateableFeature>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     Color(crate::Color, crate::Color),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::Color>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub crate::Color, pub crate::Color);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::Color>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
@@ -7,6 +7,7 @@ expression: pretty
     LineThrough : "line-through", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo {
     Length(crate::Length),
     #[visit(skip)]
     LineThrough(::css_parse::T![Ident]),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::Length>::peek(p, c) || <::css_parse::T![Ident]>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub crate::CustomIdent);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::CustomIdent>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo(pub crate::CSSInt);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::CSSInt>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo<'a>(pub crate::Image<'a>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::Image<'a>>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -16,13 +17,6 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::Image<'a>>);
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::Image<'a>>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
@@ -7,6 +7,7 @@ expression: pretty
     "foo", }
 );
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -23,13 +24,6 @@ enum Foo<'a> {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     Lengths(::bumpalo::collections::Vec<'a, crate::Length>),
-}
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::Length>::peek(p, c)
-    }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
@@ -3,6 +3,7 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 #[derive(
+    ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
     ::csskit_derives::Visitable,
@@ -21,13 +22,6 @@ struct Foo(
     pub Option<crate::Length>,
     pub Option<crate::Length>,
 );
-#[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo {
-    fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
-        use ::css_parse::Peek;
-        <crate::Length>::peek(p, c)
-    }
-}
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/value.rs
+++ b/crates/csskit_proc_macro/src/value.rs
@@ -39,16 +39,15 @@ pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 	}
 	let additonal_defs = defs.generate_additional_types(vis, ident, &ast.generics);
 	let def = defs.generate_definition(vis, ident, &ast.generics);
-	let peek_impl = defs.generate_peek_trait_implementation(ident, &ast.generics);
 	let parse_impl = defs.generate_parse_trait_implementation(ident, &ast.generics);
 	quote! {
 		#additonal_defs
 
 		#(#attrs)*
-		#[derive(::csskit_derives::ToSpan, ::csskit_derives::ToCursors, ::csskit_derives::Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::Peek, ::csskit_derives::ToSpan, ::csskit_derives::ToCursors, ::csskit_derives::Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		#def
-		#peek_impl
+
 		#parse_impl
 	}
 }


### PR DESCRIPTION
Peek is simple enough that more often than not the csskit_proc_macro generated definition ends up identical to what
would be generated with csskit_derives::Peek.

So this change deletes the generated code from csskit_proc_macro, instead opting to simply derive Peek for every style
value. This reduces significant code from csskit_proc_macro and helps ensure that csskit_derives::Peek becomes the
"source of truth" for where we generate Peek, meaning more energy can be put into make a single generator more robust,
rather than two.
