### PR TITLE
csskit: Tidy up commands more.

### DIFF
--- a/crates/csskit/src/commands/check.rs
+++ b/crates/csskit/src/commands/check.rs
@@ -1,5 +1,4 @@
-use super::GlobalConfig;
-use crate::CliResult;
+use crate::{CliResult, GlobalConfig};
 use clap::Args;
 
 /// Report potential issues around some CSS files

--- a/crates/csskit/src/commands/dbg_parse.rs
+++ b/crates/csskit/src/commands/dbg_parse.rs
@@ -1,46 +1,38 @@
-use super::GlobalConfig;
-use crate::CliResult;
+use crate::{CliResult, GlobalConfig, InputArgs};
 use bumpalo::Bump;
 use clap::Args;
 use css_ast::StyleSheet;
 use css_parse::parse;
 use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
-use std::io::{Read, stdin};
+use std::io::Read;
 
 /// Show the debug output for a parsed file
 #[derive(Debug, Args)]
 pub struct DbgParse {
-	/// A CSS file to parse.
-	#[arg(value_parser)]
-	input: Option<String>,
+	#[command(flatten)]
+	content: InputArgs,
 }
 
 impl DbgParse {
-	pub fn run(&self, config: GlobalConfig) -> CliResult {
-		let GlobalConfig { .. } = config;
-		let DbgParse { input } = self;
-		let file = if let Some(f) = input { f } else { &"-".to_owned() };
-		let source_string = if file == "-" {
-			let mut buffer = String::new();
-			stdin().read_to_string(&mut buffer)?;
-			buffer
-		} else {
-			std::fs::read_to_string(file)?
-		};
-		let source_text = source_string.as_str();
-		println!("{source_text}");
+	pub fn run(&self, _config: GlobalConfig) -> CliResult {
+		let DbgParse { content } = self;
 		let bump = Bump::default();
-		let result = parse!(in bump &source_text as StyleSheet);
-		if let Some(stylesheet) = &result.output {
-			println!("{stylesheet:#?}");
-		} else {
-			let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
-			for err in result.errors {
-				let mut report = String::new();
-				let named = NamedSource::new(file, source_string.clone());
-				let err = err.with_source_code(named);
-				handler.render_report(&mut report, err.as_ref())?;
-				println!("{report}");
+		for (file_name, mut source) in content.sources()? {
+			let mut source_string = String::new();
+			source.read_to_string(&mut source_string)?;
+			let source_text = source_string.as_str();
+			let result = parse!(in bump &source_text as StyleSheet);
+			if let Some(stylesheet) = &result.output {
+				println!("{stylesheet:#?}");
+			} else {
+				let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
+				for err in result.errors {
+					let mut report = String::new();
+					let named = NamedSource::new(file_name, source_string.clone());
+					let err = err.with_source_code(named);
+					handler.render_report(&mut report, err.as_ref())?;
+					println!("{report}");
+				}
 			}
 		}
 		Ok(())

--- a/crates/csskit/src/commands/lsp.rs
+++ b/crates/csskit/src/commands/lsp.rs
@@ -1,5 +1,4 @@
-use super::GlobalConfig;
-use crate::CliResult;
+use crate::{CliResult, GlobalConfig};
 use clap::{Args, crate_version};
 use csskit_lsp::{LSPService, Server};
 use std::io::stderr;

--- a/crates/csskit/src/commands/mod.rs
+++ b/crates/csskit/src/commands/mod.rs
@@ -1,4 +1,4 @@
-use crate::CliResult;
+use crate::{CliResult, GlobalConfig};
 use clap::Subcommand;
 
 mod build;
@@ -7,12 +7,6 @@ mod dbg_parse;
 mod fmt;
 mod lsp;
 mod min;
-
-#[derive(Debug)]
-pub struct GlobalConfig {
-	pub debug: bool,
-	pub color: bool,
-}
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {

--- a/crates/csskit/src/input.rs
+++ b/crates/csskit/src/input.rs
@@ -1,0 +1,71 @@
+use clap::Args;
+use std::{
+	fs::File,
+	io::{BufRead, BufReader, Cursor, Read, Result, StdinLock, stdin},
+};
+
+#[derive(Debug)]
+pub enum InputSource<'a> {
+	Content(Cursor<&'a str>),
+	File(BufReader<File>),
+	Stdin(StdinLock<'a>),
+}
+
+impl<'a> Read for InputSource<'a> {
+	fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+		match self {
+			InputSource::Content(cursor) => cursor.read(buf),
+			InputSource::File(reader) => reader.read(buf),
+			InputSource::Stdin(stdin) => stdin.read(buf),
+		}
+	}
+}
+
+impl<'a> BufRead for InputSource<'a> {
+	fn fill_buf(&mut self) -> Result<&[u8]> {
+		match self {
+			InputSource::Content(cursor) => cursor.fill_buf(),
+			InputSource::File(reader) => reader.fill_buf(),
+			InputSource::Stdin(stdin) => stdin.fill_buf(),
+		}
+	}
+
+	fn consume(&mut self, amt: usize) {
+		match self {
+			InputSource::Content(cursor) => cursor.consume(amt),
+			InputSource::File(reader) => reader.consume(amt),
+			InputSource::Stdin(stdin) => stdin.consume(amt),
+		}
+	}
+}
+
+#[derive(Debug, Args)]
+#[group(required = false, multiple = false)]
+pub struct InputArgs {
+	/// Process CONTENT as CSS. Use this rather than a file or stdin.
+	#[arg(short, long)]
+	content: Option<String>,
+
+	/// A list of input files, or `-` to read from stdin.
+	#[arg(default_values = &["-"])]
+	files: Vec<String>,
+}
+
+impl InputArgs {
+	pub fn sources(&self) -> Result<Vec<(&str, InputSource)>> {
+		if let Some(content) = &self.content {
+			Ok(vec![("<content>", InputSource::Content(Cursor::new(content)))])
+		} else {
+			let mut sources = Vec::new();
+			for file in &self.files {
+				let source = if file == "-" {
+					InputSource::Stdin(stdin().lock())
+				} else {
+					InputSource::File(BufReader::new(File::open(file)?))
+				};
+				sources.push((file.as_str(), source));
+			}
+			Ok(sources)
+		}
+	}
+}


### PR DESCRIPTION
This centralises the file input args and makes it possible to express `-c "css_string"`.
