### PR TITLE
ci: Build & Test with default features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,22 @@ jobs:
           shared-key: test-${{ matrix.target }}
       - run: cargo test --all-features
 
+  build_default:
+    name: Build & Test with default features
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: "true"
+      - name: Mise
+        uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+      - name: Rust cache
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 #v2.8.0
+        with:
+          shared-key: global-rust-cache
+      - run: cargo test
+
   clippy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
In https://github.com/csskit/csskit/pull/410 we learned that the release build was failing due to default features, so
this adds a `cargo test` without the `--all-features` flag to ensure that doesn't happen again.
