### PR TITLE
csskit_proc_macro: Only add #[visit] attrs if derive(Visitable), avoid Parse impl if derive(Parse)

### DIFF
--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_none.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_none.snap
@@ -6,6 +6,7 @@ expression: pretty
     #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Auto :
     "auto", None : "none", }
 );
+#[derive(Visitable)]
 enum Foo {
     #[visit(skip)]
     Auto(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
@@ -8,7 +8,6 @@ expression: pretty
 );
 enum Foo {
     Length(crate::Length, Option<crate::Length>),
-    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
@@ -6,6 +6,7 @@ expression: pretty
     #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
     "foo", Bar : "bar", }
 );
+#[derive(Visitable)]
 struct Foo<'a>(
     #[visit(skip)]
     pub css_parse::T![Ident],

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
@@ -6,6 +6,7 @@ expression: pretty
     #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
     "foo", }
 );
+#[derive(Visitable)]
 enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
@@ -6,6 +6,7 @@ expression: pretty
     #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
     "foo", Bar : "bar", Baz : "baz", }
 );
+#[derive(Visitable)]
 struct Foo {
     #[visit(skip)]
     pub foo: Option<::css_parse::T![Ident]>,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
@@ -6,6 +6,7 @@ expression: pretty
     #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
     "foo", }
 );
+#[derive(Visitable)]
 enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
@@ -7,7 +7,6 @@ expression: pretty
     "foo", }
 );
 struct Foo {
-    #[visit(skip)]
     pub foo: Option<::css_parse::T![Ident]>,
     pub bar: Option<crate::Bar>,
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
@@ -6,6 +6,7 @@ expression: pretty
     #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
     "foo", }
 );
+#[derive(Visitable)]
 enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -7,7 +7,6 @@ expression: pretty
     "foo", }
 );
 enum Foo {
-    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     CalcSizeFunction(crate::CalcSizeFunction),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -7,7 +7,6 @@ expression: pretty
     FitContent : "fit-content", }
 );
 enum Foo<'a> {
-    #[visit(skip)]
     FitContent(::css_parse::T![Ident]),
     FitContentFunction(crate::FitContentFunction),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -7,7 +7,6 @@ expression: pretty
     "normal", }
 );
 enum Foo<'a> {
-    #[visit(skip)]
     Normal(::css_parse::T![Ident]),
     StylesetFunction(crate::StylesetFunction),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
@@ -7,7 +7,6 @@ expression: pretty
     "foo", }
 );
 enum Foo {
-    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     LengthPercentage(crate::LengthPercentage),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
@@ -7,7 +7,6 @@ expression: pretty
     "foo", }
 );
 enum Foo<'a> {
-    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     AnimateableFeatures(::css_parse::CommaSeparated<'a, crate::AnimateableFeature>),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
@@ -7,7 +7,6 @@ expression: pretty
     "normal", }
 );
 enum Foo {
-    #[visit(skip)]
     Normal(::css_parse::T![Ident]),
     SelfPosition(Option<crate::OverflowPosition>, crate::SelfPosition),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -7,9 +7,8 @@ expression: pretty
     "foo", }
 );
 enum Foo {
-    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
-    Oblique(#[visit(skip)] ::css_parse::T![Ident], Option<crate::Angle>),
+    Oblique(::css_parse::T![Ident], Option<crate::Angle>),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
@@ -7,9 +7,7 @@ expression: pretty
     : "keyword", }
 );
 enum Foo {
-    #[visit(skip)]
     Keyword(::css_parse::T![Ident]),
-    #[visit(skip)]
     Literal2(crate::CSSInt),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
@@ -7,11 +7,8 @@ expression: pretty
     : "keyword", }
 );
 enum Foo {
-    #[visit(skip)]
     Keyword(::css_parse::T![Ident]),
-    #[visit(skip)]
     Literal1(crate::CSSInt),
-    #[visit(skip)]
     Literal1deg(::css_parse::T![Dimension]),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
@@ -7,7 +7,6 @@ expression: pretty
     "foo", }
 );
 enum Foo {
-    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     CustomIdent(crate::CustomIdent),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
@@ -7,13 +7,9 @@ expression: pretty
     "black", White : "white", LineThrough : "line-through", Pink : "pink", }
 );
 enum Foo {
-    #[visit(skip)]
     Black(::css_parse::T![Ident]),
-    #[visit(skip)]
     White(::css_parse::T![Ident]),
-    #[visit(skip)]
     LineThrough(::css_parse::T![Ident]),
-    #[visit(skip)]
     Pink(::css_parse::T![Ident]),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
@@ -8,7 +8,6 @@ expression: pretty
 );
 enum Foo {
     Length(crate::Length),
-    #[visit(skip)]
     LineThrough(::css_parse::T![Ident]),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_derive_parse_skips_impl.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_derive_parse_skips_impl.snap
@@ -1,0 +1,13 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", Bar : "bar", }
+);
+#[derive(Parse)]
+enum Foo {
+    Foo(::css_parse::T![Ident]),
+    Bar(::css_parse::T![Ident]),
+}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_derive_visitable_adds_attributes.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_derive_visitable_adds_attributes.snap
@@ -4,13 +4,14 @@ expression: pretty
 ---
 ::css_parse::keyword_set!(
     #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
-    "foo", }
+    "foo", Bar : "bar", }
 );
 #[derive(Visitable)]
 enum Foo {
     #[visit(skip)]
     Foo(::css_parse::T![Ident]),
-    Color(crate::Color, crate::Color),
+    #[visit(skip)]
+    Bar(::css_parse::T![Ident]),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
@@ -20,10 +21,12 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             Some(FooKeywords::Foo(ident)) => {
                 return Ok(Self::Foo(ident));
             }
+            Some(FooKeywords::Bar(ident)) => {
+                return Ok(Self::Bar(ident));
+            }
             None => {}
         }
-        let combo0 = p.parse::<crate::Color>()?;
-        let combo1 = p.parse::<crate::Color>()?;
-        Ok(Self::Color(combo0, combo1))
+        let c: ::css_parse::Cursor = p.parse::<::css_parse::T![Any]>()?.into();
+        Err(::css_parse::diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
@@ -7,7 +7,6 @@ expression: pretty
     "foo", }
 );
 enum Foo<'a> {
-    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     Lengths(::bumpalo::collections::Vec<'a, crate::Length>),
 }

--- a/crates/csskit_proc_macro/src/syntax.rs
+++ b/crates/csskit_proc_macro/src/syntax.rs
@@ -1,9 +1,28 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Error};
+use syn::punctuated::Punctuated;
+use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Meta, Token};
 
 use crate::def::*;
 use crate::generate::*;
+
+/// Check if derive(Visitable) is present in the attributes
+fn has_derive_of(attrs: &[Attribute], name: &'static str) -> bool {
+	for attr in attrs {
+		if attr.path().is_ident("derive") {
+			let nested = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated).unwrap_or_default();
+			for meta in nested {
+				match meta {
+					Meta::Path(path) if path.is_ident(name) => {
+						return true;
+					}
+					_ => {}
+				}
+			}
+		}
+	}
+	false
+}
 
 pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 	let has_a_lifetime = ast.generics.lifetimes().any(|l| l.lifetime.ident == "a");
@@ -37,15 +56,23 @@ pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 			return Error::new(ident.span(), "cannot create from_syntax on Union").into_compile_error();
 		}
 	}
+	let derives_visitable = has_derive_of(attrs, "Visitable");
+	let derives_parse = has_derive_of(attrs, "Parse");
 	let additonal_defs = defs.generate_additional_types(vis, ident, &ast.generics);
-	let def = defs.generate_definition(vis, ident, &ast.generics);
-	let parse_impl = defs.generate_parse_trait_implementation(ident, &ast.generics);
-	quote! {
+	let def = defs.generate_definition(vis, ident, &ast.generics, derives_parse, derives_visitable);
+	let dfn = quote! {
 		#additonal_defs
 
 		#(#attrs)*
 		#def
+	};
+	if !derives_parse {
+		let parse_impl = defs.generate_parse_trait_implementation(ident, &ast.generics);
+		return quote! {
+			#dfn
 
-		#parse_impl
+			#parse_impl
+		};
 	}
+	dfn
 }

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -632,9 +632,23 @@ fn value_fixed_range_color2_optimized() {
 }
 
 #[test]
+fn value_with_derive_visitable_adds_attributes() {
+	let syntax = to_valuedef! { foo | bar };
+	let data = to_deriveinput! { #[derive(Visitable)] enum Foo {} };
+	assert_snapshot!(syntax, data, "value_with_derive_visitable_adds_attributes");
+}
+
+#[test]
+fn value_with_derive_parse_skips_impl() {
+	let syntax = to_valuedef! { foo | bar };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "value_with_derive_parse_skips_impl");
+}
+
+#[test]
 fn value_fixed_range_auto_color2_optimized() {
 	let syntax = to_valuedef! { foo | <color>{2} };
-	let data = to_deriveinput! { enum Foo {} };
+	let data = to_deriveinput! { #[derive(Visitable)] enum Foo {} };
 	assert_snapshot!(syntax, data, "value_fixed_range_auto_color2_optimized");
 }
 
@@ -662,21 +676,21 @@ fn keyword_int_literal_dimension_literal() {
 #[test]
 fn combinator_optional_keyword() {
 	let syntax = to_valuedef! { foo | <color>? bar };
-	let data = to_deriveinput! { enum Foo {} };
+	let data = to_deriveinput! { #[derive(Visitable)] enum Foo {} };
 	assert_snapshot!(syntax, data, "combinator_optional_keyword");
 }
 
 #[test]
 fn combinator_optional_last_keyword() {
 	let syntax = to_valuedef! { foo | bar <color>? };
-	let data = to_deriveinput! { enum Foo {} };
+	let data = to_deriveinput! { #[derive(Visitable)] enum Foo {} };
 	assert_snapshot!(syntax, data, "combinator_optional_last_keyword");
 }
 
 #[test]
 fn combinator_optional2_keyword() {
 	let syntax = to_valuedef! { foo | <color>? <color>? bar };
-	let data = to_deriveinput! { enum Foo {} };
+	let data = to_deriveinput! { #[derive(Visitable)] enum Foo {} };
 	assert_snapshot!(syntax, data, "combinator_optional2_keyword");
 }
 
@@ -690,7 +704,7 @@ fn just_optional() {
 #[test]
 fn combinator_optional_all_keywords() {
 	let syntax = to_valuedef! { foo || bar || baz };
-	let data = to_deriveinput! { struct Foo {} };
+	let data = to_deriveinput! { #[derive(Visitable)] struct Foo {} };
 	assert_snapshot!(syntax, data, "combinator_optional_all_keywords");
 }
 
@@ -711,7 +725,7 @@ fn multiplier_with_just_keywords() {
 #[test]
 fn bounded_multiplier_of_keywords() {
 	let syntax = to_valuedef! { [ foo | bar ]{1,2} };
-	let data = to_deriveinput! { struct Foo<'a> {} };
+	let data = to_deriveinput! { #[derive(Visitable)] struct Foo<'a> {} };
 	assert_snapshot!(syntax, data, "bounded_multiplier_of_keywords");
 }
 
@@ -746,7 +760,7 @@ fn none_or_type() {
 #[test]
 fn auto_or_none() {
 	let syntax = to_valuedef!(auto | none);
-	let data = to_deriveinput! { enum Foo {} };
+	let data = to_deriveinput! { #[derive(Visitable)] enum Foo {} };
 	assert_snapshot!(syntax, data, "auto_or_none");
 }
 


### PR DESCRIPTION
In order to use #[syntax] in more places it needs to be a little more flexible about when it adds #[visit] attributes,
only adding them when something actually implements Visitable. We can't tell during a proc macro if a type is going to
impl Visitable _manually_, but we do have a good chance of finding out if it derives(Visitable), by reading the derive
attribute.

So this change checks if a type has derive(Visitable), and only adds `#[visit(skip)]` _if_ that derive is present.

This also makes sense to check if derive(Parse) is present, because if so we can simply skip implementing Parse in those
instances. So we also do that here.
