### PR TITLE
csskit_proc_macro/csskit_derives: Add #[parse(in_range=X..Y?)] syntax

### DIFF
--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
@@ -1,0 +1,58 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Transform {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        if p.peek::<Number>() {
+            let x = p.parse::<Number>()?;
+            if let Ok(i) = std::convert::TryInto::<f32>::try_into(x) {
+                if 0 > i {
+                    use ::css_parse::ToSpan;
+                    Err(::css_parse::diagnostics::NumberTooSmall(0, x.to_span()))?
+                }
+            }
+            let y = p.parse::<Number>()?;
+            if let Ok(i) = std::convert::TryInto::<f32>::try_into(y) {
+                if 0 > i {
+                    use ::css_parse::ToSpan;
+                    Err(::css_parse::diagnostics::NumberTooSmall(0, y.to_span()))?
+                }
+            }
+            Ok(Self::Scale { x: x, y: y })
+        } else if p.peek::<Number>() {
+            let angle = p.parse::<Number>()?;
+            if let Ok(i) = std::convert::TryInto::<f32>::try_into(angle) {
+                if !(-360..=360).contains(&i) {
+                    use ::css_parse::ToSpan;
+                    Err(
+                        ::css_parse::diagnostics::NumberOutOfBounds(
+                            angle.into(),
+                            format!("{}..={}", - 360, 360),
+                            angle.to_span(),
+                        ),
+                    )?
+                }
+            }
+            Ok(Self::Rotate { angle: angle })
+        } else {
+            let x = p.parse::<Length>()?;
+            let y = p.parse::<Percentage>()?;
+            if let Ok(i) = std::convert::TryInto::<f32>::try_into(y) {
+                if !(-100..=100).contains(&i) {
+                    use ::css_parse::ToSpan;
+                    Err(
+                        ::css_parse::diagnostics::NumberOutOfBounds(
+                            y.into(),
+                            format!("{}..={}", - 100, 100),
+                            y.to_span(),
+                        ),
+                    )?
+                }
+            }
+            Ok(Self::Translate { x: x, y: y })
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
@@ -1,0 +1,35 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Value {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        if p.peek::<Number>() {
+            let f0 = p.parse::<Number>()?;
+            if let Ok(i) = std::convert::TryInto::<f32>::try_into(f0) {
+                if !(0..=100).contains(&i) {
+                    use ::css_parse::ToSpan;
+                    Err(
+                        ::css_parse::diagnostics::NumberOutOfBounds(
+                            f0.into(),
+                            format!("{}..={}", 0, 100),
+                            f0.to_span(),
+                        ),
+                    )?
+                }
+            }
+            Ok(Self::Percentage { 0: f0 })
+        } else {
+            let f0 = p.parse::<Number>()?;
+            if let Ok(i) = std::convert::TryInto::<f32>::try_into(f0) {
+                if 0.1 > i {
+                    use ::css_parse::ToSpan;
+                    Err(::css_parse::diagnostics::NumberTooSmall(0.1, f0.to_span()))?
+                }
+            }
+            Ok(Self::Scale { 0: f0 })
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
@@ -1,0 +1,68 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Color {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        let red = p.parse::<CSSInt>()?;
+        if let Ok(i) = std::convert::TryInto::<f32>::try_into(red) {
+            if !(0..=255).contains(&i) {
+                use ::css_parse::ToSpan;
+                Err(
+                    ::css_parse::diagnostics::NumberOutOfBounds(
+                        red.into(),
+                        format!("{}..={}", 0, 255),
+                        red.to_span(),
+                    ),
+                )?
+            }
+        }
+        let green = p.parse::<CSSInt>()?;
+        if let Ok(i) = std::convert::TryInto::<f32>::try_into(green) {
+            if !(0..=255).contains(&i) {
+                use ::css_parse::ToSpan;
+                Err(
+                    ::css_parse::diagnostics::NumberOutOfBounds(
+                        green.into(),
+                        format!("{}..={}", 0, 255),
+                        green.to_span(),
+                    ),
+                )?
+            }
+        }
+        let blue = p.parse::<CSSInt>()?;
+        if let Ok(i) = std::convert::TryInto::<f32>::try_into(blue) {
+            if !(0..=255).contains(&i) {
+                use ::css_parse::ToSpan;
+                Err(
+                    ::css_parse::diagnostics::NumberOutOfBounds(
+                        blue.into(),
+                        format!("{}..={}", 0, 255),
+                        blue.to_span(),
+                    ),
+                )?
+            }
+        }
+        let alpha = p.parse::<Number>()?;
+        if let Ok(i) = std::convert::TryInto::<f32>::try_into(alpha) {
+            if !(0..=1).contains(&i) {
+                use ::css_parse::ToSpan;
+                Err(
+                    ::css_parse::diagnostics::NumberOutOfBounds(
+                        alpha.into(),
+                        format!("{}..={}", 0, 1),
+                        alpha.to_span(),
+                    ),
+                )?
+            }
+        }
+        Ok(Self {
+            red: red,
+            green: green,
+            blue: blue,
+            alpha: alpha,
+        })
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
@@ -1,0 +1,24 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Volume {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        let level = p.parse::<Number>()?;
+        if let Ok(i) = std::convert::TryInto::<f32>::try_into(level) {
+            if !(0.0f32..=100.0f32).contains(&i) {
+                use ::css_parse::ToSpan;
+                Err(
+                    ::css_parse::diagnostics::NumberOutOfBounds(
+                        level.into(),
+                        format!("{}..={}", 0.0f32, 100.0f32),
+                        level.to_span(),
+                    ),
+                )?
+            }
+        }
+        Ok(Self { level: level })
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
@@ -1,0 +1,18 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for PositiveValue {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        let value = p.parse::<CSSInt>()?;
+        if let Ok(i) = std::convert::TryInto::<f32>::try_into(value) {
+            if 1.0f32 > i {
+                use ::css_parse::ToSpan;
+                Err(::css_parse::diagnostics::NumberTooSmall(1.0f32, value.to_span()))?
+            }
+        }
+        Ok(Self { value: value })
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
@@ -1,0 +1,18 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Probability {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        let value = p.parse::<Number>()?;
+        if let Ok(i) = std::convert::TryInto::<f32>::try_into(value) {
+            if 1.0f32 < i {
+                use ::css_parse::ToSpan;
+                Err(::css_parse::diagnostics::NumberTooLarge(1.0f32, value.to_span()))?
+            }
+        }
+        Ok(Self { value: value })
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
@@ -1,0 +1,24 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Scale {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        let f0 = p.parse::<Number>()?;
+        if let Ok(i) = std::convert::TryInto::<f32>::try_into(f0) {
+            if !(0.1..=10.0).contains(&i) {
+                use ::css_parse::ToSpan;
+                Err(
+                    ::css_parse::diagnostics::NumberOutOfBounds(
+                        f0.into(),
+                        format!("{}..={}", 0.1, 10.0),
+                        f0.to_span(),
+                    ),
+                )?
+            }
+        }
+        Ok(Self { 0: f0 })
+    }
+}

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -215,3 +215,96 @@ fn parse_with_multiple_state_stop_combinations() {
 	};
 	assert_parse_snapshot!(data, "parse_with_multiple_state_stop_combinations");
 }
+
+#[test]
+fn parse_struct_with_inclusive_range() {
+	let data = to_deriveinput! {
+		struct Volume {
+			#[parse(in_range = 0.0f32..=100.0f32)]
+			level: Number,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_range");
+}
+
+#[test]
+fn parse_struct_with_range_from() {
+	let data = to_deriveinput! {
+		struct PositiveValue {
+			#[parse(in_range = 1.0f32..)]
+			value: CSSInt,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_range_from");
+}
+
+#[test]
+fn parse_struct_with_range_to_exclusive() {
+	let data = to_deriveinput! {
+		struct Probability {
+			#[parse(in_range = ..1.0f32)]
+			value: Number,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_range_to");
+}
+
+#[test]
+fn parse_struct_with_multiple_range_fields() {
+	let data = to_deriveinput! {
+		struct Color {
+			#[parse(in_range = 0..=255)]
+			red: CSSInt,
+			#[parse(in_range = 0..=255)]
+			green: CSSInt,
+			#[parse(in_range = 0..=255)]
+			blue: CSSInt,
+			#[parse(in_range = 0..=1)]
+			alpha: Number,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_multiple_range_fields");
+}
+
+#[test]
+fn parse_tuple_struct_with_range() {
+	let data = to_deriveinput! {
+		struct Scale(#[parse(in_range = 0.1..=10.0)] Number);
+	};
+	assert_parse_snapshot!(data, "parse_tuple_struct_with_range");
+}
+
+#[test]
+fn parse_enum_with_range_validation() {
+	let data = to_deriveinput! {
+		enum Value {
+			Percentage(#[parse(in_range = 0..=100)] Number),
+			Scale(#[parse(in_range = 0.1..)] Number),
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_with_range_validation");
+}
+
+#[test]
+fn parse_enum_struct_variants_with_ranges() {
+	let data = to_deriveinput! {
+		enum Transform {
+			Scale {
+				#[parse(in_range = 0..)]
+				x: Number,
+				#[parse(in_range = 0..)]
+				y: Number,
+			},
+			Rotate {
+				#[parse(in_range = -360..=360)]
+				angle: Number,
+			},
+			Translate {
+				x: Length,
+				#[parse(in_range = -100..=100)]
+				y: Percentage,
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_struct_variants_with_ranges");
+}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_type_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_or_type_with_checks_derive_parse.snap
@@ -1,0 +1,6 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+#[derive(Parse)]
+struct Foo(#[parse(in_range = -90f32..= 90f32)] pub crate::AutoOr<crate::Angle>);

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks_derive_parse.snap
@@ -1,0 +1,14 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", }
+);
+#[derive(Parse)]
+enum Foo {
+    Foo(::css_parse::T![Ident]),
+    #[parse(in_range = 0f32..)]
+    LengthPercentage(crate::LengthPercentage),
+}

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -548,6 +548,13 @@ fn custom_type_with_checks() {
 }
 
 #[test]
+fn custom_type_with_checks_derive_parse() {
+	let syntax = to_valuedef!(" foo | <length-percentage [0,∞]> ");
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "custom_type_with_checks_derive_parse");
+}
+
+#[test]
 fn custom_function_type() {
 	let syntax = to_valuedef!(" foo | <calc-size()> ");
 	let data = to_deriveinput! { enum Foo {} };
@@ -776,6 +783,13 @@ fn auto_or_type_with_checks() {
 	let syntax = to_valuedef!( auto | <angle [-90deg,90deg]> );
 	let data = to_deriveinput! { struct Foo; };
 	assert_snapshot!(syntax, data, "auto_or_type_with_checks");
+}
+
+#[test]
+fn auto_or_type_with_checks_derive_parse() {
+	let syntax = to_valuedef!( auto | <angle [-90deg,90deg]> );
+	let data = to_deriveinput! { #[derive(Parse)] struct Foo; };
+	assert_snapshot!(syntax, data, "auto_or_type_with_checks_derive_parse");
 }
 
 #[test]


### PR DESCRIPTION
While #[syntax] allows for checking values within ranges, #[derive(Parse)] has no such capability.

This change implements a new attribute: `#[parse(in_range=X..Y?)]`. With this attribute the field that gets parsed will
have checks generated which will fail a parse, much in the same way #[syntax] does.

These new checks rely on TryInto, which might require some follow up changes to various types for them to implement that
type. If TryInto fails the check is ignored.
