### PR TITLE
 css_ast: Use #[syntax] for AnchorName

### DIFF
--- a/crates/css_ast/src/types/anchor_name.rs
+++ b/crates/css_ast/src/types/anchor_name.rs
@@ -1,10 +1,40 @@
-use css_parse::T;
-use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
+use csskit_derives::{IntoCursor, Peek, ToCursors, Visitable};
+use csskit_proc_macro::syntax;
 
-// https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-name
-#[derive(
-	IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
-)]
+/// <https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-name>
+///
+/// ```text,ignore
+/// <anchor-name> = <dashed-ident>
+/// ```
+#[syntax("<dashed-ident>")]
+#[derive(IntoCursor, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
-pub struct AnchorName(T![DashedIdent]);
+#[visit]
+pub struct AnchorName;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::assert_visits;
+	use css_parse::{assert_parse, assert_parse_error};
+
+	#[test]
+	fn size_test() {
+		assert_eq!(std::mem::size_of::<AnchorName>(), 12);
+	}
+
+	#[test]
+	fn test_writes() {
+		assert_parse!(AnchorName, "--foo");
+	}
+
+	#[test]
+	fn test_errors() {
+		assert_parse_error!(AnchorName, "foo");
+	}
+
+	#[test]
+	fn test_visits() {
+		assert_visits!("--foo", AnchorName, DashedIdent);
+	}
+}


### PR DESCRIPTION
Following https://github.com/csskit/csskit/pull/349 & https://github.com/csskit/csskit/pull/350 we can now start to use #[syntax] for types as well as values.

This change dips our toes into this by implementing this for AnchorName - which is a simple type which wraps a DashedIdent. This change also adds relevant tests for this type to ensure it works correctly.
