### PR TITLE
css_ast: Shrink color function size by using CommaOrSlash struct

### DIFF
--- a/crates/css_ast/src/functions/gradient_functions.rs
+++ b/crates/css_ast/src/functions/gradient_functions.rs
@@ -203,7 +203,7 @@ mod tests {
 		assert_eq!(std::mem::size_of::<Gradient>(), 216);
 		assert_eq!(std::mem::size_of::<LinearDirection>(), 44);
 		assert_eq!(std::mem::size_of::<RadialSize>(), 32);
-		assert_eq!(std::mem::size_of::<ColorStopOrHint>(), 176);
+		assert_eq!(std::mem::size_of::<ColorStopOrHint>(), 160);
 	}
 
 	#[test]

--- a/crates/css_ast/src/functions/stripes_function.rs
+++ b/crates/css_ast/src/functions/stripes_function.rs
@@ -54,7 +54,7 @@ mod tests {
 	#[test]
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<StripesFunction>(), 64);
-		assert_eq!(std::mem::size_of::<ColorStripe>(), 176);
+		assert_eq!(std::mem::size_of::<ColorStripe>(), 160);
 	}
 
 	#[test]

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -168,8 +168,8 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<Property>(), 400);
-		assert_eq!(std::mem::size_of::<StyleValue>(), 328);
+		assert_eq!(std::mem::size_of::<Property>(), 368);
+		assert_eq!(std::mem::size_of::<StyleValue>(), 296);
 	}
 
 	#[test]

--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -301,7 +301,7 @@ mod tests {
 		assert_eq!(std::mem::size_of::<BlockSizeContainerFeature>(), 124);
 		assert_eq!(std::mem::size_of::<AspectRatioContainerFeature>(), 180);
 		assert_eq!(std::mem::size_of::<OrientationContainerFeature>(), 64);
-		assert_eq!(std::mem::size_of::<StyleQuery>(), 416);
+		assert_eq!(std::mem::size_of::<StyleQuery>(), 384);
 		assert_eq!(std::mem::size_of::<ScrollStateQuery>(), 88);
 		assert_eq!(std::mem::size_of::<ScrollStateFeature>(), 68);
 		assert_eq!(std::mem::size_of::<ScrollableScrollStateFeature>(), 64);

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -226,8 +226,8 @@ mod tests {
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<ContainerRule>(), 128);
 		assert_eq!(std::mem::size_of::<ContainerConditionList>(), 32);
-		assert_eq!(std::mem::size_of::<ContainerCondition>(), 448);
-		assert_eq!(std::mem::size_of::<ContainerQuery>(), 432);
+		assert_eq!(std::mem::size_of::<ContainerCondition>(), 416);
+		assert_eq!(std::mem::size_of::<ContainerQuery>(), 400);
 	}
 
 	#[test]

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -88,7 +88,7 @@ mod tests {
 	#[test]
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<FontFaceRule>(), 96);
-		assert_eq!(std::mem::size_of::<FontFaceRuleStyleValue>(), 328);
+		assert_eq!(std::mem::size_of::<FontFaceRuleStyleValue>(), 296);
 		assert_eq!(std::mem::size_of::<FontFaceRuleBlock>(), 64);
 	}
 

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -203,8 +203,8 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<SupportsRule>(), 544);
-		assert_eq!(std::mem::size_of::<SupportsCondition>(), 448);
+		assert_eq!(std::mem::size_of::<SupportsRule>(), 512);
+		assert_eq!(std::mem::size_of::<SupportsCondition>(), 416);
 		assert_eq!(std::mem::size_of::<SupportsRuleBlock>(), 64);
 	}
 

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -152,7 +152,7 @@ mod tests {
 	#[test]
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<StyleSheet>(), 32);
-		assert_eq!(std::mem::size_of::<Rule>(), 544);
+		assert_eq!(std::mem::size_of::<Rule>(), 512);
 	}
 
 	#[test]

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -76,7 +76,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<Color>(), 160);
+		assert_eq!(std::mem::size_of::<Color>(), 144);
 	}
 
 	#[test]
@@ -107,8 +107,6 @@ mod tests {
 		assert_parse!(Color, "rgb(255,255,255,)");
 		// Using legacy comma syntax but with /
 		assert_parse!(Color, "rgb(255,255,255/0.5)");
-		// Using both legacy commas and also a /
-		assert_parse!(Color, "rgba(255,255,255,/0.5)");
 		// Missing a comma
 		assert_parse!(Color, "rgb(29,164 192,95%)");
 	}

--- a/crates/css_ast/src/types/shadow.rs
+++ b/crates/css_ast/src/types/shadow.rs
@@ -59,7 +59,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<Shadow>(), 240);
+		assert_eq!(std::mem::size_of::<Shadow>(), 224);
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/backgrounds/impls.rs
+++ b/crates/css_ast/src/values/backgrounds/impls.rs
@@ -9,7 +9,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<BackgroundColorStyleValue>(), 160);
+		assert_eq!(std::mem::size_of::<BackgroundColorStyleValue>(), 144);
 		// assert_eq!(std::mem::size_of::<BackgroundImageStyleValue>(), 1);
 		assert_eq!(std::mem::size_of::<BackgroundRepeatStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<BackgroundAttachmentStyleValue>(), 32);

--- a/crates/css_ast/src/values/borders/impls.rs
+++ b/crates/css_ast/src/values/borders/impls.rs
@@ -9,17 +9,17 @@ mod tests {
 
 	#[test]
 	pub fn size_test() {
-		assert_eq!(std::mem::size_of::<BorderTopColorStyleValue>(), 160);
-		assert_eq!(std::mem::size_of::<BorderRightColorStyleValue>(), 160);
-		assert_eq!(std::mem::size_of::<BorderBottomColorStyleValue>(), 160);
-		assert_eq!(std::mem::size_of::<BorderLeftColorStyleValue>(), 160);
-		assert_eq!(std::mem::size_of::<BorderBlockStartColorStyleValue>(), 160);
-		assert_eq!(std::mem::size_of::<BorderBlockEndColorStyleValue>(), 160);
-		assert_eq!(std::mem::size_of::<BorderInlineStartColorStyleValue>(), 160);
-		assert_eq!(std::mem::size_of::<BorderInlineEndColorStyleValue>(), 160);
+		assert_eq!(std::mem::size_of::<BorderTopColorStyleValue>(), 144);
+		assert_eq!(std::mem::size_of::<BorderRightColorStyleValue>(), 144);
+		assert_eq!(std::mem::size_of::<BorderBottomColorStyleValue>(), 144);
+		assert_eq!(std::mem::size_of::<BorderLeftColorStyleValue>(), 144);
+		assert_eq!(std::mem::size_of::<BorderBlockStartColorStyleValue>(), 144);
+		assert_eq!(std::mem::size_of::<BorderBlockEndColorStyleValue>(), 144);
+		assert_eq!(std::mem::size_of::<BorderInlineStartColorStyleValue>(), 144);
+		assert_eq!(std::mem::size_of::<BorderInlineEndColorStyleValue>(), 144);
 		// assert_eq!(std::mem::size_of::<BorderColorStyleValue>(), 1);
-		assert_eq!(std::mem::size_of::<BorderBlockColorStyleValue>(), 320);
-		assert_eq!(std::mem::size_of::<BorderInlineColorStyleValue>(), 320);
+		assert_eq!(std::mem::size_of::<BorderBlockColorStyleValue>(), 288);
+		assert_eq!(std::mem::size_of::<BorderInlineColorStyleValue>(), 288);
 		assert_eq!(std::mem::size_of::<BorderTopStyleStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<BorderRightStyleStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<BorderBottomStyleStyleValue>(), 16);
@@ -39,16 +39,16 @@ mod tests {
 		assert_eq!(std::mem::size_of::<BorderInlineEndWidthStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<BorderBlockWidthStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<BorderInlineWidthStyleValue>(), 32);
-		assert_eq!(std::mem::size_of::<BorderTopStyleValue>(), 192);
-		assert_eq!(std::mem::size_of::<BorderRightStyleValue>(), 192);
-		assert_eq!(std::mem::size_of::<BorderBottomStyleValue>(), 192);
-		assert_eq!(std::mem::size_of::<BorderLeftStyleValue>(), 192);
-		assert_eq!(std::mem::size_of::<BorderBlockStartStyleValue>(), 192);
-		assert_eq!(std::mem::size_of::<BorderBlockEndStyleValue>(), 192);
-		assert_eq!(std::mem::size_of::<BorderInlineStartStyleValue>(), 192);
-		assert_eq!(std::mem::size_of::<BorderInlineEndStyleValue>(), 192);
-		assert_eq!(std::mem::size_of::<BorderBlockStyleValue>(), 192);
-		assert_eq!(std::mem::size_of::<BorderInlineStyleValue>(), 192);
+		assert_eq!(std::mem::size_of::<BorderTopStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<BorderRightStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<BorderBottomStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<BorderLeftStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<BorderBlockStartStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<BorderBlockEndStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<BorderInlineStartStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<BorderInlineEndStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<BorderBlockStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<BorderInlineStyleValue>(), 176);
 		assert_eq!(std::mem::size_of::<BorderTopLeftRadiusStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<BorderTopRightRadiusStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<BorderBottomRightRadiusStyleValue>(), 32);

--- a/crates/css_ast/src/values/color/impls.rs
+++ b/crates/css_ast/src/values/color/impls.rs
@@ -5,11 +5,12 @@ pub(crate) use csskit_proc_macro::*;
 #[cfg(test)]
 mod tests {
 	use super::super::*;
+	use crate::{Color, assert_visits};
 	use css_parse::assert_parse;
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<ColorStyleValue>(), 160);
+		assert_eq!(std::mem::size_of::<ColorStyleValue>(), 144);
 		assert_eq!(std::mem::size_of::<OpacityStyleValue>(), 16);
 	}
 

--- a/crates/css_ast/src/values/scrollbars/impls.rs
+++ b/crates/css_ast/src/values/scrollbars/impls.rs
@@ -9,7 +9,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<ScrollbarColorStyleValue>(), 320);
+		assert_eq!(std::mem::size_of::<ScrollbarColorStyleValue>(), 288);
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/text_decor/impls.rs
+++ b/crates/css_ast/src/values/text_decor/impls.rs
@@ -11,11 +11,11 @@ mod tests {
 	pub fn size_test() {
 		// assert_eq!(std::mem::size_of::<TextDecorationLineStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<TextDecorationStyleStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<TextDecorationColorStyleValue>(), 160);
+		assert_eq!(std::mem::size_of::<TextDecorationColorStyleValue>(), 144);
 		// assert_eq!(std::mem::size_of::<TextDecorationStyleValue>(), 16);
 		// assert_eq!(std::mem::size_of::<TextUnderlinePositionStyleValue>(), 16);
 		// assert_eq!(std::mem::size_of::<TextEmphasisStyleStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<TextEmphasisColorStyleValue>(), 160);
+		assert_eq!(std::mem::size_of::<TextEmphasisColorStyleValue>(), 144);
 		// assert_eq!(std::mem::size_of::<TextEmphasisStyleValue>(), 16);
 		// assert_eq!(std::mem::size_of::<TextEmphasisPositionStyleValue>(), 16);
 		// assert_eq!(std::mem::size_of::<TextShadowStyleValue>(), 16);

--- a/crates/css_ast/src/values/ui/impls.rs
+++ b/crates/css_ast/src/values/ui/impls.rs
@@ -9,17 +9,17 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<OutlineStyleValue>(), 192);
+		assert_eq!(std::mem::size_of::<OutlineStyleValue>(), 176);
 		assert_eq!(std::mem::size_of::<OutlineWidthStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<OutlineStyleStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<OutlineColorStyleValue>(), 160);
+		assert_eq!(std::mem::size_of::<OutlineColorStyleValue>(), 144);
 		assert_eq!(std::mem::size_of::<OutlineOffsetStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<ResizeStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<CursorStyleValue>(), 48);
-		assert_eq!(std::mem::size_of::<CaretColorStyleValue>(), 160);
+		assert_eq!(std::mem::size_of::<CaretColorStyleValue>(), 144);
 		assert_eq!(std::mem::size_of::<CaretAnimationStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<CaretShapeStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<CaretStyleValue>(), 192);
+		assert_eq!(std::mem::size_of::<CaretStyleValue>(), 176);
 		// assert_eq!(std::mem::size_of::<NavUpStyleValue>(), 1);
 		// assert_eq!(std::mem::size_of::<NavRightStyleValue>(), 1);
 		// assert_eq!(std::mem::size_of::<NavDownStyleValue>(), 1);
@@ -30,7 +30,7 @@ mod tests {
 		assert_eq!(std::mem::size_of::<InterestDelayStartStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<InterestDelayEndStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<InterestDelayStyleValue>(), 32);
-		assert_eq!(std::mem::size_of::<AccentColorStyleValue>(), 160);
+		assert_eq!(std::mem::size_of::<AccentColorStyleValue>(), 144);
 		assert_eq!(std::mem::size_of::<AppearanceStyleValue>(), 20);
 	}
 

--- a/crates/css_ast/tests/snapshots/popular_snapshots__popular_bootstrap.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__popular_bootstrap.snap
@@ -186607,7 +186607,6 @@ expression: result.output.unwrap()
                                             "offset": 123498,
                                             "len": 1
                                           },
-                                          null,
                                           {
                                             "Some": {
                                               "number": {
@@ -186751,7 +186750,6 @@ expression: result.output.unwrap()
                                             "offset": 123563,
                                             "len": 1
                                           },
-                                          null,
                                           {
                                             "Some": {
                                               "number": {
@@ -186841,7 +186839,6 @@ expression: result.output.unwrap()
                                             "offset": 123594,
                                             "len": 1
                                           },
-                                          null,
                                           {
                                             "Some": {
                                               "number": {
@@ -311179,7 +311176,6 @@ expression: result.output.unwrap()
                       "offset": 209787,
                       "len": 1
                     },
-                    null,
                     {
                       "Some": {
                         "number": {
@@ -311353,7 +311349,6 @@ expression: result.output.unwrap()
                       "offset": 209877,
                       "len": 1
                     },
-                    null,
                     {
                       "Some": {
                         "number": {


### PR DESCRIPTION
RgbFunctions & similar can be represented in the "legacy comma" style, or the style without commas and a `/` for alpha.
The struct for these allowed both the comma and slash to appear simultaneously, but this would be a parse error in browsers. We can reasonably enforce the same level of strictness, which would shrink the struct size for these types, which cascades quite nicely all the way up to StyleValue & Rule, so a worthwhile win.
