### PR TITLE
move SourceCursor into css_lexer & refine

### DIFF
--- a/crates/css_lexer/src/cursor.rs
+++ b/crates/css_lexer/src/cursor.rs
@@ -1,21 +1,18 @@
 use crate::{
 	AssociatedWhitespaceRules, CommentStyle, DimensionUnit, Kind, KindSet, QuoteStyle, SourceOffset, Span, ToSpan,
 	Token,
-	span::SpanContents,
 	syntax::{ParseEscape, is_newline},
 };
 use bumpalo::{Bump, collections::String};
 use std::{char::REPLACEMENT_CHARACTER, fmt};
 
 /// Wraps [Token] with a [SourceOffset], allows it to reason about the character data of the source text.
-///
-///
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cursor(SourceOffset, Token);
 
 impl Cursor {
-	pub const DUMMY_SITE_NUMBER_ZERO: Cursor = Cursor(SourceOffset::DUMMY, Token::NUMBER_ZERO);
-	pub const EMPTY: Cursor = Cursor(SourceOffset::ZERO, Token::EMPTY);
+	pub const DUMMY_SITE_NUMBER_ZERO: Self = Self(SourceOffset::DUMMY, Token::NUMBER_ZERO);
+	pub const EMPTY: Self = Self(SourceOffset::ZERO, Token::EMPTY);
 
 	#[inline(always)]
 	pub const fn new(offset: SourceOffset, token: Token) -> Self {
@@ -51,7 +48,7 @@ impl Cursor {
 	}
 
 	#[inline(always)]
-	pub fn len(&self) -> u32 {
+	pub const fn len(&self) -> u32 {
 		self.token().len()
 	}
 
@@ -129,13 +126,8 @@ impl Cursor {
 	}
 
 	#[inline(always)]
-	pub fn span_contents<'a>(&self, str: &'a str) -> SpanContents<'a> {
-		self.span().span_contents(str)
-	}
-
-	#[inline(always)]
 	pub fn str_slice<'a>(&self, str: &'a str) -> &'a str {
-		self.span_contents(str).contents()
+		&str[(self.offset().0 as usize)..(self.end_offset().0 as usize)]
 	}
 
 	pub fn eq_ignore_ascii_case<'a>(&self, source: &'a str, other: &'a str) -> bool {
@@ -326,19 +318,19 @@ impl Cursor {
 		str.into_bump_str()
 	}
 
-	pub fn with_quotes(&self, quote_style: QuoteStyle) -> Cursor {
+	pub fn with_quotes(&self, quote_style: QuoteStyle) -> Self {
 		if *self == quote_style || *self != Kind::String {
 			return *self;
 		}
-		Cursor::new(self.offset(), self.token().with_quotes(quote_style))
+		Self::new(self.offset(), self.token().with_quotes(quote_style))
 	}
 
-	pub fn with_associated_whitespace(&self, rules: AssociatedWhitespaceRules) -> Cursor {
+	pub fn with_associated_whitespace(&self, rules: AssociatedWhitespaceRules) -> Self {
 		debug_assert!(self.1 == KindSet::DELIM_LIKE);
 		if self.1.associated_whitespace().to_bits() == rules.to_bits() {
 			return *self;
 		}
-		Cursor::new(self.offset(), self.token().with_associated_whitespace(rules))
+		Self::new(self.offset(), self.token().with_associated_whitespace(rules))
 	}
 }
 

--- a/crates/css_lexer/src/dimension_unit.rs
+++ b/crates/css_lexer/src/dimension_unit.rs
@@ -101,7 +101,7 @@ impl DimensionUnit {
 		self == &Self::Unknown
 	}
 
-	pub fn len(&self) -> u32 {
+	pub const fn len(&self) -> u32 {
 		match self {
 			Self::Unknown => 0,
 			Self::Percent | Self::Q | Self::S | Self::X => 1,
@@ -161,10 +161,8 @@ impl DimensionUnit {
 			| Self::Cqmin => 5,
 		}
 	}
-}
 
-impl From<u8> for DimensionUnit {
-	fn from(value: u8) -> Self {
+	pub(crate) const fn from_u8(value: u8) -> Self {
 		let unit = match value {
 			1 => Self::Cap,
 			2 => Self::Ch,
@@ -232,8 +230,14 @@ impl From<u8> for DimensionUnit {
 			64 => Self::X,
 			_ => Self::Unknown,
 		};
-		debug_assert!(unit as u8 == value, "{:#010b} != {:#010b} ({:?})", unit as u8, value, unit);
+		debug_assert!(unit as u8 == value, "DimensionUnit::from_u8 failed as unit was not equal to value");
 		unit
+	}
+}
+
+impl From<u8> for DimensionUnit {
+	fn from(value: u8) -> Self {
+		Self::from_u8(value)
 	}
 }
 

--- a/crates/css_lexer/src/lib.rs
+++ b/crates/css_lexer/src/lib.rs
@@ -85,6 +85,7 @@ mod kindset;
 mod pairwise;
 mod private;
 mod quote_style;
+mod source_cursor;
 mod source_offset;
 mod span;
 mod syntax;
@@ -100,8 +101,9 @@ pub use kind::Kind;
 pub use kindset::KindSet;
 pub use pairwise::PairWise;
 pub use quote_style::QuoteStyle;
+pub use source_cursor::SourceCursor;
 pub use source_offset::SourceOffset;
-pub use span::{Span, SpanContents, ToSpan};
+pub use span::{Span, ToSpan};
 pub use token::Token;
 pub use whitespace_style::Whitespace;
 

--- a/crates/css_lexer/src/source_cursor.rs
+++ b/crates/css_lexer/src/source_cursor.rs
@@ -1,0 +1,115 @@
+use crate::{
+	AssociatedWhitespaceRules, CommentStyle, Cursor, Kind, KindSet, QuoteStyle, SourceOffset, Span, ToSpan, Token,
+};
+use std::fmt::{Display, Formatter, Result};
+
+/// Wraps [Cursor] with a [str] that represents the underlying character data for this cursor.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SourceCursor<'a> {
+	cursor: Cursor,
+	source: &'a str,
+}
+
+impl<'a> ToSpan for SourceCursor<'a> {
+	fn to_span(&self) -> Span {
+		self.cursor.to_span()
+	}
+}
+
+impl<'a> Display for SourceCursor<'a> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		match self.token().kind() {
+			Kind::Eof => Ok(()),
+			// It is important to manually write out quotes for 2 reasons:
+			//  1. The quote style can be mutated from the source string (such as the case of normalising/switching quotes.
+			//  2. Some strings may not have the closing quote, which should be corrected.
+			Kind::String => match self.token().quote_style() {
+				QuoteStyle::Single => {
+					let inner =
+						&self.source[1..(self.token().len() as usize) - self.token().has_close_quote() as usize];
+					write!(f, "'{inner}'")
+				}
+				QuoteStyle::Double => {
+					let inner =
+						&self.source[1..(self.token().len() as usize) - self.token().has_close_quote() as usize];
+					write!(f, "\"{inner}\"")
+				}
+				// Strings must always be quoted!
+				QuoteStyle::None => unreachable!(),
+			},
+			Kind::Delim
+			| Kind::Colon
+			| Kind::Semicolon
+			| Kind::Comma
+			| Kind::LeftSquare
+			| Kind::LeftParen
+			| Kind::RightSquare
+			| Kind::RightParen
+			| Kind::LeftCurly
+			| Kind::RightCurly => self.token().char().unwrap().fmt(f),
+			_ => f.write_str(self.source),
+		}
+	}
+}
+
+impl<'a> SourceCursor<'a> {
+	pub const SPACE: SourceCursor<'static> = SourceCursor::from(Cursor::new(SourceOffset(0), Token::SPACE), " ");
+	pub const TAB: SourceCursor<'static> = SourceCursor::from(Cursor::new(SourceOffset(0), Token::TAB), "\t");
+	pub const NEWLINE: SourceCursor<'static> = SourceCursor::from(Cursor::new(SourceOffset(0), Token::NEWLINE), "\n");
+
+	#[inline(always)]
+	pub const fn from(cursor: Cursor, source: &'a str) -> Self {
+		debug_assert!(
+			(cursor.len() as usize) == source.len(),
+			"A SourceCursor should be constructed with a source that matches the length of the cursor!"
+		);
+		Self { cursor, source }
+	}
+
+	#[inline(always)]
+	pub const fn cursor(&self) -> Cursor {
+		self.cursor
+	}
+
+	#[inline(always)]
+	pub const fn token(&self) -> Token {
+		self.cursor.token()
+	}
+
+	#[inline(always)]
+	pub const fn source(&self) -> &'a str {
+		self.source
+	}
+
+	pub fn with_quotes(&self, quote_style: QuoteStyle) -> Self {
+		Self::from(self.cursor.with_quotes(quote_style), self.source)
+	}
+
+	pub fn with_associated_whitespace(&self, rules: AssociatedWhitespaceRules) -> Self {
+		Self::from(self.cursor.with_associated_whitespace(rules), self.source)
+	}
+}
+
+impl PartialEq<Kind> for SourceCursor<'_> {
+	fn eq(&self, other: &Kind) -> bool {
+		self.token() == *other
+	}
+}
+
+impl PartialEq<CommentStyle> for SourceCursor<'_> {
+	fn eq(&self, other: &CommentStyle) -> bool {
+		self.token() == *other
+	}
+}
+
+impl From<SourceCursor<'_>> for KindSet {
+	fn from(cursor: SourceCursor<'_>) -> Self {
+		cursor.token().into()
+	}
+}
+
+impl PartialEq<KindSet> for SourceCursor<'_> {
+	fn eq(&self, other: &KindSet) -> bool {
+		self.token() == *other
+	}
+}

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -274,8 +274,8 @@
 
 // Re-export commonly used components from css_lexer:
 pub use css_lexer::{
-	AssociatedWhitespaceRules, Cursor, DimensionUnit, Kind, KindSet, PairWise, QuoteStyle, SourceOffset, Span, ToSpan,
-	Token, Whitespace,
+	AssociatedWhitespaceRules, Cursor, DimensionUnit, Kind, KindSet, PairWise, QuoteStyle, SourceCursor, SourceOffset,
+	Span, ToSpan, Token, Whitespace,
 };
 
 mod comparison;

--- a/crates/csskit_lsp/src/service.rs
+++ b/crates/csskit_lsp/src/service.rs
@@ -87,8 +87,7 @@ impl File {
 										.sorted_by(|a, b| Ord::cmp(&a.span(), &b.span()))
 										.map(|h| {
 											// TODO: figure out a more efficient way to get line/col
-											let span_contents = h.span().span_contents(&string);
-											let (line, start) = span_contents.line_and_column();
+											let (line, start) = h.span().line_and_column(&string);
 											let delta_line: Line = line - current_line;
 											current_line = line;
 											let delta_start: Col =


### PR DESCRIPTION
SourceCursor is quite useful but one issue is that the span data becomes inconsistent with overlays, due to the way a SourceCursor reads into its string data. So this change alters SourceCursor so that the span data is not related to the string slice, and instead the string slice holds the entirety of the character data for that token (as opposed to being a superset).

This change also meant that we could decouple Cursor from its ability to write out data, and instead push more of that responsibility into SourceCursor. This _also_ means getting rid of SpanContents which was an awkward type mostly just used to get the line & column data. SourceCursor replaces SpanContents's intent beyond that.

This then _also_ makes SourceCursor better placed in css_lexer instead of css_parse, so that also happens in this
change.

Lastly, all downstream APIs need updating. Mostly small API changes, but also making some functions const.
