### PR TITLE
css_ast: Improve dynamic-range-limit

### DIFF
--- a/crates/css_ast/src/values/color_hdr/impls.rs
+++ b/crates/css_ast/src/values/color_hdr/impls.rs
@@ -15,7 +15,6 @@ mod tests {
 	#[test]
 	fn test_writes() {
 		assert_parse!(DynamicRangeLimitStyleValue, "standard");
-		assert_parse!(DynamicRangeLimitStyleValue, "dynamic-range-limit-mix(high 80%,standard 20%)");
-		assert_parse!(DynamicRangeLimitStyleValue, "dynamic-range-limit-mix(high 8%,standard 2%)");
+		assert_parse!(DynamicRangeLimitStyleValue, "dynamic-range-limit-mix(no-limit 80%,standard 20%)");
 	}
 }


### PR DESCRIPTION
dynamic-range-limit is an emerging property, so there have been changes in syntax:

 - The `high` keyword is no longer, replaced with `no-limit`.
 - dynamic-range-limit-mix() allows recursive calls, e.g. `dynamic-range-limit-mix(dynamic-range-limit-mix(...) 10%)`

So this change implements the recursive nature and replaces the `high` keyword, but it does so in a more convenient way:
by using `#[syntax]` to simplify the heavy lifting, made possible by prior PRs like https://github.com/csskit/csskit/pull/359.