### PR TITLE
css_parse/csskit_proc_macro: Bring Optionals parsing into derive(Parse)

### DIFF
--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for FlexValue {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<AutoKeyword>() {
             let f0 = p.parse::<AutoKeyword>()?;
             Ok(Self::Auto { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a, T> ::css_parse::Parse<'a> for Container<T> {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<T>() {
             let f0 = p.parse::<T>()?;
             Ok(Self::Single { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_and_tuple_mixed.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_and_tuple_mixed.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for FlexValue {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<Ident>() {
             let f0 = p.parse::<Ident>()?;
             Ok(Self::Auto { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Transform {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<Number>() {
             let x = p.parse::<Number>()?;
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&x) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for AllMustOccurEnum {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<String>() {
             let f0 = p.parse::<String>()?;
             Ok(Self::Simple { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<String>() {
             let f0 = p.parse::<String>()?;
             Ok(Self::Normal { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<AutoKeyword>() {
             let mut auto: Option<AutoKeyword> = None;
             let mut percentage: Option<Number> = None;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for TestEnum {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<String>() {
             let f0 = p.parse::<String>()?;
             Ok(Self::Normal { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
@@ -5,8 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
-        use css_parse::Peek;
+        use css_parse::{Parse, Peek, Build};
         let c = p.peek_n(1);
         let keywords = if Keyword::peek(p, c) {
             Some(<Keyword>::build(p, c))

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
@@ -5,8 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
-        use css_parse::Peek;
+        use css_parse::{Parse, Peek, Build};
         let c = p.peek_n(1);
         let keywords = if Keyword::peek(p, c) {
             Some(<Keyword>::build(p, c))

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_fields.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<String>() {
             let f0 = p.parse::<String>()?;
             Ok(Self::Keyword { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_lifetime.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for CssValue<'a> {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<String>() {
             let f0 = p.parse::<String>()?;
             Ok(Self::Keyword { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<Number>() {
             let f0 = p.parse::<Number>()?;
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&f0) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_struct_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_struct_variants.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for BorderStyle {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<Ident>() {
             let f0 = p.parse::<Ident>()?;
             Ok(Self::Solid { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_enum.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_enum.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Display {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         if p.peek::<Ident>() {
             let f0 = p.parse::<Ident>()?;
             Ok(Self::Block { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_struct.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         Ok(Self {})
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_single_field_tuple_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_single_field_tuple_struct.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Opacity {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let f0 = p.parse::<Number>()?;
         Ok(Self { 0: f0 })
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for AllMustOccurNewtypeTest {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let mut auto_value: Option<Auto> = None;
         let mut none_value: Option<None> = None;
         let mut length: Option<Length> = None;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_existing_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_existing_lifetime.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Token<'a> {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let span = p.parse::<str>()?;
         Ok(Self { span: span })
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for RegularKeywordTest {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let auto_value = {
             let c = p.peek_n(1);
             if <FooKeywords>::peek(p, c) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for AutoAndLength {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let mut auto: Option<AutoKeyword> = None;
         let mut length: Option<Length> = None;
         loop {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for AutoAndLengthWithRange {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let mut auto: Option<AutoKeyword> = None;
         let mut length: Option<Length> = None;
         loop {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for AutoAndLengthInState {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let state = p.set_state(State::InValue);
         let mut auto: Option<AutoKeyword> = None;
         let mut length: Option<Length> = None;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_fields.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Color {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let red = p.parse::<CSSInt>()?;
         let green = p.parse::<CSSInt>()?;
         let blue = p.parse::<CSSInt>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let mut auto_value: Option<AutoValue> = None;
         let mut percentage: Option<Number> = None;
         loop {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_lifetime.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value<'a> {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let content = p.parse::<Ident>()?;
         Ok(Self { content: content })
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_many_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_many_fields.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Transform {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let rotate_x = p.parse::<Angle>()?;
         let rotate_y = p.parse::<Angle>()?;
         let rotate_z = p.parse::<Angle>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Color {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let red = p.parse::<CSSInt>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&red) {
             if !(0..=255).contains(&i) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_newtype_keyword.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for NewtypeKeywordTest {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let auto_value = p.parse::<Auto>()?;
         let length = p.parse::<Length>()?;
         Ok(Self {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
@@ -3,44 +3,38 @@ source: crates/csskit_derives/src/test/test_parse.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Parse<'a> for SpecificKeywordTest {
+impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Peek, Build};
-        let mut auto_field: Option<AutoValue> = None;
-        let mut none_field: Option<NoneValue> = None;
-        let mut length: Option<Length> = None;
+        let mut auto_value: Option<Ident> = None;
+        let mut none_value: Option<Ident> = None;
         loop {
             let c = p.peek_n(1);
-            if auto_field.is_none() && <FooKeywords>::peek(p, c) {
+            if auto_value.is_none() && <FooKeywords>::peek(p, c) {
                 let keyword = <FooKeywords>::build(p, c);
                 if let FooKeywords::Auto(ident) = keyword {
                     p.next();
-                    auto_field = Some(ident);
+                    auto_value = Some(ident);
                     continue;
                 }
             }
-            if none_field.is_none() && <FooKeywords>::peek(p, c) {
+            if none_value.is_none() && <FooKeywords>::peek(p, c) {
                 let keyword = <FooKeywords>::build(p, c);
                 if let FooKeywords::None(ident) = keyword {
                     p.next();
-                    none_field = Some(ident);
+                    none_value = Some(ident);
                     continue;
                 }
             }
-            if length.is_none() && <Length>::peek(p, c) {
-                length = Some(p.parse::<Length>()?);
-                continue;
-            }
             break;
         }
-        if auto_field.is_none() || none_field.is_none() || length.is_none() {
+        if auto_value.is_none() && none_value.is_none() {
             let c = p.peek_n(1);
             Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
         }
         Ok(Self {
-            auto_field: auto_field.unwrap(),
-            none_field: none_field.unwrap(),
-            length: length.unwrap(),
+            auto_value: auto_value,
+            none_value: none_value,
         })
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Volume {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let level = p.parse::<Number>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&level) {
             if !(0.0f32..=100.0f32).contains(&i) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for PositiveValue {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let value = p.parse::<CSSInt>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&value) {
             if 1.0f32 > i {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Probability {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let value = p.parse::<Number>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&value) {
             if 1.0f32 < i {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Length {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let f0 = p.parse::<Number>()?;
         let f1 = p.parse::<Unit>()?;
         Ok(Self { 0: f0, 1: f1 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Scale {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let f0 = p.parse::<Number>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&f0) {
             if !(0.1..=10.0).contains(&i) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_unit_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_unit_struct.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Auto {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         Ok(Self {})
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_both_state_and_stop.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_both_state_and_stop.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for RuleContent {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let stop = p.set_stop(KindSet::new(&[Kind::RightBrace]));
         let state = p.set_state(State::InRule);
         let declarations = p.parse::<Vec<String>>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_multiple_state_stop_combinations.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_multiple_state_stop_combinations.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Declaration {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let stop = p.set_stop(KindSet::DeclarationEnd);
         let state = p.set_state(State::InDeclaration);
         let property = p.parse::<Ident>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_state_attribute.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_state_attribute.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for ValueInState {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let state = p.set_state(State::InValue);
         let content = p.parse::<String>()?;
         p.set_state(state);

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kind_attribute.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kind_attribute.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for StopOnSemicolon {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let stop = p.set_stop(KindSet::new(&[Kind::Semicolon]));
         let items = p.parse::<Vec<String>>()?;
         p.set_stop(stop);

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kindset_attribute.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kindset_attribute.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for StopOnBlockEnd {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::{Parse, Build};
+        use css_parse::{Parse, Peek, Build};
         let stop = p.set_stop(KindSet::BlockEnd);
         let declarations = p.parse::<Vec<String>>()?;
         p.set_stop(stop);

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -425,6 +425,20 @@ fn parse_struct_with_different_keyword_variants() {
 }
 
 #[test]
+fn parse_struct_with_optional_keywords() {
+	let data = to_deriveinput! {
+		#[parse(one_must_occur)]
+		struct KeywordWithRange {
+			#[parse(keyword = FooKeywords::Auto)]
+			auto_value: Option<Ident>,
+			#[parse(keyword = FooKeywords::None)]
+			none_value: Option<Ident>,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_optional_keywords");
+}
+
+#[test]
 fn parse_struct_regular_with_keyword_pattern() {
 	// Test keyword parsing in regular (non-all_must_occur) structs
 	let data = to_deriveinput! {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords_with_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords_with_derive_parse.snap
@@ -1,0 +1,21 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", Bar : "bar", Baz : "baz", }
+);
+#[derive(Parse, Visitable)]
+#[parse(one_must_occur)]
+struct Foo {
+    #[visit(skip)]
+    #[parse(keyword = FooKeywords::Foo)]
+    pub foo: Option<::css_parse::T![Ident]>,
+    #[visit(skip)]
+    #[parse(keyword = FooKeywords::Bar)]
+    pub bar: Option<::css_parse::T![Ident]>,
+    #[visit(skip)]
+    #[parse(keyword = FooKeywords::Baz)]
+    pub baz: Option<::css_parse::T![Ident]>,
+}

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -730,6 +730,13 @@ fn combinator_optional_all_keywords() {
 }
 
 #[test]
+fn combinator_optional_all_keywords_with_derive_parse() {
+	let syntax = to_valuedef! { foo || bar || baz };
+	let data = to_deriveinput! { #[derive(Parse, Visitable)] struct Foo {} };
+	assert_snapshot!(syntax, data, "combinator_optional_all_keywords_with_derive_parse");
+}
+
+#[test]
 fn combinator_optional_keywords_and_types() {
 	let syntax = to_valuedef! { foo || <bar> };
 	let data = to_deriveinput! { struct Foo {} };


### PR DESCRIPTION
A syntax of optionals (e.g. `foo || bar`) could use #[syntax], but would fail on derive(Parse). This change fixes that
by adding a `OneMustOccur` field parsing mode to derive(Parse).
