### PR TITLE
csskit_derives: Use syn "full" feature.

### DIFF
--- a/crates/csskit_derives/Cargo.toml
+++ b/crates/csskit_derives/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 proc-macro = true
 
 [dependencies]
-syn = { workspace = true, features = ["extra-traits"] }
+syn = { workspace = true, features = ["extra-traits", "full"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
csskit_derives is currently failing to build with the default feature set because of this.
