### PR TITLE
csskit: add new colo(u)rs command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ version = "0.0.0"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
+ "chromashift",
  "console 0.16.0",
  "criterion",
  "css_feature_data",
@@ -546,13 +547,16 @@ dependencies = [
 name = "csskit"
 version = "0.0.1"
 dependencies = [
+ "anstyle",
  "bumpalo",
+ "chromashift",
  "clap",
  "css_ast",
  "css_lexer",
  "css_parse",
  "csskit_highlight",
  "csskit_lsp",
+ "itertools 0.14.0",
  "miette",
  "serde",
  "serde_json",

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -11,13 +11,17 @@ repository.workspace = true
 
 [dependencies]
 css_lexer = { workspace = true }
-css_ast = { workspace = true }
+css_ast = { workspace = true, features = ["chromashift"] }
 css_parse = { workspace = true }
 csskit_lsp = { workspace = true }
 csskit_highlight = { workspace = true, features = ["ansi"] }
+chromashift = { workspace = true, features = ["anstyle"] }
+
+itertools = { workspace = true }
 
 clap = { workspace = true, features = ["derive", "cargo"] }
 miette = { workspace = true }
+anstyle = { workspace = true }
 
 bumpalo = { workspace = true, features = ["collections", "boxed"] }
 

--- a/crates/csskit/src/commands/colors.rs
+++ b/crates/csskit/src/commands/colors.rs
@@ -1,0 +1,282 @@
+use super::GlobalConfig;
+use crate::{CliResult, InputArgs};
+use anstyle::Style;
+use bumpalo::Bump;
+use chromashift::*;
+use clap::Args;
+use css_ast::{Color as ASTColor, StyleSheet, ToChromashift, Visitable};
+use css_parse::parse;
+use itertools::Itertools;
+use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
+use std::{collections::HashSet, io::Read};
+
+struct ColorExtractor {
+	colors: Vec<Color>,
+	seen: HashSet<Hex>,
+}
+
+impl ColorExtractor {
+	fn new() -> Self {
+		Self { colors: Vec::new(), seen: HashSet::new() }
+	}
+}
+
+impl css_ast::Visit for ColorExtractor {
+	fn visit_color(&mut self, color: &ASTColor) {
+		if let Some(raw_color) = color.to_chromashift() {
+			let hex = raw_color.into();
+			if !self.seen.contains(&hex) {
+				self.seen.insert(hex);
+				self.colors.push(raw_color);
+			}
+		}
+	}
+}
+
+fn format_wcag_status(level: WcagLevel) -> &'static str {
+	match level {
+		WcagLevel::Fail => "❌",
+		WcagLevel::AALarge => "⚠️ ",
+		WcagLevel::AA => "✅",
+		WcagLevel::AAA => "🌟",
+	}
+}
+
+fn suggest_wcag_variant<T>(color: T, other: Named, level: WcagLevel, conf: &GlobalConfig)
+where
+	anstyle::RgbColor: From<T>,
+	anstyle::Color: From<T>,
+	T: core::fmt::Display + Copy + WcagColorContrast<T> + From<Named>,
+	Oklch: From<T>,
+	Srgb: From<T>,
+{
+	if let Some(wcag_color) = color.find_minimum_contrast::<Oklch>(other.into(), level) {
+		let style = if conf.colors() {
+			Style::new().fg_color(Some(wcag_color.into())).bg_color(Some(color.into()))
+		} else {
+			Style::new()
+		};
+		let dim = if conf.colors() { Style::new().dimmed() } else { Style::new() };
+		let ratio = wcag_color.wcag_contrast_ratio(other.into());
+		let hex = format!("{}", Hex::from(wcag_color));
+		let desc = level.description();
+		println!(" {style} {hex:9}{style:#}   {ratio:.1}:1 {dim}({desc}){dim:#}");
+	}
+}
+
+fn print_color_block<T>(color: T, config: &GlobalConfig)
+where
+	anstyle::RgbColor: From<T>,
+	anstyle::Color: From<T>,
+	T: core::fmt::Display + Copy,
+{
+	let bg = if config.colors() { Style::new().bg_color(Some(color.into())) } else { Style::new() };
+	println!(" {bg}{:10}{bg:#}  {color}", "");
+}
+
+fn print_color_info(color: Color, config: &GlobalConfig, all: bool, wcag: bool, named: bool) {
+	let a98 = A98Rgb::from(color);
+	let hex = Hex::from(color);
+	let hsv = Hsv::from(color);
+	let hsl = Hsl::from(color);
+	let hwb = Hwb::from(color);
+	let lab = Lab::from(color);
+	let lch = Lch::from(color);
+	let linear = LinearRgb::from(color);
+	let oklab = Oklab::from(color);
+	let oklch = Oklch::from(color);
+	let rgb = Srgb::from(color);
+	let d50 = XyzD50::from(color);
+	let d65 = XyzD65::from(color);
+
+	// let a: Named = n.into();
+
+	let (bg, bold, dim) = if config.colors() {
+		(Style::new().bg_color(Some(color.into())), Style::new().bold(), Style::new().dimmed())
+	} else {
+		(Style::new(), Style::new(), Style::new())
+	};
+
+	println!(" {bg}{:10}{bg:#}  {bold}{color}{bold}", "");
+	println!(" {bg}{:10}{bg:#}", "");
+
+	if !matches!(color, Color::Hex(_)) {
+		print_color_block(hex, config);
+	}
+	if !matches!(color, Color::Srgb(_)) {
+		print_color_block(rgb, config);
+	}
+	if !matches!(color, Color::Oklab(_)) {
+		print_color_block(oklab, config);
+	}
+	if !matches!(color, Color::Oklch(_)) {
+		print_color_block(oklch, config);
+	}
+	if all {
+		if !matches!(color, Color::A98Rgb(_)) {
+			print_color_block(a98, config);
+		}
+		if !matches!(color, Color::Hsv(_)) {
+			print_color_block(hsv, config);
+		}
+		if !matches!(color, Color::Hsl(_)) {
+			print_color_block(hsl, config);
+		}
+		if !matches!(color, Color::Hwb(_)) {
+			print_color_block(hwb, config);
+		}
+		if !matches!(color, Color::Lab(_)) {
+			print_color_block(lab, config);
+		}
+		if !matches!(color, Color::Lch(_)) {
+			print_color_block(lch, config);
+		}
+		if !matches!(color, Color::LinearRgb(_)) {
+			print_color_block(linear, config);
+		}
+		if !matches!(color, Color::XyzD50(_)) {
+			print_color_block(d50, config);
+		}
+		if !matches!(color, Color::XyzD65(_)) {
+			print_color_block(d65, config);
+		}
+	}
+
+	// Show WCAG contrast information
+	if wcag {
+		println!(" {bg}{:10}{bg:#}", "");
+		println!(" {bg}{:10}{bg:#} {bold}WCAG Contrast Analysis{bold:#}", "");
+
+		let white_ratio = rgb.wcag_contrast_ratio(Named::White);
+		let black_ratio = rgb.wcag_contrast_ratio(Named::Black);
+		let white_level = rgb.wcag_level(Named::White);
+		let black_level = rgb.wcag_level(Named::Black);
+
+		let (wcag_white, wcag_black) = if config.colors() {
+			(
+				Style::new().fg_color(Some(Named::White.into())).bg_color(Some(color.into())),
+				Style::new().fg_color(Some(Named::Black.into())).bg_color(Some(color.into())),
+			)
+		} else {
+			(Style::new(), Style::new())
+		};
+
+		println!(
+			" {wcag_white} vs White {wcag_white:#}   {:.1}:1 {dim}({}){dim:#} {}",
+			white_ratio,
+			white_level.description(),
+			format_wcag_status(white_level)
+		);
+		println!(
+			" {wcag_black} vs Black {wcag_black:#}   {:.1}:1 {dim}({}){dim:#} {}",
+			black_ratio,
+			black_level.description(),
+			format_wcag_status(black_level)
+		);
+
+		if white_level != WcagLevel::AA || black_level != WcagLevel::AA {
+			println!(" {bg}{:10}{bg:#}", "");
+			println!(" {bg}{:10}{bg:#} {bold}Minimum contrast{bold:#}", "");
+
+			suggest_wcag_variant(rgb, Named::White, WcagLevel::AA, config);
+			suggest_wcag_variant(rgb, Named::White, WcagLevel::AAA, config);
+			suggest_wcag_variant(rgb, Named::Black, WcagLevel::AA, config);
+			suggest_wcag_variant(rgb, Named::Black, WcagLevel::AAA, config);
+		}
+	}
+
+	if named && !matches!(color, Color::Named(_)) {
+		let colors: Vec<Named> = Named::iter()
+			.filter(|named| named.close_to(color, 10.0))
+			.sorted_by(|a, b| {
+				((a.delta_e(color) * 1000.0).round() as u64).cmp(&((b.delta_e(color) * 1000.0).round() as u64))
+			})
+			.take(2)
+			.collect::<Vec<Named>>();
+		// We have one (near enough) identical colour...
+		if colors.first().is_some_and(|named| named.close_to(color, COLOR_EPSILON)) {
+			println!(" {bg}{:10}{bg:#}", "");
+			println!(" {bg}{:10}{bg:#} {bold}Named color{bold:#}", "");
+			println!(" {bg}{:10}{bg:#} {bold}{}{bold:#}", "", colors.first().unwrap());
+		} else if !colors.is_empty() {
+			println!(" {bg}{:10}{bg:#}", "");
+			println!(" {bg}{:10}{bg:#} {bold}Similar named colors{bold:#}", "");
+			for similar_color in colors {
+				let similar_bg =
+					if config.colors() { Style::new().bg_color(Some(similar_color.into())) } else { Style::new() };
+				println!(" {bg}{:10}{bg:#} {similar_bg}{:10}{similar_bg:#} {similar_color}", "", "");
+			}
+		}
+	}
+
+	println!(" {bg}{:10}{bg:#}", "");
+}
+
+/// Extract the colours from a CSS file.
+#[derive(Debug, Args)]
+pub struct ColorCommand {
+	#[command(flatten)]
+	content: InputArgs,
+
+	/// Print every known syntax for each colour
+	#[arg(short, long, value_parser)]
+	all: bool,
+
+	/// Print WCAG contrast analysis for each colour
+	#[arg(long, value_parser)]
+	wcag: bool,
+
+	/// Print similar Named colours for each colour
+	#[arg(long, value_parser)]
+	named: bool,
+}
+
+impl ColorCommand {
+	pub fn run(&self, config: GlobalConfig) -> CliResult {
+		let bump = Bump::default();
+		let ColorCommand { content, all, wcag, named } = self;
+		let wcag = *wcag || *all;
+		let named = *named || *all;
+		for (file_name, mut source) in content.sources()? {
+			let mut source_string = String::new();
+			source.read_to_string(&mut source_string)?;
+			let source_text = source_string.as_str();
+			if let Some(single_color) = parse!(in bump &source_text as ASTColor).output {
+				if let Some(raw_color) = single_color.to_chromashift() {
+					println!();
+					print_color_info(raw_color, &config, *all, wcag, named);
+					println!();
+				}
+			} else {
+				let result = parse!(in bump &source_text as StyleSheet);
+				if let Some(stylesheet) = result.output {
+					let mut color_visitor = ColorExtractor::new();
+					stylesheet.accept(&mut color_visitor);
+					if color_visitor.colors.is_empty() {
+						eprintln!("No colors found in input");
+					} else {
+						let i = color_visitor.colors.len();
+						println!();
+						eprintln!("Found {i} color{}", if i > 0 { "s" } else { "" });
+						println!();
+						for color in color_visitor.colors {
+							print_color_info(color, &config, *all, wcag, named);
+							println!();
+						}
+						println!();
+					}
+				} else {
+					let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
+					for err in result.errors {
+						let mut report = String::new();
+						let named = NamedSource::new(file_name, source_string.clone());
+						let err = err.with_source_code(named);
+						handler.render_report(&mut report, err.as_ref())?;
+						println!("{report}");
+					}
+				}
+			}
+		}
+		Ok(())
+	}
+}

--- a/crates/csskit/src/commands/mod.rs
+++ b/crates/csskit/src/commands/mod.rs
@@ -3,6 +3,7 @@ use clap::Subcommand;
 
 mod build;
 mod check;
+mod colors;
 mod dbg_parse;
 mod fmt;
 mod lsp;
@@ -18,6 +19,12 @@ pub enum Commands {
 
 	/// Minify CSS files to compress them optimized delivery.
 	Min(min::Min),
+
+	/// Extract the colours from a CSS file.
+	Colors(colors::ColorCommand),
+
+	#[command(hide = true)]
+	Colours(colors::ColorCommand),
 
 	#[command(hide = true)]
 	/// Show the debug output for a parsed file
@@ -37,6 +44,8 @@ impl Commands {
 			Commands::Check(cmd) => cmd.run(config),
 			Commands::Fmt(cmd) => cmd.run(config),
 			Commands::Min(cmd) => cmd.run(config),
+			Commands::Colors(cmd) => cmd.run(config),
+			Commands::Colours(cmd) => cmd.run(config),
 			Commands::DbgParse(cmd) => cmd.run(config),
 			Commands::Build(cmd) => cmd.run(config),
 			Commands::Lsp(cmd) => cmd.run(config),


### PR DESCRIPTION
This new command extracts colours from an AST and uses chromashift to parse them and display them in the terminal.

<img width="848" height="654" alt="A screenshot of the terminal output showing colour info extracted from a CSS file." src="https://github.com/user-attachments/assets/2fbf3a6a-f790-4583-9f47-3c443771bf35" />
