### PR TITLE
css_lexer/css_parse: Introduce AssociatedWhitespaceRules

### DIFF
--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -211,7 +211,7 @@ mod tests {
 		assert_parse!(Nth, "+n + 7 ", "+n+ 7");
 		assert_parse!(Nth, "N- 123");
 		assert_parse!(Nth, "n- 10");
-		assert_parse!(Nth, "-n\n- 1", "-n- 1");
+		assert_parse!(Nth, "-n\n- 1", "-n - 1");
 		assert_parse!(Nth, " 23n\n\n+\n\n123 ", "23n+ 123");
 	}
 

--- a/crates/css_lexer/src/associated_whitespace_rules.rs
+++ b/crates/css_lexer/src/associated_whitespace_rules.rs
@@ -1,0 +1,66 @@
+use bitmask_enum::bitmask;
+
+/// A [bitmask][bitmask_enum] representing rules around the whitespace surrounding a [Kind::Delim][crate::Kind::Delim]
+/// token.
+///
+/// A [Token][crate::Token] with [Kind::Delim][crate::Kind::Delim] or one of the other single character tokens (such as
+/// [Kind::LeftCurly][crate::Kind::LeftCurly] will store this data internal to the token. Using
+/// [Token::associated_whitespace()][crate::Token::associated_whitespace()] will return this bitmask, depending on what
+/// rules are set for this token. By default the [Lexer][crate::Lexer] will produce tokens with
+/// [AssociatedWhitespaceRules::None], but new tokens can be created which can be accompanied with a different set of
+/// rules.
+///
+/// ```
+/// use css_lexer::*;
+/// let mut lexer = Lexer::new(".");
+/// {
+///		// This token will be a Delim of `.`
+///		let token = lexer.advance();
+///		assert_eq!(token, Kind::Delim);
+///		assert_eq!(token, AssociatedWhitespaceRules::None);
+/// }
+/// ```
+#[bitmask(u8)]
+#[bitmask_config(vec_debug)]
+pub enum AssociatedWhitespaceRules {
+	None = 0b000,
+	/// If the token before this one is not whitespace, then whitespace must be placed before this token.
+	EnforceBefore = 0b100,
+	/// The token must produce a whitespace token to separate it and the next token (if the next token is not already
+	/// whitespace).
+	EnforceAfter = 0b010,
+	/// The token after this one must not be whitespace, doing so would result in breaking a higher level association with
+	/// the adjacent token (for example a pseudo class such as `:hover`).
+	BanAfter = 0b001,
+}
+
+impl AssociatedWhitespaceRules {
+	pub(crate) const fn from_bits(bits: u8) -> Self {
+		Self { bits: bits & 0b111 }
+	}
+
+	pub(crate) const fn to_bits(self) -> u8 {
+		self.bits
+	}
+}
+
+#[test]
+fn size_test() {
+	assert_eq!(::std::mem::size_of::<AssociatedWhitespaceRules>(), 1);
+}
+
+#[test]
+fn test_from_bits() {
+	assert!(
+		AssociatedWhitespaceRules::from_bits(AssociatedWhitespaceRules::EnforceBefore.bits)
+			.contains(AssociatedWhitespaceRules::EnforceBefore)
+	);
+	assert!(
+		AssociatedWhitespaceRules::from_bits(AssociatedWhitespaceRules::EnforceAfter.bits)
+			.contains(AssociatedWhitespaceRules::EnforceAfter)
+	);
+	assert!(
+		AssociatedWhitespaceRules::from_bits(AssociatedWhitespaceRules::BanAfter.bits)
+			.contains(AssociatedWhitespaceRules::BanAfter)
+	);
+}

--- a/crates/css_lexer/src/cursor.rs
+++ b/crates/css_lexer/src/cursor.rs
@@ -1,5 +1,6 @@
 use crate::{
-	CommentStyle, DimensionUnit, Kind, KindSet, QuoteStyle, SourceOffset, Span, ToSpan, Token,
+	AssociatedWhitespaceRules, CommentStyle, DimensionUnit, Kind, KindSet, QuoteStyle, SourceOffset, Span, ToSpan,
+	Token,
 	span::SpanContents,
 	syntax::{ParseEscape, is_newline},
 };
@@ -324,6 +325,21 @@ impl Cursor {
 		}
 		str.into_bump_str()
 	}
+
+	pub fn with_quotes(&self, quote_style: QuoteStyle) -> Cursor {
+		if *self == quote_style || *self != Kind::String {
+			return *self;
+		}
+		Cursor::new(self.offset(), self.token().with_quotes(quote_style))
+	}
+
+	pub fn with_associated_whitespace(&self, rules: AssociatedWhitespaceRules) -> Cursor {
+		debug_assert!(self.1 == KindSet::DELIM_LIKE);
+		if self.1.associated_whitespace().to_bits() == rules.to_bits() {
+			return *self;
+		}
+		Cursor::new(self.offset(), self.token().with_associated_whitespace(rules))
+	}
 }
 
 impl From<Cursor> for Token {
@@ -394,6 +410,12 @@ impl From<Cursor> for QuoteStyle {
 
 impl PartialEq<QuoteStyle> for Cursor {
 	fn eq(&self, other: &QuoteStyle) -> bool {
+		self.1 == *other
+	}
+}
+
+impl PartialEq<AssociatedWhitespaceRules> for Cursor {
+	fn eq(&self, other: &AssociatedWhitespaceRules) -> bool {
 		self.1 == *other
 	}
 }

--- a/crates/css_lexer/src/kindset.rs
+++ b/crates/css_lexer/src/kindset.rs
@@ -49,6 +49,20 @@ impl KindSet {
 	pub const LEFT_CURLY_RIGHT_PAREN_COMMA_OR_SEMICOLON: KindSet =
 		KindSet::new(&[Kind::LeftCurly, Kind::RightParen, Kind::Comma, Kind::Semicolon]);
 
+	/// A [KindSet] that matches any single character token, such as [Kind::Delim] or [Kind::Colon] - [Kind::RightCurly].
+	pub const DELIM_LIKE: KindSet = KindSet::new(&[
+		Kind::Delim,
+		Kind::Colon,
+		Kind::Semicolon,
+		Kind::Comma,
+		Kind::LeftSquare,
+		Kind::RightSquare,
+		Kind::LeftParen,
+		Kind::RightParen,
+		Kind::LeftCurly,
+		Kind::RightCurly,
+	]);
+
 	/// A [KindSet] that matches _any_ token.
 	pub const ANY: KindSet = KindSet(u32::MAX);
 

--- a/crates/css_lexer/src/lib.rs
+++ b/crates/css_lexer/src/lib.rs
@@ -74,6 +74,7 @@
 //! [1]: https://drafts.csswg.org/css-syntax/#tokenization
 //! [2]: https://en.wikipedia.org/wiki/Undefined_behavior
 
+mod associated_whitespace_rules;
 mod comment_style;
 mod constants;
 mod cursor;
@@ -90,6 +91,7 @@ mod syntax;
 mod token;
 mod whitespace_style;
 
+pub use associated_whitespace_rules::AssociatedWhitespaceRules;
 pub use comment_style::CommentStyle;
 pub use cursor::Cursor;
 pub use dimension_unit::DimensionUnit;

--- a/crates/css_parse/src/cursor_pretty_write_sink.rs
+++ b/crates/css_parse/src/cursor_pretty_write_sink.rs
@@ -1,4 +1,7 @@
-use crate::{Cursor, CursorSink, Kind, KindSet, QuoteStyle, SourceCursor, SourceCursorSink, Token, Whitespace};
+use crate::{
+	AssociatedWhitespaceRules, Cursor, CursorSink, Kind, KindSet, QuoteStyle, SourceCursor, SourceCursorSink, Token,
+	Whitespace,
+};
 use core::fmt::{Result, Write};
 
 /// This is a [CursorSink] that wraps a Writer (`impl fmt::Write`) and on each [CursorSink::append()] call, will write
@@ -30,12 +33,14 @@ impl<'a, T: Write> CursorPrettyWriteSink<'a, T> {
 		// CSS demands it
 		first.needs_separator_for(second)
 		// It's a kind which might like some space around it.
-		|| (second != Kind::Whitespace && (first == SPACE_AFTER_KINDSET || first == '>' || first == '<'))
+		|| (second != Kind::Whitespace && (first == SPACE_AFTER_KINDSET || first == '>' || first == '<' || first == '+' || first == '-'))
 	}
 
 	fn space_after(first: Token, second: Token) -> bool {
 		// It's a kind which might like some space around it.
-		first != Kind::Whitespace && (second == SPACE_BEFORE_KINDSET || second == '>' || second == '<')
+		first != Kind::Whitespace
+			&& first != AssociatedWhitespaceRules::BanAfter
+			&& (second == SPACE_BEFORE_KINDSET || second == '>' || second == '<')
 	}
 
 	fn newline_after(first: Token, second: Token) -> bool {

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -274,7 +274,8 @@
 
 // Re-export commonly used components from css_lexer:
 pub use css_lexer::{
-	Cursor, DimensionUnit, Kind, KindSet, PairWise, QuoteStyle, SourceOffset, Span, ToSpan, Token, Whitespace,
+	AssociatedWhitespaceRules, Cursor, DimensionUnit, Kind, KindSet, PairWise, QuoteStyle, SourceOffset, Span, ToSpan,
+	Token, Whitespace,
 };
 
 mod comparison;

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -43,6 +43,14 @@ macro_rules! define_kinds {
 			pub const fn dummy() -> Self {
 				Self($crate::Cursor::dummy($crate::Token::dummy($crate::Kind::$ident)))
 			}
+
+			pub fn associated_whitespace(&self) -> $crate::AssociatedWhitespaceRules {
+				self.0.token().associated_whitespace()
+			}
+
+			pub fn with_associated_whitespace(&self, rules: $crate::AssociatedWhitespaceRules) -> Self {
+				Self(self.0.with_associated_whitespace(rules))
+			}
 		}
 
 		impl $crate::ToCursors for $ident {


### PR DESCRIPTION
Rules around whitespace in CSS are a little complex, as they're often contextual. In
https://github.com/csskit/csskit/pull/388 we spotted a bug where `calc(100vh - 68px)` would be potentially re-serialized as ``calc(100vh-68px)` which is invalid, and while that fix was proper, it didn't tell a complete story of some of the complexities around whitespace, especially with regard to re-serializing in different modes (such as a "prettier" version vs a "compact" version.

This change introduces more context embedded into the Tokens themselves, as an AssociatedWhitespaceRules set of bitflags. These bitflags determine the rules for when whitespace must be enforced either side of a delimiter, which can be more strictly enforced inside of a set of `ComponentValues`, or more loosely applied in other places. It also allows for us to ban whitespace for delim-ident adjacent tokens such as `:hover`, `::before`, `$var` which would break if a "prettier" formatter were to try and separate with whitespace.

Overall this provides a small but useful change which we can leverage more in css_ast as the need arises, but this in of
itself also should alleviate some issues like the bugs spotted in https://github.com/csskit/csskit/pull/388 in a more
robust but also more flexible manner.
