### PR TITLE
css_ast: Clean up various types, using derive(Parse).

### DIFF
--- a/crates/css_ast/src/functions/easing_functions.rs
+++ b/crates/css_ast/src/functions/easing_functions.rs
@@ -143,7 +143,7 @@ function_set!(pub struct CubicBezierFunctionName "cubic-bezier");
 #[visit(self)]
 pub struct CubicBezierFunction(Function<CubicBezierFunctionName, CubicBezierFunctionParams>);
 
-#[derive(Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct CubicBezierFunctionParams {
 	x1: T![Number],
@@ -153,19 +153,6 @@ pub struct CubicBezierFunctionParams {
 	y1: T![Number],
 	c3: Option<T![,]>,
 	y2: T![Number],
-}
-
-impl<'a> Parse<'a> for CubicBezierFunctionParams {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let x1 = p.parse::<T![Number]>()?;
-		let c1 = p.parse_if_peek::<T![,]>()?;
-		let x2 = p.parse::<T![Number]>()?;
-		let c2 = p.parse_if_peek::<T![,]>()?;
-		let y1 = p.parse::<T![Number]>()?;
-		let c3 = p.parse_if_peek::<T![,]>()?;
-		let y2 = p.parse::<T![Number]>()?;
-		Ok(Self { x1, c1, x2, c2, y1, c3, y2 })
-	}
 }
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -1,4 +1,3 @@
-use bumpalo::collections::Vec;
 use css_parse::{
 	Build, CommaSeparated, Cursor, KindSet, Parse, Parser, Result as ParserResult, T, function_set, keyword_set,
 };
@@ -157,27 +156,13 @@ pub struct LangPseudoFunction<'a> {
 
 #[derive(ToSpan, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct LangValues<'a>(pub Vec<'a, LangValue>);
+pub struct LangValues<'a>(pub CommaSeparated<'a, LangValue>);
 
-#[derive(ToSpan, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum LangValue {
-	Ident(T![Ident], Option<T![,]>),
-	String(T![String], Option<T![,]>),
-}
-
-impl<'a> Parse<'a> for LangValue {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		if p.peek::<T![Ident]>() {
-			let value = p.parse::<T![Ident]>()?;
-			let comma = p.parse_if_peek::<T![,]>()?;
-			Ok(Self::Ident(value, comma))
-		} else {
-			let value = p.parse::<T![String]>()?;
-			let comma = p.parse_if_peek::<T![,]>()?;
-			Ok(Self::String(value, comma))
-		}
-	}
+	Ident(T![Ident]),
+	String(T![String]),
 }
 
 #[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/types/single_transition_property.rs
+++ b/crates/css_ast/src/types/single_transition_property.rs
@@ -1,26 +1,18 @@
 #![allow(warnings)]
-use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, SourceOffset, T, ToCursors};
-use csskit_derives::{Peek, ToCursors, ToSpan, Visitable};
+use css_parse::{T, keyword_set};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+
+keyword_set!(pub struct AllKeyword "all");
 
 // https://drafts.csswg.org/css-transitions-1/#single-transition-property
 // <single-transition-property> = all | <custom-ident>
-#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
 pub enum SingleTransitionProperty {
+	#[parse(keyword = AllKeyword)]
 	All(T![Ident]),
 	CustomIdent(T![Ident]),
-}
-
-impl<'a> Parse<'a> for SingleTransitionProperty {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let ident = p.parse::<T![Ident]>()?;
-		if p.eq_ignore_ascii_case(ident.into(), "all") {
-			return Ok(SingleTransitionProperty::All(ident));
-		}
-
-		Ok(SingleTransitionProperty::CustomIdent(ident))
-	}
 }
 
 #[cfg(test)]

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_animate.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_animate.snap
@@ -656,20 +656,19 @@ expression: result.output.unwrap()
               "offset": 761,
               "len": 1
             },
-            "value": {
-              "values": [
+            "value": [
+              [
                 {
-                  "kind": "Whitespace",
-                  "offset": 762,
-                  "len": 1
+                  "type": "number",
+                  "value": {
+                    "kind": "Number",
+                    "offset": 763,
+                    "len": 1
+                  }
                 },
-                {
-                  "kind": "Number",
-                  "offset": 763,
-                  "len": 1
-                }
+                null
               ]
-            },
+            ],
             "important": null,
             "semicolon": {
               "kind": "Semicolon",

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -474,7 +474,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
           // Single type like #[parse(keyword = Auto)]
           if keyword_variant.path.segments.len() == 1 {
             let keyword_type = &keyword_variant.path.segments.first().unwrap().ident;
-            quote! { <#keyword_type>::peek(p, c) }
+            quote! { <#keyword_type>::peek(p, p.peek_n(1)) }
           } else {
             // Enum variant like #[parse(keyword = FooKeywords::Auto)]
             let keyword_type = keyword_variant


### PR DESCRIPTION
Some quick wins here.
