### PR TITLE
css_ast: derive(Parse) on more types

### DIFF
--- a/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
+++ b/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
@@ -17,7 +17,7 @@ pub struct DynamicRangeLimitMixFunction<'a>(
 );
 
 #[syntax(" <'dynamic-range-limit'> && <percentage [0,100]> ")]
-#[derive(Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct DynamicRangeLimitMixFunctionParams<'a>;
 

--- a/crates/css_ast/src/types/anchor_name.rs
+++ b/crates/css_ast/src/types/anchor_name.rs
@@ -1,4 +1,4 @@
-use csskit_derives::{IntoCursor, Peek, ToCursors, Visitable};
+use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 use csskit_proc_macro::syntax;
 
 /// <https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-name>
@@ -7,7 +7,7 @@ use csskit_proc_macro::syntax;
 /// <anchor-name> = <dashed-ident>
 /// ```
 #[syntax("<dashed-ident>")]
-#[derive(IntoCursor, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub struct AnchorName;

--- a/crates/css_ast/src/types/bg_size.rs
+++ b/crates/css_ast/src/types/bg_size.rs
@@ -1,5 +1,5 @@
 use css_parse::keyword_set;
-use csskit_derives::{Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 use csskit_proc_macro::syntax;
 
 /// <https://drafts.csswg.org/css-backgrounds-3/#typedef-bg-size>
@@ -8,7 +8,7 @@ use csskit_proc_macro::syntax;
 /// <bg-size> = [ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain
 /// ```
 #[syntax(" [ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain ")]
-#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit]
 pub enum BgSize {}

--- a/crates/css_ast/src/types/family_name.rs
+++ b/crates/css_ast/src/types/family_name.rs
@@ -1,4 +1,4 @@
-use csskit_derives::{Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 use csskit_proc_macro::syntax;
 
 /// <https://drafts.csswg.org/css-fonts-4/#family-name-syntax>
@@ -7,7 +7,7 @@ use csskit_proc_macro::syntax;
 /// <family-name> = <string> | <custom-ident>+
 /// ```
 #[syntax(" <string> | <custom-ident>+ ")]
-#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit]
 pub enum FamilyName<'a> {}

--- a/crates/css_ast/src/types/font_weight_absolute.rs
+++ b/crates/css_ast/src/types/font_weight_absolute.rs
@@ -1,4 +1,4 @@
-use csskit_derives::{IntoCursor, Peek, ToCursors, Visitable};
+use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 use csskit_proc_macro::syntax;
 
 /// <https://drafts.csswg.org/css-fonts-4/#font-weight-absolute-values>
@@ -7,7 +7,7 @@ use csskit_proc_macro::syntax;
 /// <font-weight-absolute> = [normal | bold | <number [1,1000]>]
 /// ```
 #[syntax(" normal | bold | <number [1,1000]> ")]
-#[derive(Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", content = "value"))]
 #[visit(self)]
 pub enum FontWeightAbsolute {}

--- a/crates/css_ast/src/types/generic_family.rs
+++ b/crates/css_ast/src/types/generic_family.rs
@@ -7,13 +7,13 @@ function_set!(pub struct GenericScriptSpecificFunctionName "generic");
 /// <https://drafts.csswg.org/css-fonts-4/#family-name-syntax>
 ///
 /// ```text,ignore
-/// <generic-family> = <generic-script-specific>| <generic-complete> | <generic-incomplete>
+/// <generic-family> = <generic-script-specific> | <generic-complete> | <generic-incomplete>
 /// <generic-script-specific> = generic(fangsong) | generic(kai) | generic(khmer-mul) |  generic(nastaliq)
 /// <generic-complete> = serif | sans-serif | system-ui | cursive | fantasy | math | monospace
 /// <generic-incomplete> = ui-serif | ui-sans-serif | ui-monospace | ui-rounded
 /// ```
-#[syntax(" <generic-script-specific>| <generic-complete> | <generic-incomplete> ")]
-#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[syntax(" <generic-script-specific> | <generic-complete> | <generic-incomplete> ")]
+#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit(self)]
 pub enum GenericFamily {}


### PR DESCRIPTION
These types relied on the generate.rs parse impl, they should opt into derive(Parse) instead now.
