### PR TITLE
csskit_proc_macro: Use #[parse(keywords = )] annotation in #[syntax] when derive(Parse)

### DIFF
--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -491,7 +491,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
               .expect("keyword variant path should have at least one segment")
               .ident
               .clone();
-            let keyword_parse = quote! { let c = p.peek_n(1); let keywords = if #keyword_type::peek(p, c) { Some(<#keyword_type>::build(p, c)) } else { None }; };
+            let keyword_parse = quote! { use css_parse::Peek; let c = p.peek_n(1); let keywords = if #keyword_type::peek(p, c) { Some(<#keyword_type>::build(p, c)) } else { None }; };
             let desired = quote! { #keyword_variant };
             return match position {
               Position::First => quote! { #keyword_parse; if let Some(#desired(ident)) = keywords { #step } },

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
@@ -6,6 +6,7 @@ expression: pretty
 impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
+        use css_parse::Peek;
         let c = p.peek_n(1);
         let keywords = if Keyword::peek(p, c) {
             Some(<Keyword>::build(p, c))

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
@@ -6,6 +6,7 @@ expression: pretty
 impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
+        use css_parse::Peek;
         let c = p.peek_n(1);
         let keywords = if Keyword::peek(p, c) {
             Some(<Keyword>::build(p, c))

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -909,6 +909,7 @@ impl GenerateDefinition for Def {
 					let variants: TokenStream = children
 						.iter()
 						.map(|d| {
+							let mut attrs = d.type_attributes(derives_parse, derives_visitable);
 							let name = d.to_variant_name(0);
 							let types = match d {
 								Self::Combinator(defs, DefCombinatorStyle::Ordered) => defs
@@ -919,9 +920,14 @@ impl GenerateDefinition for Def {
 										quote! { #attrs #ty }
 									})
 									.collect(),
+								Self::Ident(_) => {
+									if derives_parse {
+										attrs.extend(quote! { #[parse(keyword = #keyword_name::#name)] });
+									}
+									d.to_types()
+								}
 								_ => d.to_types(),
 							};
-							let attrs = d.type_attributes(derives_parse, derives_visitable);
 							quote! { #attrs #name(#(#types),*), }
 						})
 						.collect();

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks_derive_parse.snap
@@ -8,6 +8,7 @@ expression: pretty
 );
 #[derive(Parse)]
 enum Foo {
+    #[parse(keyword = FooKeywords::Foo)]
     Foo(::css_parse::T![Ident]),
     #[parse(in_range = 0f32..)]
     LengthPercentage(crate::LengthPercentage),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords_derive_parse.snap
@@ -1,0 +1,19 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Black :
+    "black", White : "white", LineThrough : "line-through", Pink : "pink", }
+);
+#[derive(Parse)]
+enum Foo {
+    #[parse(keyword = FooKeywords::Black)]
+    Black(::css_parse::T![Ident]),
+    #[parse(keyword = FooKeywords::White)]
+    White(::css_parse::T![Ident]),
+    #[parse(keyword = FooKeywords::LineThrough)]
+    LineThrough(::css_parse::T![Ident]),
+    #[parse(keyword = FooKeywords::Pink)]
+    Pink(::css_parse::T![Ident]),
+}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_derive_parse_skips_impl.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_derive_parse_skips_impl.snap
@@ -8,6 +8,8 @@ expression: pretty
 );
 #[derive(Parse)]
 enum Foo {
+    #[parse(keyword = FooKeywords::Foo)]
     Foo(::css_parse::T![Ident]),
+    #[parse(keyword = FooKeywords::Bar)]
     Bar(::css_parse::T![Ident]),
 }

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -513,6 +513,13 @@ fn multiple_keywords() {
 }
 
 #[test]
+fn multiple_keywords_derive_parse() {
+	let syntax = to_valuedef!("black | white | line-through | pink");
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "multiple_keywords_derive_parse");
+}
+
+#[test]
 fn value_group_type_keyword() {
 	let syntax = to_valuedef!( <length [1,]> | line-through );
 	let data = to_deriveinput! { enum Foo {} };


### PR DESCRIPTION
Following straight on from https://github.com/csskit/csskit/pull/361 this enables the new attribute in #[syntax].
