### PR TITLE
Add #[in_range] as a generic attribute for both derive(Parse) and derive(Peek).

### DIFF
--- a/crates/css_ast/src/types/opacity_value.rs
+++ b/crates/css_ast/src/types/opacity_value.rs
@@ -1,14 +1,14 @@
-use css_parse::{Cursor, Parser, Peek, T};
-use csskit_derives::{IntoCursor, Parse, ToCursors, Visitable};
+use css_parse::T;
+use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 
 use crate::Percentage;
 
-#[derive(IntoCursor, Parse, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Peek, Parse, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[visit(self)]
 pub enum OpacityValue {
-	Number(#[parse(in_range=0.0..=1.0)] T![Number]),
-	Percent(#[parse(in_range=0.0..=100.0)] Percentage),
+	Number(#[in_range(0.0..=1.0)] T![Number]),
+	Percent(#[in_range(0.0..=100.0)] Percentage),
 }
 
 impl OpacityValue {
@@ -31,13 +31,6 @@ impl From<OpacityValue> for f32 {
 			OpacityValue::Number(t) => t.into(),
 			OpacityValue::Percent(t) => t.into(),
 		}
-	}
-}
-
-impl<'a> Peek<'a> for OpacityValue {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		(<T![Number]>::peek(p, c) && (0.0..=1.0).contains(&c.token().value()))
-			|| (<Percentage>::peek(p, c) && (0.0..=100.0).contains(&c.token().value()))
 	}
 }
 

--- a/crates/css_ast/src/types/single_animation_iteration_count.rs
+++ b/crates/css_ast/src/types/single_animation_iteration_count.rs
@@ -15,7 +15,7 @@ keyword_set!(pub struct InfiniteKeyword "infinite");
 pub enum SingleAnimationIterationCount {
 	#[parse(keyword = InfiniteKeyword)]
 	Infinite(T![Ident]),
-	Number(#[parse(in_range = 0.0f32..)] T![Number]),
+	Number(#[in_range(0.0f32..)] T![Number]),
 }
 
 #[cfg(test)]

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -64,7 +64,7 @@ impl<'a> Parse<'a> for Angle {
 pub enum AngleOrZero {
 	Angle(Angle),
 	#[visit(skip)]
-	#[parse(in_range = 0..0)]
+	#[in_range(0..0)]
 	Zero(T![Number]),
 }
 

--- a/crates/csskit_derives/src/attributes.rs
+++ b/crates/csskit_derives/src/attributes.rs
@@ -1,0 +1,20 @@
+use syn::{Attribute, ExprRange, Meta};
+
+/// Extract #[in_range(...)] attribute from a field
+pub fn extract_in_range(attrs: &[Attribute]) -> Option<ExprRange> {
+	if let Some(Attribute { meta, .. }) = attrs.iter().find(|a| a.path().is_ident("in_range")) {
+		match meta {
+			Meta::List(meta) => {
+				let range = meta.parse_args::<syn::Expr>().unwrap();
+				if let syn::Expr::Range(range_expr) = range {
+					Some(range_expr)
+				} else {
+					panic!("Expected range expression in #[in_range(...)]");
+				}
+			}
+			_ => panic!("could not parse in_range meta"),
+		}
+	} else {
+		None
+	}
+}

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -3,6 +3,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::{AngleBracketedGenericArguments, Error, GenericArgument, PathArguments, PathSegment, Type, TypePath};
 
+mod attributes;
 mod css_feature;
 mod into_cursor;
 mod parse;
@@ -21,13 +22,13 @@ pub fn derive_to_cursors(stream: TokenStream) -> TokenStream {
 	to_cursors::derive(input).into()
 }
 
-#[proc_macro_derive(Parse, attributes(parse))]
+#[proc_macro_derive(Parse, attributes(parse, in_range))]
 pub fn derive_parse(stream: TokenStream) -> TokenStream {
 	let input = syn::parse(stream).unwrap();
 	parse::derive(input).into()
 }
 
-#[proc_macro_derive(Peek, attributes(peek))]
+#[proc_macro_derive(Peek, attributes(peek, in_range))]
 pub fn derive_peek(stream: TokenStream) -> TokenStream {
 	let input = syn::parse(stream).unwrap();
 	peek::derive(input).into()

--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -1,9 +1,36 @@
-use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Type, parse_quote};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, ExprRange, Type, parse_quote};
 
-use crate::err;
+use crate::{attributes::extract_in_range, err};
+
+fn generate_range_check(range_expr: &ExprRange) -> TokenStream {
+	let start = &range_expr.start;
+	let end = &range_expr.end;
+	match (start, end) {
+		// 1..=10 (inclusive end)
+		(Some(start), Some(end)) => {
+			quote! { (#start..=#end).contains(&c.token().value()) }
+		}
+		(Some(start), None) => {
+			quote! { #start <= c.token().value() }
+		}
+		(None, Some(end)) => {
+			quote! { c.token().value() <= #end }
+		}
+		// .. (full range) - no validation needed
+		(None, None) => quote! { true },
+	}
+}
+
+fn generate_field_peek(ty: &Type, in_range: &Option<ExprRange>) -> TokenStream {
+	if let Some(range) = in_range {
+		let range_check = generate_range_check(range);
+		quote! { <#ty>::peek(p, c) && #range_check }
+	} else {
+		quote! { <#ty>::peek(p, c) }
+	}
+}
 
 pub fn derive(input: DeriveInput) -> TokenStream {
 	let ident = input.ident;
@@ -21,23 +48,33 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 		Data::Union(_) => err(ident.span(), "Cannot derive Peek on a Union"),
 
 		Data::Struct(DataStruct { fields, .. }) => {
-			let ty = &fields.iter().next().unwrap().ty;
-			quote! { <#ty>::peek(p, c) }
+			let field = fields.iter().next().unwrap();
+			let ty = match &field.ty {
+				Type::Reference(refty) => refty.elem.as_ref(),
+				ty => ty,
+			};
+			let in_range = extract_in_range(&field.attrs);
+			generate_field_peek(ty, &in_range)
 		}
 
 		Data::Enum(DataEnum { variants, .. }) => {
-			let ty: Vec<_> = variants
+			let peek_conditions: Vec<_> = variants
 				.iter()
-				.map(|variant| variant.fields.iter().next())
-				.filter_map(|f| {
-					f.map(|f| match &f.ty {
-						Type::Reference(refty) => refty.elem.as_ref(),
-						ty => ty,
-					})
+				.filter_map(|variant| {
+					if let Some(field) = variant.fields.iter().next() {
+						let ty = match &field.ty {
+							Type::Reference(refty) => refty.elem.as_ref(),
+							ty => ty,
+						};
+						let in_range = extract_in_range(&field.attrs);
+						Some(generate_field_peek(ty, &in_range))
+					} else {
+						None
+					}
 				})
-				.dedup()
 				.collect();
-			quote! { #(<#ty>::peek(p, c))||* }
+
+			quote! { #(#peek_conditions)||* }
 		}
 	};
 	quote! {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_duplicate_types.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_duplicate_types.snap
@@ -6,6 +6,6 @@ expression: pretty
 impl<'a> ::css_parse::Peek<'a> for Color {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
-        <CSSInt>::peek(p, c)
+        <CSSInt>::peek(p, c) || <CSSInt>::peek(p, c) || <CSSInt>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_range.snap
@@ -3,9 +3,10 @@ source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for BorderStyle {
+impl<'a> ::css_parse::Peek<'a> for OpacityValue {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
-        <Length>::peek(p, c) || <Length>::peek(p, c)
+        <Number>::peek(p, c) && (0.0..=1.0).contains(&c.token().value())
+            || <Percentage>::peek(p, c) && (0.0..=100.0).contains(&c.token().value())
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_simple_enum.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_simple_enum.snap
@@ -6,6 +6,6 @@ expression: pretty
 impl<'a> ::css_parse::Peek<'a> for Display {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
-        <Ident>::peek(p, c)
+        <Ident>::peek(p, c) || <Ident>::peek(p, c) || <Ident>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_lifetime.snap
@@ -6,6 +6,6 @@ expression: pretty
 impl<'a> ::css_parse::Peek<'a> for Value<'a> {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
-        <&'a Ident>::peek(p, c)
+        <Ident>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_range.snap
@@ -3,9 +3,9 @@ source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for BorderStyle {
+impl<'a> ::css_parse::Peek<'a> for Opacity {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
-        <Length>::peek(p, c) || <Length>::peek(p, c)
+        <Number>::peek(p, c) && (0.0..=1.0).contains(&c.token().value())
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_range_from.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_range_from.snap
@@ -3,9 +3,9 @@ source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for BorderStyle {
+impl<'a> ::css_parse::Peek<'a> for PositiveValue {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
-        <Length>::peek(p, c) || <Length>::peek(p, c)
+        <Number>::peek(p, c) && 1.0 <= c.token().value()
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_range_to.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_range_to.snap
@@ -3,9 +3,9 @@ source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for BorderStyle {
+impl<'a> ::css_parse::Peek<'a> for BoundedValue {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_parse::Cursor) -> bool {
         use ::css_parse::Peek;
-        <Length>::peek(p, c) || <Length>::peek(p, c)
+        <Number>::peek(p, c) && c.token().value() <= 100.0
     }
 }

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -220,7 +220,7 @@ fn parse_with_multiple_state_stop_combinations() {
 fn parse_struct_with_inclusive_range() {
 	let data = to_deriveinput! {
 		struct Volume {
-			#[parse(in_range = 0.0f32..=100.0f32)]
+			#[in_range(0.0f32..=100.0f32)]
 			level: Number,
 		}
 	};
@@ -231,7 +231,7 @@ fn parse_struct_with_inclusive_range() {
 fn parse_struct_with_range_from() {
 	let data = to_deriveinput! {
 		struct PositiveValue {
-			#[parse(in_range = 1.0f32..)]
+			#[in_range(1.0f32..)]
 			value: CSSInt,
 		}
 	};
@@ -242,7 +242,7 @@ fn parse_struct_with_range_from() {
 fn parse_struct_with_range_to_exclusive() {
 	let data = to_deriveinput! {
 		struct Probability {
-			#[parse(in_range = ..1.0f32)]
+			#[in_range(..1.0f32)]
 			value: Number,
 		}
 	};
@@ -253,13 +253,13 @@ fn parse_struct_with_range_to_exclusive() {
 fn parse_struct_with_multiple_range_fields() {
 	let data = to_deriveinput! {
 		struct Color {
-			#[parse(in_range = 0..=255)]
+			#[in_range(0..=255)]
 			red: CSSInt,
-			#[parse(in_range = 0..=255)]
+			#[in_range(0..=255)]
 			green: CSSInt,
-			#[parse(in_range = 0..=255)]
+			#[in_range(0..=255)]
 			blue: CSSInt,
-			#[parse(in_range = 0..=1)]
+			#[in_range(0..=1)]
 			alpha: Number,
 		}
 	};
@@ -269,7 +269,7 @@ fn parse_struct_with_multiple_range_fields() {
 #[test]
 fn parse_tuple_struct_with_range() {
 	let data = to_deriveinput! {
-		struct Scale(#[parse(in_range = 0.1..=10.0)] Number);
+		struct Scale(#[in_range(0.1..=10.0)] Number);
 	};
 	assert_parse_snapshot!(data, "parse_tuple_struct_with_range");
 }
@@ -278,8 +278,8 @@ fn parse_tuple_struct_with_range() {
 fn parse_enum_with_range_validation() {
 	let data = to_deriveinput! {
 		enum Value {
-			Percentage(#[parse(in_range = 0..=100)] Number),
-			Scale(#[parse(in_range = 0.1..)] Number),
+			Percentage(#[in_range(0..=100)] Number),
+			Scale(#[in_range(0.1..)] Number),
 		}
 	};
 	assert_parse_snapshot!(data, "parse_enum_with_range_validation");
@@ -290,18 +290,18 @@ fn parse_enum_struct_variants_with_ranges() {
 	let data = to_deriveinput! {
 		enum Transform {
 			Scale {
-				#[parse(in_range = 0..)]
+				#[in_range(0..)]
 				x: Number,
-				#[parse(in_range = 0..)]
+				#[in_range(0..)]
 				y: Number,
 			},
 			Rotate {
-				#[parse(in_range = -360..=360)]
+				#[in_range(-360..=360)]
 				angle: Number,
 			},
 			Translate {
 				x: Length,
-				#[parse(in_range = -100..=100)]
+				#[in_range(-100..=100)]
 				y: Percentage,
 			},
 		}
@@ -327,7 +327,7 @@ fn parse_struct_with_all_must_occur_and_range() {
 		#[parse(all_must_occur)]
 		struct AutoAndLengthWithRange {
 			auto: AutoKeyword,
-			#[parse(in_range = 0..=100)]
+			#[in_range(0..=100)]
 			length: Length,
 		}
 	};
@@ -368,7 +368,7 @@ fn parse_enum_variant_with_all_must_occur_and_range() {
 			#[parse(all_must_occur)]
 			WithRange {
 				auto: AutoKeyword,
-				#[parse(in_range = 0..=100)]
+				#[in_range(0..=100)]
 				percentage: Number,
 			},
 			Simple(String),
@@ -385,7 +385,7 @@ fn parse_enum_mixed_variants() {
 			#[parse(all_must_occur)]
 			MinMax {
 				min: Length,
-				#[parse(in_range = 0..)]
+				#[in_range(0..)]
 				max: Length,
 			},
 			Length(Length),
@@ -401,7 +401,7 @@ fn parse_struct_with_keyword_pattern_and_range() {
 		struct KeywordWithRange {
 			#[parse(keyword = FooKeywords::Auto)]
 			auto_value: AutoValue,
-			#[parse(in_range = 0..=100)]
+			#[in_range(0..=100)]
 			percentage: Number,
 		}
 	};

--- a/crates/csskit_derives/src/test/test_peek.rs
+++ b/crates/csskit_derives/src/test/test_peek.rs
@@ -99,3 +99,38 @@ fn peek_enum_with_lifetime() {
 	};
 	assert_peek_snapshot!(data, "peek_enum_with_lifetime");
 }
+
+#[test]
+fn peek_struct_with_range() {
+	let data = to_deriveinput! {
+		struct Opacity(#[in_range(0.0..=1.0)] Number);
+	};
+	assert_peek_snapshot!(data, "peek_struct_with_range");
+}
+
+#[test]
+fn peek_enum_with_range() {
+	let data = to_deriveinput! {
+		enum OpacityValue {
+			Number(#[in_range(0.0..=1.0)] Number),
+			Percentage(#[in_range(0.0..=100.0)] Percentage),
+		}
+	};
+	assert_peek_snapshot!(data, "peek_enum_with_range");
+}
+
+#[test]
+fn peek_struct_with_range_from() {
+	let data = to_deriveinput! {
+		struct PositiveValue(#[in_range(1.0..)] Number);
+	};
+	assert_peek_snapshot!(data, "peek_struct_with_range_from");
+}
+
+#[test]
+fn peek_struct_with_range_to() {
+	let data = to_deriveinput! {
+		struct BoundedValue(#[in_range(..100.0)] Number);
+	};
+	assert_peek_snapshot!(data, "peek_struct_with_range_to");
+}

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -262,10 +262,10 @@ impl Def {
 		let in_range = match self {
 			Def::IntLiteral(i) if derives_parse => {
 				let f = *i as f32;
-				quote! { #[parse(in_range = #f..=#f)] }
+				quote! { #[in_range(#f..=#f)] }
 			}
 			Def::DimensionLiteral(f, _) if derives_parse => {
-				quote! { #[parse(in_range = #f..=#f)] }
+				quote! { #[in_range(#f..=#f)] }
 			}
 			Def::Optional(def) => match def.deref() {
 				Def::Type(deftype) if derives_parse => deftype.generate_in_range_attr(),
@@ -587,9 +587,9 @@ impl DefType {
 	pub fn generate_in_range_attr(&self) -> TokenStream {
 		match self.checks() {
 			DefRange::None | DefRange::Fixed(_) => quote! {},
-			DefRange::Range(Range { start, end }) => quote! { #[parse(in_range = #start..=#end)] },
-			DefRange::RangeFrom(start) => quote! { #[parse(in_range = #start..)] },
-			DefRange::RangeTo(end) => quote! { #[parse(in_range = ..=#end)] },
+			DefRange::Range(Range { start, end }) => quote! { #[in_range(#start..=#end)] },
+			DefRange::RangeFrom(start) => quote! { #[in_range(#start..)] },
+			DefRange::RangeTo(end) => quote! { #[in_range(..=#end)] },
 		}
 	}
 

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_struct_with_range.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_struct_with_range.snap
@@ -6,6 +6,6 @@ expression: pretty
 #[parse(all_must_occur)]
 struct Foo(
     pub ::css_parse::T![Ident],
-    #[parse(in_range = 0f32..= 100f32)]
+    #[in_range(0f32..= 100f32)]
     pub crate::Percentage,
 );

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__alternatives_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__alternatives_with_checks_derive_parse.snap
@@ -10,5 +10,5 @@ expression: pretty
 enum Foo {
     #[parse(keyword = FooKeywords::Bar)]
     Bar(::css_parse::T![Ident]),
-    Angle(#[parse(in_range = -90f32..= 90f32)] Option<crate::Angle>),
+    Angle(#[in_range(-90f32..= 90f32)] Option<crate::Angle>),
 }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_and_length_with_range.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_and_length_with_range.snap
@@ -6,6 +6,6 @@ expression: pretty
 #[parse(all_must_occur)]
 struct Foo<'a>(
     pub ::css_parse::T![Ident],
-    #[parse(in_range = 0f32..= 100f32)]
+    #[in_range(0f32..= 100f32)]
     pub crate::Length,
 );

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks_derive_parse.snap
@@ -3,4 +3,4 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-struct Foo(#[parse(in_range = -90f32..= 90f32)] pub crate::AutoOr<crate::Angle>);
+struct Foo(#[in_range(-90f32..= 90f32)] pub crate::AutoOr<crate::Angle>);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks_derive_parse.snap
@@ -10,5 +10,5 @@ expression: pretty
 enum Foo {
     #[parse(keyword = FooKeywords::Foo)]
     Foo(::css_parse::T![Ident]),
-    LengthPercentage(#[parse(in_range = 0f32..)] crate::LengthPercentage),
+    LengthPercentage(#[in_range(0f32..)] crate::LengthPercentage),
 }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__literal_with_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__literal_with_derive_parse.snap
@@ -4,6 +4,6 @@ expression: pretty
 ---
 #[derive(Parse)]
 enum Foo {
-    Literal0deg(#[parse(in_range = 0f32..= 0f32)] ::css_parse::T![Dimension]),
-    Literal90deg(#[parse(in_range = 90f32..= 90f32)] ::css_parse::T![Dimension]),
+    Literal0deg(#[in_range(0f32..= 0f32)] ::css_parse::T![Dimension]),
+    Literal90deg(#[in_range(90f32..= 90f32)] ::css_parse::T![Dimension]),
 }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_combinator_with_checks_derives_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_combinator_with_checks_derives_parse.snap
@@ -10,9 +10,5 @@ expression: pretty
 enum Foo {
     #[parse(keyword = FooKeywords::Bar)]
     Bar(::css_parse::T![Ident]),
-    Foo(
-        ::css_parse::T![Ident],
-        #[parse(in_range = -90f32..= 90f32)]
-        Option<crate::Angle>,
-    ),
+    Foo(::css_parse::T![Ident], #[in_range(-90f32..= 90f32)] Option<crate::Angle>),
 }


### PR DESCRIPTION
Checking the range is cheap enough to do during Peek steps, and we've inconsistently checked it, historically, so this
change allows us to be more consistent by making it part of the attributes that derive(Peek) will read, alongside
derive(Parse).
