### PR TITLE
csskit_proc_macro/csskit_derives: Implement AllMustOccur simple cases

### DIFF
--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
@@ -1,0 +1,49 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for FlexValue {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        if p.peek::<AutoKeyword>() {
+            let f0 = p.parse::<AutoKeyword>()?;
+            Ok(Self::Auto { 0: f0 })
+        } else if p.peek::<Length>() {
+            let mut min: Option<Length> = None;
+            let mut max: Option<Length> = None;
+            loop {
+                let c = p.peek_n(1);
+                if min.is_none() && <Length>::peek(p, c) {
+                    min = Some(p.parse::<Length>()?);
+                    continue;
+                }
+                if max.is_none() && <Length>::peek(p, c) {
+                    let val = p.parse::<Length>()?;
+                    if let Ok(i) = std::convert::TryInto::<f32>::try_into(val) {
+                        if 0 > i {
+                            use ::css_parse::ToSpan;
+                            Err(
+                                ::css_parse::diagnostics::NumberTooSmall(0, val.to_span()),
+                            )?
+                        }
+                    }
+                    max = Some(val);
+                    continue;
+                }
+                break;
+            }
+            if min.is_none() || max.is_none() {
+                let c = p.peek_n(1);
+                Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            }
+            Ok(Self::MinMax {
+                min: min.unwrap(),
+                max: max.unwrap(),
+            })
+        } else {
+            let f0 = p.parse::<Length>()?;
+            Ok(Self::Length { 0: f0 })
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
@@ -1,0 +1,37 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Value {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        if p.peek::<String>() {
+            let f0 = p.parse::<String>()?;
+            Ok(Self::Normal { 0: f0 })
+        } else {
+            let mut auto: Option<AutoKeyword> = None;
+            let mut length: Option<Length> = None;
+            loop {
+                let c = p.peek_n(1);
+                if auto.is_none() && <AutoKeyword>::peek(p, c) {
+                    auto = Some(p.parse::<AutoKeyword>()?);
+                    continue;
+                }
+                if length.is_none() && <Length>::peek(p, c) {
+                    length = Some(p.parse::<Length>()?);
+                    continue;
+                }
+                break;
+            }
+            if auto.is_none() || length.is_none() {
+                let c = p.peek_n(1);
+                Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            }
+            Ok(Self::Complex {
+                auto: auto.unwrap(),
+                length: length.unwrap(),
+            })
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
@@ -1,0 +1,50 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Value {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        if p.peek::<AutoKeyword>() {
+            let mut auto: Option<AutoKeyword> = None;
+            let mut percentage: Option<Number> = None;
+            loop {
+                let c = p.peek_n(1);
+                if auto.is_none() && <AutoKeyword>::peek(p, c) {
+                    auto = Some(p.parse::<AutoKeyword>()?);
+                    continue;
+                }
+                if percentage.is_none() && <Number>::peek(p, c) {
+                    let val = p.parse::<Number>()?;
+                    if let Ok(i) = std::convert::TryInto::<f32>::try_into(val) {
+                        if !(0..=100).contains(&i) {
+                            use ::css_parse::ToSpan;
+                            Err(
+                                ::css_parse::diagnostics::NumberOutOfBounds(
+                                    val.into(),
+                                    format!("{}..={}", 0, 100),
+                                    val.to_span(),
+                                ),
+                            )?
+                        }
+                    }
+                    percentage = Some(val);
+                    continue;
+                }
+                break;
+            }
+            if auto.is_none() || percentage.is_none() {
+                let c = p.peek_n(1);
+                Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            }
+            Ok(Self::WithRange {
+                auto: auto.unwrap(),
+                percentage: percentage.unwrap(),
+            })
+        } else {
+            let f0 = p.parse::<String>()?;
+            Ok(Self::Simple { 0: f0 })
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
@@ -1,0 +1,32 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for AutoAndLength {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        let mut auto: Option<AutoKeyword> = None;
+        let mut length: Option<Length> = None;
+        loop {
+            let c = p.peek_n(1);
+            if auto.is_none() && <AutoKeyword>::peek(p, c) {
+                auto = Some(p.parse::<AutoKeyword>()?);
+                continue;
+            }
+            if length.is_none() && <Length>::peek(p, c) {
+                length = Some(p.parse::<Length>()?);
+                continue;
+            }
+            break;
+        }
+        if auto.is_none() || length.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+        }
+        Ok(Self {
+            auto: auto.unwrap(),
+            length: length.unwrap(),
+        })
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
@@ -1,0 +1,45 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for AutoAndLengthWithRange {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        let mut auto: Option<AutoKeyword> = None;
+        let mut length: Option<Length> = None;
+        loop {
+            let c = p.peek_n(1);
+            if auto.is_none() && <AutoKeyword>::peek(p, c) {
+                auto = Some(p.parse::<AutoKeyword>()?);
+                continue;
+            }
+            if length.is_none() && <Length>::peek(p, c) {
+                let val = p.parse::<Length>()?;
+                if let Ok(i) = std::convert::TryInto::<f32>::try_into(val) {
+                    if !(0..=100).contains(&i) {
+                        use ::css_parse::ToSpan;
+                        Err(
+                            ::css_parse::diagnostics::NumberOutOfBounds(
+                                val.into(),
+                                format!("{}..={}", 0, 100),
+                                val.to_span(),
+                            ),
+                        )?
+                    }
+                }
+                length = Some(val);
+                continue;
+            }
+            break;
+        }
+        if auto.is_none() || length.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+        }
+        Ok(Self {
+            auto: auto.unwrap(),
+            length: length.unwrap(),
+        })
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
@@ -1,0 +1,34 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for AutoAndLengthInState {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        let state = p.set_state(State::InValue);
+        let mut auto: Option<AutoKeyword> = None;
+        let mut length: Option<Length> = None;
+        loop {
+            let c = p.peek_n(1);
+            if auto.is_none() && <AutoKeyword>::peek(p, c) {
+                auto = Some(p.parse::<AutoKeyword>()?);
+                continue;
+            }
+            if length.is_none() && <Length>::peek(p, c) {
+                length = Some(p.parse::<Length>()?);
+                continue;
+            }
+            break;
+        }
+        p.set_state(state);
+        if auto.is_none() || length.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+        }
+        Ok(Self {
+            auto: auto.unwrap(),
+            length: length.unwrap(),
+        })
+    }
+}

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -308,3 +308,88 @@ fn parse_enum_struct_variants_with_ranges() {
 	};
 	assert_parse_snapshot!(data, "parse_enum_struct_variants_with_ranges");
 }
+
+#[test]
+fn parse_struct_with_all_must_occur() {
+	let data = to_deriveinput! {
+		#[parse(all_must_occur)]
+		struct AutoAndLength {
+			auto: AutoKeyword,
+			length: Length,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_all_must_occur");
+}
+
+#[test]
+fn parse_struct_with_all_must_occur_and_range() {
+	let data = to_deriveinput! {
+		#[parse(all_must_occur)]
+		struct AutoAndLengthWithRange {
+			auto: AutoKeyword,
+			#[parse(in_range = 0..=100)]
+			length: Length,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_all_must_occur_and_range");
+}
+
+#[test]
+fn parse_struct_with_all_must_occur_and_state() {
+	let data = to_deriveinput! {
+		#[parse(all_must_occur, state = State::InValue)]
+		struct AutoAndLengthInState {
+			auto: AutoKeyword,
+			length: Length,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_all_must_occur_and_state");
+}
+
+#[test]
+fn parse_enum_variant_with_all_must_occur() {
+	let data = to_deriveinput! {
+		enum Value {
+			Normal(String),
+			#[parse(all_must_occur)]
+			Complex {
+				auto: AutoKeyword,
+				length: Length
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_variant_with_all_must_occur");
+}
+
+#[test]
+fn parse_enum_variant_with_all_must_occur_and_range() {
+	let data = to_deriveinput! {
+		enum Value {
+			#[parse(all_must_occur)]
+			WithRange {
+				auto: AutoKeyword,
+				#[parse(in_range = 0..=100)]
+				percentage: Number,
+			},
+			Simple(String),
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_variant_with_all_must_occur_and_range");
+}
+
+#[test]
+fn parse_enum_mixed_variants() {
+	let data = to_deriveinput! {
+		enum FlexValue {
+			Auto(AutoKeyword),
+			#[parse(all_must_occur)]
+			MinMax {
+				min: Length,
+				#[parse(in_range = 0..)]
+				max: Length,
+			},
+			Length(Length),
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_mixed_variants");
+}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_and_length_with_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_and_length_with_range.snap
@@ -1,0 +1,41 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+struct Foo<'a>(pub ::css_parse::T![Ident], crate::Length);
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
+    fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
+        use ::css_parse::{Parse, Peek};
+        let mut val0: Option<::css_parse::T![Ident]> = None;
+        let mut val1: Option<crate::Length> = None;
+        loop {
+            let c = p.peek_n(1);
+            if val0.is_none() && <FooKeywords>::peek(p, c) {
+                val0 = Some(p.parse::<FooKeywords>()?.into());
+                continue;
+            }
+            if val1.is_none() && <crate::Length>::peek(p, c) {
+                let ty = p.parse::<crate::Length>()?;
+                if !(0f32..=100f32).contains(&Into::<f32>::into(ty)) {
+                    use css_parse::ToSpan;
+                    Err(
+                        ::css_parse::diagnostics::NumberOutOfBounds(
+                            ty.into(),
+                            format!("{}..{}", 0f32, 100f32),
+                            ty.to_span(),
+                        ),
+                    )?
+                }
+                val1 = Some(ty);
+                continue;
+            }
+            break;
+        }
+        if val0.is_none() || val1.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+        }
+        Ok(Self(val0.unwrap(), val1.unwrap()))
+    }
+}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__simple_optionals.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__simple_optionals.snap
@@ -1,0 +1,30 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+struct Foo<'a>(pub crate::Length, ::css_parse::T![Ident]);
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
+    fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
+        use ::css_parse::{Parse, Peek};
+        let mut val0: Option<crate::Length> = None;
+        let mut val1: Option<::css_parse::T![Ident]> = None;
+        loop {
+            let c = p.peek_n(1);
+            if val0.is_none() && <crate::Length>::peek(p, c) {
+                val0 = Some(p.parse::<crate::Length>()?);
+                continue;
+            }
+            if val1.is_none() && <FooKeywords>::peek(p, c) {
+                val1 = Some(p.parse::<FooKeywords>()?.into());
+                continue;
+            }
+            break;
+        }
+        if val0.is_none() || val1.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+        }
+        Ok(Self(val0.unwrap(), val1.unwrap()))
+    }
+}

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -812,3 +812,17 @@ fn bg_image() {
 	let data = to_deriveinput! { struct Foo<'a>; };
 	assert_snapshot!(syntax, data, "bg_image");
 }
+
+#[test]
+fn simple_all_must_occur() {
+	let syntax = to_valuedef!(" <length> && auto ");
+	let data = to_deriveinput! { struct Foo<'a>; };
+	assert_snapshot!(syntax, data, "simple_optionals");
+}
+
+#[test]
+fn auto_and_length_with_range() {
+	let syntax = to_valuedef!(" auto && <length [0,100]> ");
+	let data = to_deriveinput! { struct Foo<'a>; };
+	assert_snapshot!(syntax, data, "auto_and_length_with_range");
+}


### PR DESCRIPTION
The AllMustOccur combinator style wasn't parseable in #[syntax], erroring out. This change introduces some very
basic tests and the basic parsing code in order to generate an AllMustOccur style syntax implementation. In addition to
that, in order to try to keep parity with derive(Parse) this introduces the #[parse(all_must_occur)] attribute in
struct/enum variants for derive(Parse) to achieve the same functionality.
