### PR TITLE
css_parse/css_lexer: Fix requiring whitespace between dimension and `-`

### DIFF
--- a/crates/css_lexer/src/token.rs
+++ b/crates/css_lexer/src/token.rs
@@ -900,6 +900,7 @@ impl Token {
 					(!second.has_sign() || second.value() < 0.0))
 					|| matches!(second.kind(), Kind::Ident | Kind::Function | Kind::Url | Kind::BadUrl)
 					|| second.is_cdc()
+					|| matches!(second.char(), Some('-'))
 			}
 			Kind::Number => {
 				matches!(

--- a/crates/css_parse/src/cursor_compact_write_sink.rs
+++ b/crates/css_parse/src/cursor_compact_write_sink.rs
@@ -56,8 +56,7 @@ impl<'a, T: Write> CursorCompactWriteSink<'a, T> {
 		self.last_token = Some(c.token());
 		let mut write_c = c;
 		if c.token().quote_style() == QuoteStyle::Single {
-			dbg!(c);
-			write_c = dbg!(Cursor::new(c.offset(), c.token().with_quotes(QuoteStyle::Double)));
+			write_c = Cursor::new(c.offset(), c.token().with_quotes(QuoteStyle::Double));
 		}
 		write_c.write_str(source, &mut self.writer)?;
 		Ok(())
@@ -126,5 +125,10 @@ mod test {
 		"#,
 			"body>div{bar:baz}"
 		);
+	}
+
+	#[test]
+	fn test_does_not_compact_whitespace_resulting_in_new_ident() {
+		assert_format!("12px - 1px", "12px - 1px");
 	}
 }


### PR DESCRIPTION
`npx csskit@canary min` on a file of `div{height:calc(100vh - 68px);}` was producing incorrect CSS of `div{height:calc(100vh-68px);}`. This would retokenize as a single ident of `100vh-68px`.

The `needs_separator_for` had a bug - the table comment above shows dimension followed by `-` does need a separator, but
that particular line of logic was missing.

This change introduces that line of logic, plus an acceptance style test in the CursorCompactWriteSink to demonstrate
the failure mode.
