### PR TITLE
csskit: Minor improvements to colors command:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "anstyle",
  "bitmask-enum",
  "bumpalo",
+ "chromashift",
  "console 0.16.0",
  "css_ast",
  "css_lexer",

--- a/crates/chromashift/src/hex.rs
+++ b/crates/chromashift/src/hex.rs
@@ -2,7 +2,7 @@ use crate::Srgb;
 use core::fmt;
 
 /// An Hex representation of the sRGB colour space.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Hex(u32);
 
 fn is_shorthand_byte(byte: u8) -> bool {

--- a/crates/csskit/src/commands/colors.rs
+++ b/crates/csskit/src/commands/colors.rs
@@ -1,5 +1,5 @@
 use super::GlobalConfig;
-use crate::{CliResult, InputArgs};
+use crate::{CliResult, InputArgs, InputSource};
 use anstyle::Style;
 use bumpalo::Bump;
 use chromashift::*;
@@ -74,7 +74,7 @@ where
 	println!(" {bg}{:10}{bg:#}  {color}", "");
 }
 
-fn print_color_info(color: Color, config: &GlobalConfig, all: bool, wcag: bool, named: bool, lc: Option<(u32, u32)>) {
+fn print_color_info(color: Color, config: &GlobalConfig, all: bool, wcag: bool, named: bool, lc: Option<(&'_ str, u32, u32)>) {
 	let a98 = A98Rgb::from(color);
 	let hex = Hex::from(color);
 	let hsv = Hsv::from(color);
@@ -97,8 +97,8 @@ fn print_color_info(color: Color, config: &GlobalConfig, all: bool, wcag: bool, 
 		(Style::new(), Style::new(), Style::new())
 	};
 
-	if let Some((line, column)) = lc {
-		println!(" {bg}{:10}{bg:#}  {bold}{color}{bold} - on line {line}:{column}", "");
+	if let Some((file, line, column)) = lc {
+		println!(" {bg}{:10}{bg:#}  {bold}{color}{bold} - {file}:{line}:{column}", "");
 	} else {
 		println!(" {bg}{:10}{bg:#}  {bold}{color}{bold}", "");
 	}
@@ -245,37 +245,14 @@ impl ColorCommand {
 			let mut source_string = String::new();
 			source.read_to_string(&mut source_string)?;
 			let source_text = source_string.as_str();
-			if let Some(single_color) = parse!(in bump &source_text as ASTColor).output {
-				if let Some(raw_color) = single_color.to_chromashift() {
-					println!();
-					print_color_info(raw_color, &config, *all, wcag, named, None);
-					println!();
-				}
+			let mut color_visitor = ColorExtractor::new();
+			let result = parse!(in bump &source_text as bumpalo::collections::Vec<ASTColor>);
+			if result.output.is_some() && result.errors.is_empty() {
+				result.output.unwrap().accept(&mut color_visitor);
 			} else {
 				let result = parse!(in bump &source_text as StyleSheet);
 				if let Some(stylesheet) = result.output {
-					let mut color_visitor = ColorExtractor::new();
 					stylesheet.accept(&mut color_visitor);
-					if color_visitor.colors.is_empty() {
-						eprintln!("No colors found in input");
-					} else {
-						let i = color_visitor.colors.len();
-						println!();
-						eprintln!("Found {i} color{}", if i > 0 { "s" } else { "" });
-						println!();
-						for (color, span) in color_visitor.colors {
-							print_color_info(
-								color,
-								&config,
-								*all,
-								wcag,
-								named,
-								Some(span.line_and_column(source_text)),
-							);
-							println!();
-						}
-						println!();
-					}
 				} else {
 					let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
 					for err in result.errors {
@@ -286,6 +263,25 @@ impl ColorCommand {
 						println!("{report}");
 					}
 				}
+			}
+			if color_visitor.colors.is_empty() {
+				eprintln!("No colors found in {file_name}");
+			} else {
+				let i = color_visitor.colors.len();
+				println!();
+				eprintln!("Found {i} color{}", if i > 0 { "s" } else { "" });
+				println!();
+				for (color, span) in color_visitor.colors {
+					let lc = if matches!(source, InputSource::File(_)) {
+						let (line, col) = span.line_and_column(source_text);
+						Some((file_name, line, col))
+					} else {
+						None
+					};
+					print_color_info(color, &config, *all, wcag, named, lc);
+					println!();
+				}
+				println!();
 			}
 		}
 		Ok(())

--- a/crates/csskit/src/commands/colors.rs
+++ b/crates/csskit/src/commands/colors.rs
@@ -74,7 +74,14 @@ where
 	println!(" {bg}{:10}{bg:#}  {color}", "");
 }
 
-fn print_color_info(color: Color, config: &GlobalConfig, all: bool, wcag: bool, named: bool, lc: Option<(&'_ str, u32, u32)>) {
+fn print_color_info(
+	color: Color,
+	config: &GlobalConfig,
+	all: bool,
+	wcag: bool,
+	named: bool,
+	lc: Option<(&'_ str, u32, u32)>,
+) {
 	let a98 = A98Rgb::from(color);
 	let hex = Hex::from(color);
 	let hsv = Hsv::from(color);

--- a/crates/csskit_highlight/Cargo.toml
+++ b/crates/csskit_highlight/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 css_ast = { workspace = true }
 css_lexer = { workspace = true }
 css_parse = { workspace = true }
+chromashift = { workspace = true }
 
 bitmask-enum = { workspace = true }
 strum = { workspace = true, features = ["derive"] }

--- a/crates/csskit_highlight/src/css.rs
+++ b/crates/csskit_highlight/src/css.rs
@@ -1,11 +1,11 @@
 use css_ast::{
 	Angle, CSSInt, Class, Color, ContainerRule, Declaration, DeclarationValue, DocumentRule, Flex, FontFaceRule, Id,
 	KeyframesRule, LayerRule, Length, LengthPercentage, MarginRule, MediaRule, MozDocumentRule, PageRule, PropertyRule,
-	PseudoClass, PseudoElement, StyleRule, SupportsRule, Tag, Time, Url, Visit, WebkitKeyframesRule,
+	PseudoClass, PseudoElement, StyleRule, SupportsRule, Tag, Time, ToChromashift, Url, Visit, WebkitKeyframesRule,
 };
 use css_lexer::ToSpan;
 
-use crate::{SemanticKind, SemanticModifier, TokenHighlighter};
+use crate::{SemanticDecoration, SemanticKind, SemanticModifier, TokenHighlighter};
 
 impl Visit for TokenHighlighter {
 	fn visit_tag(&mut self, tag: &Tag) {
@@ -124,7 +124,17 @@ impl Visit for TokenHighlighter {
 	}
 
 	fn visit_color(&mut self, color: &Color) {
-		self.insert(color.to_span(), SemanticKind::StyleValueColor, SemanticModifier::none());
+		if let Some(bg) = color.to_chromashift() {
+			let swatch = SemanticDecoration::BackgroundColor(bg.into());
+			self.insert_with_decoration(
+				color.to_span(),
+				SemanticKind::StyleValueColor,
+				SemanticModifier::none(),
+				swatch,
+			);
+		} else {
+			self.insert(color.to_span(), SemanticKind::StyleValueColor, SemanticModifier::none());
+		}
 	}
 
 	fn visit_url(&mut self, url: &Url) {

--- a/crates/csskit_highlight/src/lib.rs
+++ b/crates/csskit_highlight/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(warnings)]
 use bitmask_enum::bitmask;
+use chromashift::Hex;
 use core::fmt;
 use css_lexer::Span;
 use std::collections::HashMap;
@@ -91,9 +92,16 @@ impl fmt::Display for SemanticModifier {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SemanticDecoration {
+	None,
+	BackgroundColor(Hex),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Highlight {
 	kind: SemanticKind,
 	modifier: SemanticModifier,
+	decoration: SemanticDecoration,
 	span: Span,
 }
 
@@ -111,6 +119,11 @@ impl Highlight {
 	#[inline(always)]
 	pub fn kind(&self) -> SemanticKind {
 		self.kind
+	}
+
+	#[inline(always)]
+	pub fn decoration(&self) -> SemanticDecoration {
+		self.decoration
 	}
 }
 
@@ -133,6 +146,16 @@ impl TokenHighlighter {
 	}
 
 	fn insert(&mut self, span: Span, kind: SemanticKind, modifier: SemanticModifier) {
-		self.highlights.insert(span, Highlight { span, kind, modifier });
+		self.insert_with_decoration(span, kind, modifier, SemanticDecoration::None);
+	}
+
+	fn insert_with_decoration(
+		&mut self,
+		span: Span,
+		kind: SemanticKind,
+		modifier: SemanticModifier,
+		decoration: SemanticDecoration,
+	) {
+		self.highlights.insert(span, Highlight { span, kind, modifier, decoration });
 	}
 }


### PR DESCRIPTION
 - Allow a Vec of Colors to be entered as content (e.g. `csskit colors -c "red blue black"`)
 - Output the file name alongside the line count.
