### PR TITLE
css_lexer: Fix hex_value parsing

### DIFF
--- a/crates/css_lexer/tests/tests.rs
+++ b/crates/css_lexer/tests/tests.rs
@@ -1177,14 +1177,14 @@ fn tokenizes_weird_url_function_names() {
 fn tokenizes_hex_values_correctly() {
 	let mut lexer = Lexer::new("#ff0");
 	let token = lexer.advance();
-	assert_eq!(token.hex_value(), 0xFF0);
+	assert_eq!(format!("{:x}", token.hex_value()), "ffff00ff");
 	let mut lexer = Lexer::new("#ffg");
 	let token = lexer.advance();
-	assert_eq!(token.hex_value(), 0);
+	assert_eq!(format!("{:x}", token.hex_value()), "0");
 	let mut lexer = Lexer::new("#CAFEBABE");
 	let token = lexer.advance();
-	assert_eq!(token.hex_value(), 0xCAFEBABE);
+	assert_eq!(format!("{:x}", token.hex_value()), "cafebabe");
 	let mut lexer = Lexer::new("#CAFE BABE");
 	let token = lexer.advance();
-	assert_eq!(token.hex_value(), 0xCAFE);
+	assert_eq!(format!("{:x}", token.hex_value()), "ccaaffee");
 }


### PR DESCRIPTION
https://github.com/csskit/csskit/pull/399 tried to eagerly parse hex codes and stuff it in token data, but the
implementation was naive and quite broken. It collected the hex characters but did not "pad" for shorter values such as
when the alpha channel was missing (in 3 and 6 character hex codes) or when the letters were "short form" (in 3 and
4 character hex codes).

This changes fixes the parsing to be more accurate, so that the resulting hex values can actually reproduce the
underlying hex code.
