### PR TITLE
Replace miette diagnostics with custom Sized struct.

### DIFF
--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -52,7 +52,8 @@ pprof = { workspace = true, features = ["flamegraph", "criterion"] }
 [features]
 default = []
 serde = ["dep:serde", "dep:serde_json", "css_parse/serde", "smallvec/serde"]
-fancy = ["miette/fancy-no-backtrace"]
+miette = ["css_parse/miette"]
+fancy = ["miette", "miette/fancy-no-backtrace"]
 css_feature_data = ["dep:css_feature_data"]
 chromashift = ["dep:chromashift"]
 

--- a/crates/css_ast/src/diagnostics.rs
+++ b/crates/css_ast/src/diagnostics.rs
@@ -1,366 +1,133 @@
-use css_parse::{Cursor, Kind, Span};
-use miette::Diagnostic;
-use thiserror::Error;
+use css_parse::diagnostics::DiagnosticMeta;
+use css_parse::{Diagnostic, SourceCursor};
 
-pub use css_parse::diagnostics::*;
+pub trait CssDiagnostic {
+	fn unimplemented(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn unexpected_pseudo_class(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn unexpected_pseudo_element(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn unexpected_at_rule(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn unexpected_function(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn expected_unsigned(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn number_out_of_bounds(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn number_too_small(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn expected_int(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn unexpected_zero(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn reserved_keyframe_name(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("This cannot yet be parsed by the parser :(")]
-#[diagnostic(code(css_parse::Unimplemented))]
-#[help("This feature needs to be implemented within csskit. This file won't parse without it.")]
-pub struct Unimplemented(#[label("Didn't recognise this bit")] pub Cursor);
+impl CssDiagnostic for Diagnostic {
+	fn unimplemented(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::Unimplemented",
+			message: "This cannot yet be parsed by the parser :(".into(),
+			help: "This feature needs to be implemented within csskit. This file won't parse without it.".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("This at-rule mut not have a 'prelude'.")]
-#[diagnostic(code(css_parse::DisllowedAtRulePrelude))]
-#[help("The 'prelude' is the bit between the @keyword and the {{")]
-pub struct DisallowedAtRulePrelude(#[label("Remove this part")] pub Cursor);
+	fn unexpected_pseudo_class(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedPseudo",
+			message: format!("Unexpected pseudo selector ':{}'", SourceCursor::from(diagnostic.start_cursor, source)),
+			help: "This isn't a valid psuedo selector for this rule.".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("This at-rule must not have a 'block'.")]
-#[diagnostic(code(css_parse::DisllowedAtRuleBlock))]
-#[help("The 'block' is the bit between the {{ and }}")]
-pub struct DisallowedAtRuleBlock(#[label("Remove this part")] pub Cursor);
+	fn unexpected_pseudo_element(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let start = cursor.offset().0 as usize;
+		let len = cursor.token().len() as usize;
+		let text = if start + len <= source.len() { &source[start..start + len] } else { "<unknown>" };
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedPseudoElement",
+			message: format!("Unexpected pseudo element '::{text}'"),
+			help: "This isn't a valid psuedo selector for this rule.".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("This at-rule must have a 'prelude'.")]
-#[diagnostic(code(css_parse::MissingAtRulePrelude))]
-#[help("The 'prelude' is the bit between the @ and the {{")]
-pub struct MissingAtRulePrelude(#[label("Add content here")] pub Cursor);
+	fn unexpected_at_rule(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let start = cursor.offset().0 as usize;
+		let len = cursor.token().len() as usize;
+		let text = if start + len <= source.len() { &source[start..start + len] } else { "<unknown>" };
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedAtRule",
+			message: format!("Unexpected at rule '@{text}'"),
+			help: "This isn't a recognisable at-rule here. If the rule is valid, it might not be allowed here.".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("This at-rule must have a 'block'.")]
-#[diagnostic(code(css_parse::MissingAtRuleBlock))]
-#[help("The 'block' is the bit between the {{ and }}")]
-pub struct MissingAtRuleBlock(#[label("Add {{}} here")] pub Cursor);
+	fn unexpected_function(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let start = cursor.offset().0 as usize;
+		let len = cursor.token().len() as usize;
+		let text = if start + len <= source.len() { &source[start..start + len] } else { "<unknown>" };
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedFunction",
+			message: format!("Unexpected function '{text}'()"),
+			help: "A function with this name wasn't expected in this position.".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected charset '{0}'. '{0}' isn't allowed here. This must be a valid IANA language code.")]
-#[diagnostic(code(css_parse::UnexpectedCharset))]
-#[help("Consider removing the rule or setting this to 'utf-8'")]
-pub struct UnexpectedCharset(pub String, #[label("This charset code is not allowed here")] pub Cursor);
+	fn expected_unsigned(diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::ExpectedUnsigned",
+			message: format!("Expected an unsigned number but saw `{}`", diagnostic.start_cursor.token().value()),
+			help: "This number cannot have a + or a -".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected literal '{0}'")]
-#[diagnostic(code(css_parse::UnexpectedLiteral))]
-#[help("Try removing the word here.")]
-pub struct UnexpectedLiteral(pub String, #[label("??")] pub Cursor);
+	fn number_out_of_bounds(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::NumberOutOfBounds",
+			message: "This number is out of bounds.".into(),
+			help: "This needs to be within the valid range.".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected identifier '{0}'. '{0}' isn't allowed here, but '{1}' is.")]
-#[diagnostic(code(css_parse::UnexpectedIdentSuggest))]
-#[help("Try changing this to '{1}'")]
-pub struct UnexpectedIdentSuggest(pub String, pub String, #[label("This keyword is not allowed here")] pub Cursor);
+	fn number_too_small(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::NumberTooSmall",
+			message: "This number is too small.".into(),
+			help: "This needs to be a larger value.".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected duplicate '{0}'")]
-#[diagnostic(code(css_parse::UnexpectedDuplicateIdent))]
-#[help("Try removing the word here.")]
-pub struct UnexpectedDuplicateIdent(pub String, #[label("Remove this duplicate")] pub Cursor);
+	fn expected_int(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::ExpectedInt",
+			message: "This value isn't allowed to have a fraction, it must be a whole number.".into(),
+			help: "Try using a whole number instead".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected pseudo selector ':{0}'")]
-#[diagnostic(code(css_parse::UnexpectedPseudo))]
-#[help("This isn't a valid psuedo selector for this rule.")]
-pub struct UnexpectedPseudoClass(pub String, #[label("This psuedo selector")] pub Cursor);
+	fn unexpected_zero(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::ExpectedZero",
+			message: "This number must not be 0.".into(),
+			help: "Try replacing it with a positive or negative number".into(),
+			labels: vec![],
+		}
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected pseudo selector ':{0}'()")]
-#[diagnostic(code(css_parse::UnexpectedPseudoClassFunction))]
-#[help("This isn't a valid psuedo selector for this rule.")]
-pub struct UnexpectedPseudoClassFunction(pub String, #[label("This psuedo selector")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected pseudo element '::{0}'")]
-#[diagnostic(code(css_parse::UnexpectedPseudoElement))]
-#[help("This isn't a valid psuedo selector for this rule.")]
-pub struct UnexpectedPseudoElement(pub String, #[label("This psuedo selector")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected pseudo element '::{0}'")]
-#[diagnostic(code(css_parse::UnexpectedPseudoElementFunction))]
-#[help("This isn't a valid psuedo selector for this rule.")]
-pub struct UnexpectedPseudoElementFunction(pub String, #[label("This psuedo selector")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("The dimension '{0}' wasn't recognised for this value type")]
-#[diagnostic(code(css_parse::UnexpectedDimension))]
-#[help(
-	"This isn't a recognisable dimension for this value type. If it's a valid dimension, it might be that it cannot be used for this rule or in this position."
-)]
-pub struct UnexpectedDimension(pub String, #[label("This isn't recognised")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected at rule '@{0}'")]
-#[diagnostic(code(css_parse::UnexpectedAtRule))]
-#[help("This isn't a recognisable at-rule here. If the rule is valid, it might not be allowed here.")]
-pub struct UnexpectedAtRule(pub String, #[label("This isn't recognised")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected function '{0}'()")]
-#[diagnostic(code(css_parse::UnexpectedFunction))]
-#[help("A function with this name wasn't expected in this position.")]
-pub struct UnexpectedFunction(pub String, #[label("Here")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unknown Rule")]
-#[diagnostic(code(css_parse::UnknownRule))]
-#[help("This might be a mistake in the parser, please file an issue!")]
-pub struct UnknownRule(#[label("Don't know how to interpret this")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unknown Value")]
-#[diagnostic(code(css_parse::UnknownValue))]
-#[help("This might be a mistake in the parser, please file an issue!")]
-pub struct UnknownValue(#[label("Don't know how to interpret this")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unknown named color '{0}'")]
-#[diagnostic(code(css_parse::UnknownColor))]
-#[help("Replace this unknown color with a known named color or a valid color value.")]
-pub struct UnknownColor(pub String, #[label("This isn't a known color")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected `{}` but found `{}`", self.0, Kind::from(self.1))]
-#[diagnostic(code(css_parse::ExpectedToken))]
-#[help("This is not correct CSS syntax.")]
-pub struct ExpectedKind(pub Kind, #[label("`{}` expected", self.0)] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected a dimension but found `{}`", Kind::from(self.0))]
-#[diagnostic(code(css_parse::ExpectedDimension))]
-#[help("This is not correct CSS syntax.")]
-pub struct ExpectedDimension(#[label("dimension expected")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected a function but found `{0}`")]
-#[diagnostic(code(css_parse::ExpectedFunction))]
-#[help("This is not correct CSS syntax.")]
-pub struct ExpectedFunction(pub Kind, #[label("This token")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected to see {0}() but saw {1}()")]
-#[diagnostic(code(css_parse::ExpectedFunctionOf))]
-#[help("Try changing the {1}() to {0}()")]
-pub struct ExpectedFunctionOf(pub String, pub String, #[label("This function")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected an @ keyword but saw `{0}`")]
-#[diagnostic(code(css_parse::ExpectedAtKeyword))]
-#[help("This is not correct CSS syntax.")]
-pub struct ExpectedAtKeyword(pub Kind, #[label("This at-keyword")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected to see @{0} but saw @{1}")]
-#[diagnostic(code(css_parse::ExpectedAtKeywordOf))]
-#[help("Try changing the @{1} to @{0}")]
-pub struct ExpectedAtKeywordOf(pub String, pub String, #[label("This at-keyword")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected to see {0} but saw {1}")]
-#[diagnostic(code(css_parse::ExpectedDelimOf))]
-#[help("Try changing the {1} to {0}")]
-pub struct ExpectedDelimOf(pub char, pub char, #[label("This delimiter")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Invalid hexidecimal value for color: '{0}'")]
-#[diagnostic(code(css_parse::BadHexColor))]
-#[help("Hex colours must be 3, 4, 6 or 8 digits long.")]
-pub struct BadHexColor(pub String, #[label("This is the wrong format")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This block uses an invalid selector, so the whole block would be discarded.")]
-#[diagnostic(code(css_parse::NoSelector))]
-#[help("Try adding a selector to this style rule")]
-pub struct NoSelector(#[label("This selector isn't valid")] pub Span, pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This selector has two combinators next to each other, which is disallowed.")]
-#[diagnostic(code(css_parse::AdjacentSelectorCombinators))]
-#[help("Try removing one of the combinators or add a selector in between them")]
-pub struct AdjacentSelectorCombinators(
-	#[label("...because this combinator is right next to the previous one")] pub Span,
-	#[label("This selector is invalid...")] pub Span,
-);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This selector has two types next to each other, which is disallowed.")]
-#[diagnostic(code(css_parse::AdjacentSelectorTypes))]
-#[help("Try removing one of the types or add a space inbetween")]
-pub struct AdjacentSelectorTypes(
-	#[label("...because this type is right next to the previous one.")] pub Span,
-	#[label("This selector is invalid...")] pub Span,
-);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This value isn't allowed to be a raw number, it has to have a dimension.")]
-#[diagnostic(code(css_parse::DisallowedValueWithoutDimension))]
-#[help("Try adding a dimension, like '{0}'")]
-pub struct DisallowedValueWithoutDimension(pub String, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("A math function isn't valid here.")]
-#[diagnostic(code(css_parse::DisallowedMathFunction))]
-#[help("var() and env() can be used but math functions like {0}() cannot.")]
-pub struct DisallowedMathFunction(pub String, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected an opening curly brace but saw `{}`", Kind::from(self.0))]
-#[diagnostic(code(css_parse::ExpectedOpenCurly))]
-#[help("This is not correct CSS syntax.")]
-pub struct ExpectedOpenCurly(#[label("This value")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected a number but saw `{0}`")]
-#[diagnostic(code(css_parse::ExpectedNumber))]
-#[help("This is not correct CSS syntax.")]
-pub struct ExpectedNumber(pub Kind, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected a signed number but saw `{0}`")]
-#[diagnostic(code(css_parse::ExpectedSign))]
-#[help("This number needs a + or a -.")]
-pub struct ExpectedSign(pub f32, #[label("Add a + here")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected an unsigned number but saw `{}`", self.0.token().value())]
-#[diagnostic(code(css_parse::ExpectedUnsigned))]
-#[help("This number cannot have a + or a -.")]
-pub struct ExpectedUnsigned(#[label("This should be {}", self.0.token().value().abs())] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number is out of bounds.")]
-#[diagnostic(code(css_parse::NumberOutOfBounds))]
-#[help("This needs to be a number between {1}.")]
-pub struct NumberOutOfBounds(pub f32, pub String, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number cannot be negative.")]
-#[diagnostic(code(css_parse::NumberNotNegative))]
-#[help("This needs to be greater or equal to 0")]
-pub struct NumberNotNegative(pub f32, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number is too small.")]
-#[diagnostic(code(css_parse::NumberTooSmall))]
-#[help("This needs to be larger than {0}")]
-pub struct NumberTooSmall(pub f32, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number is too large.")]
-#[diagnostic(code(css_parse::NumberTooLarge))]
-#[help("This needs to be smaller than {0}")]
-pub struct NumberTooLarge(pub f32, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This value isn't allowed to have a fraction, it must be a whole number (integer).")]
-#[diagnostic(code(css_parse::ExpectedInt))]
-#[help("Try using {} instead", self.0.token().value().round())]
-pub struct ExpectedInt(#[label("This value")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This value must have a fraction, it must be float.")]
-#[diagnostic(code(css_parse::ExpectedFloat))]
-#[help("Try using {} instead", self.0.token().value())]
-pub struct ExpectedFloat(#[label("This value")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number must be 0, got {} instead.", self.0.token().value())]
-#[diagnostic(code(css_parse::ExpectedZero))]
-#[help("Try replacing it with the literal 0 instead")]
-pub struct ExpectedZero(#[label("This value")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number must not be 0.")]
-#[diagnostic(code(css_parse::ExpectedZero))]
-#[help("Try replacing it with a positive or negative number")]
-pub struct UnexpectedZero(#[label("This value")] pub Cursor);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This media query tries to compare itself equal to two different numbers.")]
-#[diagnostic(code(css_parse::UnexpectedMediaRangeComparisonEqualsTwice))]
-#[help("Try deleting one.")]
-pub struct UnexpectedMediaRangeComparisonEqualsTwice(#[label("This comparison")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Display 'list-item' can only be combined with 'flow' or 'flow-root'")]
-#[diagnostic(code(css_parse::DisplayHasInvalidListItemCombo))]
-#[help("{0} is not valid in combination with list-item, try changing it to 'flow' or 'flow-root'")]
-pub struct DisplayHasInvalidListItemCombo(pub String, pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("hwb and hsl colors must have a hue as their first argument.")]
-#[diagnostic(code(css_parse::ColorMustStartWithHue))]
-#[help("Try adding a % to the first color component.")]
-pub struct ColorMustStartWithHue(#[label("This component")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Only hwb and hsl colors have a hue as their first argument.")]
-#[diagnostic(code(css_parse::ColorMustNotStartWithHue))]
-#[help("Try removing the %")]
-pub struct ColorMustNotStartWithHue(#[label("This component")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Colors should not use a hue as the middle color component")]
-#[diagnostic(code(css_parse::ColorMustNotStartWithHue))]
-#[help("Try removing the %")]
-pub struct ColorMustNotHaveHueInMiddle(#[label("This component")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Colors using the legacy syntax must have commas between the components")]
-#[diagnostic(code(css_parse::ColorLegacyMustIncludeComma))]
-#[help("Try using the non-legacy syntax, without commas")]
-pub struct ColorLegacyMustIncludeComma(#[label("Put a commma here")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Colors using the legacy syntax must not use percentages, but absolute numbers")]
-#[diagnostic(code(css_parse::ColorLegacyMustNotUsePercent))]
-#[help("Try removing the %, or use the non-legacy syntax")]
-pub struct ColorLegacyMustNotUsePercent(#[label("This should not be a percentage")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Hex colors can be 3, 4, 6, or 8 characters in length. This one is {0}")]
-#[diagnostic(code(css_parse::ColorLegacyMustNotUsePercent))]
-#[help("Try rewriting this to be 3, 4, 6 or 8 characters")]
-pub struct ColorHexWrongLength(pub usize, #[label("This is not the right number of characters")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("{0} cannot be used as a keyframe name, as it's a reserved word.")]
-#[diagnostic(code(css_parse::ReservedKeyframeName))]
-#[help("")]
-pub struct ReservedKeyframeName(pub String, #[label("Rename it, or try wrapping it in quotes")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("An @layer {{}} (block) rule cannot have multiple names.")]
-#[diagnostic(code(css_parse::DisallowedLayerBlockWithMultipleNames))]
-#[help("")]
-pub struct DisallowedLayerBlockWithMultipleNames(#[label("Remove most (or all) of these names.")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("!important cannot be used for this property")]
-#[diagnostic(code(css_parse::DisallowedImportant))]
-#[help("")]
-pub struct DisallowedImportant(#[label("Remove this.")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("{0} requires at least {1} arguments, but saw {2}")]
-#[diagnostic(code(css_parse::DisallowedImportant))]
-#[help("")]
-pub struct NotEnoughArguments(
-	pub String,
-	pub usize,
-	pub usize,
-	#[label("Add another argument to this function.")] pub Span,
-);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("'{0}' not a valid <counter-name>")]
-#[diagnostic(code(css_parse::Unexpected))]
-#[help("")]
-pub struct InvalidCounterName(pub String, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This attr(name) is invalid.")]
-#[diagnostic(code(css_parse::Unexpected))]
-#[help("Try adding a | between each name.")]
-pub struct InvalidAttrName(#[label("This value")] pub Span);
+	fn reserved_keyframe_name(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let start = cursor.offset().0 as usize;
+		let len = cursor.token().len() as usize;
+		let text = if start + len <= source.len() { &source[start..start + len] } else { "<unknown>" };
+		DiagnosticMeta {
+			code: "css_parse::ReservedKeyframeName",
+			message: format!("{text} cannot be used as a keyframe name, as it's a reserved word."),
+			help: "Rename it, or try wrapping it in quotes".into(),
+			labels: vec![],
+		}
+	}
+}

--- a/crates/css_ast/src/functions/attr_function.rs
+++ b/crates/css_ast/src/functions/attr_function.rs
@@ -1,6 +1,7 @@
-use crate::{Syntax, diagnostics};
+use crate::Syntax;
 use css_parse::{
-	ComponentValues, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set,
+	ComponentValues, Cursor, Diagnostic, Function, Parse, Parser, Peek, Result as ParserResult, T, function_set,
+	keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -46,7 +47,7 @@ impl<'a> Parse<'a> for AttrName {
 		}
 
 		if a.is_none() && b.is_none() {
-			Err(diagnostics::ExpectedIdent(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::expected_ident))?
 		}
 
 		debug_assert!(a.is_some() && b.is_some());

--- a/crates/css_ast/src/functions/color_function.rs
+++ b/crates/css_ast/src/functions/color_function.rs
@@ -1,6 +1,6 @@
 use crate::{AngleOrNumber, NoneOr, NumberOrPercentage};
 use css_parse::{
-	Cursor, Function, Parse, Parser, Peek, Result as ParseResult, T, diagnostics, function_set, keyword_set,
+	Cursor, Diagnostic, Function, Parse, Parser, Peek, Result as ParseResult, T, function_set, keyword_set,
 };
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -41,7 +41,7 @@ impl<'a> Peek<'a> for CommaOrSlash {
 impl<'a> Parse<'a> for CommaOrSlash {
 	fn parse(p: &mut Parser<'a>) -> ParseResult<Self> {
 		if !p.peek::<Self>() {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 		Ok(Self(p.next()))
 	}

--- a/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
+++ b/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
@@ -1,3 +1,4 @@
+use crate::diagnostics::CssDiagnostic;
 use css_parse::{CommaSeparated, Function, function_set};
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 use csskit_proc_macro::syntax;

--- a/crates/css_ast/src/functions/easing_functions.rs
+++ b/crates/css_ast/src/functions/easing_functions.rs
@@ -1,10 +1,11 @@
-use crate::{Percentage, diagnostics};
+use crate::Percentage;
 use css_parse::{
-	CommaSeparated, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set,
+	CommaSeparated, Cursor, Diagnostic, Function, Parse, Parser, Peek, Result as ParserResult, T, function_set,
+	keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
-use crate::CSSInt;
+use crate::{CSSInt, diagnostics::CssDiagnostic};
 
 function_set!(
 	pub enum EasingFunctionName {
@@ -105,7 +106,7 @@ impl<'a> Parse<'a> for EasingFunction<'a> {
 			Some(EasingFunctionName::Linear(_)) => p.parse::<LinearFunction>().map(Self::LinearFunction),
 			Some(EasingFunctionName::CubicBezier(_)) => p.parse::<CubicBezierFunction>().map(Self::CubicBezierFunction),
 			Some(EasingFunctionName::Steps(_)) => p.parse::<StepsFunction>().map(Self::StepsFunction),
-			None => Err(diagnostics::Unexpected(p.next()))?,
+			None => Err(Diagnostic::new(p.next(), Diagnostic::unexpected_function))?,
 		}
 	}
 }

--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -27,9 +27,10 @@ pub use units::*;
 pub use values::*;
 pub use visit::*;
 
-use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan};
+use crate::diagnostics::CssDiagnostic;
+pub use css_parse::{Declaration, DeclarationValue, Diagnostic};
 
-pub use css_parse::{Declaration, DeclarationValue};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan};
 
 // TODO! - delete this when we're done ;)
 #[derive(Visitable, Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -48,7 +49,7 @@ impl<'a> Peek<'a> for Todo {
 
 impl<'a> Parse<'a> for Todo {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		Err(diagnostics::Unimplemented(p.next()))?
+		Err(Diagnostic::new(p.next(), Diagnostic::unimplemented))?
 	}
 }
 

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -1,6 +1,6 @@
 use crate::values;
 use css_parse::{
-	ComponentValues, Cursor, DeclarationValue, KindSet, Parser, Peek, Result as ParserResult, State, T, diagnostics,
+	ComponentValues, Cursor, DeclarationValue, Diagnostic, KindSet, Parser, Peek, Result as ParserResult, State, T,
 	keyword_set,
 };
 use csskit_derives::{Parse, ToCursors, ToSpan, Visitable};
@@ -148,7 +148,7 @@ impl<'a> DeclarationValue<'a> for StyleValue<'a> {
 			( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $str: tt,)+ ) => {
 				match PropertyId::from_cursor(p, name) {
 					$(Some(PropertyId::$name(_)) => p.parse::<values::$ty>().map(Self::$name),)+
-					None => Err(diagnostics::Unexpected(name))?,
+					None => Err(Diagnostic::new(name, Diagnostic::unexpected))?,
 				}
 			}
 		}

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -1,5 +1,5 @@
-use crate::diagnostics;
-use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T};
+use crate::diagnostics::CssDiagnostic;
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-syntax-3/#charset-rule
@@ -23,7 +23,7 @@ impl<'a> Parse<'a> for CharsetRule {
 		// CharsetRule MUST be all lowercase, alt cases such as CHARSET or charSet aren't
 		// valid here, compares to other at-rules which are case insensitive.
 		if !p.eq_ignore_ascii_case(c, "charset") {
-			Err(diagnostics::UnexpectedAtRule(p.parse_str(c).into(), c))?;
+			Err(Diagnostic::new(c, Diagnostic::unexpected_at_rule))?;
 		}
 		// Charsets MUST have a space between the at keyword and the string. This
 		// isn't necessary in other at rules where an at keyword can align with other

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -1,7 +1,7 @@
-use crate::{Rule, Visit, VisitMut, Visitable as VisitableTrait, VisitableMut, diagnostics};
+use crate::{Rule, Visit, VisitMut, Visitable as VisitableTrait, VisitableMut};
 use bumpalo::collections::Vec;
 use css_parse::{
-	AtRule, ConditionKeyword, Cursor, FeatureConditionList, Kind, Parse, Parser, Peek, PreludeList,
+	AtRule, ConditionKeyword, Cursor, Diagnostic, FeatureConditionList, Kind, Parse, Parser, Peek, PreludeList,
 	Result as ParserResult, RuleList, T, atkeyword_set, keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
@@ -181,10 +181,7 @@ impl<'a> Parse<'a> for ContainerFeature<'a> {
 							let value = $typ::parse(p)?;
 							Self::$name(value)
 						},)+
-						None => {
-							let source_cursor = p.to_source_cursor(c);
-							Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), c))?
-						}
+						None => Err(Diagnostic::new(c, Diagnostic::unexpected))?
 					}
 				}
 			}

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -1,7 +1,7 @@
-use crate::{Percentage, StyleValue, diagnostics};
+use crate::{Percentage, StyleValue, diagnostics::CssDiagnostic};
 use css_parse::{
-	AtRule, CommaSeparated, Cursor, NoBlockAllowed, Parse, Parser, Peek, QualifiedRule, Result as ParserResult,
-	RuleList, T, ToSpan, atkeyword_set, keyword_set,
+	AtRule, CommaSeparated, Cursor, Diagnostic, NoBlockAllowed, Parse, Parser, Peek, QualifiedRule,
+	Result as ParserResult, RuleList, T, atkeyword_set, keyword_set,
 };
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -44,7 +44,7 @@ impl<'a> Parse<'a> for KeyframesName {
 		let ident = p.parse::<T![Ident]>()?;
 		let str = p.parse_str_lower(ident.into());
 		if !KeyframesName::valid_ident(str) {
-			Err(diagnostics::ReservedKeyframeName(str.into(), ident.to_span()))?
+			Err(Diagnostic::new(ident.into(), Diagnostic::reserved_keyframe_name))?
 		}
 		Ok(Self::Ident(ident))
 	}
@@ -96,7 +96,7 @@ impl<'a> Parse<'a> for KeyframeSelector {
 		if (0.0..=100.0).contains(&f) {
 			Ok(Self::Percent(percent))
 		} else {
-			Err(diagnostics::NumberOutOfBounds(f, format!("{:?}", 0.0..=100.0), c.into()))?
+			Err(Diagnostic::new(c, Diagnostic::number_out_of_bounds))?
 		}
 	}
 }

--- a/crates/css_ast/src/rules/media/features/hack.rs
+++ b/crates/css_ast/src/rules/media/features/hack.rs
@@ -1,5 +1,4 @@
-use crate::diagnostics;
-use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T};
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T};
 use csskit_derives::{ToCursors, ToSpan};
 
 #[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -13,15 +12,14 @@ impl<'a> Parse<'a> for HackMediaFeature {
 		let open = p.parse::<T!['(']>()?;
 		let keyword = p.parse::<T![Ident]>()?;
 		if !p.eq_ignore_ascii_case(keyword.into(), "min-width") {
-			let source_cursor = p.to_source_cursor(keyword.into());
-			Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), keyword.into()))?
+			Err(Diagnostic::new(keyword.into(), Diagnostic::expected_ident))?
 		}
 		let colon = p.parse::<T![:]>()?;
 		let dimension = p.parse::<T![Dimension]>()?;
 		let c: Cursor = dimension.into();
 		let str = p.parse_raw_str(c);
 		if str != "0\\0" {
-			Err(diagnostics::Unexpected(c))?
+			Err(Diagnostic::new(c, Diagnostic::unexpected))?
 		}
 		let close = p.parse::<T![')']>()?;
 		Ok(Self::IEBackslashZero(open, keyword, colon, dimension, close))

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -3,8 +3,8 @@ use crate::{
 };
 use bumpalo::collections::Vec;
 use css_parse::{
-	AtRule, ComponentValues, ConditionKeyword, Declaration, FeatureConditionList, Parse, Parser,
-	Result as ParserResult, RuleList, T, atkeyword_set, diagnostics, function_set,
+	AtRule, ComponentValues, ConditionKeyword, Declaration, Diagnostic, FeatureConditionList, Parse, Parser,
+	Result as ParserResult, RuleList, T, atkeyword_set, function_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -165,7 +165,7 @@ impl<'a> Parse<'a> for SupportsFeature<'a> {
 			let close = p.parse_if_peek::<T![')']>()?;
 			Ok(Self::Property(open, property, close))
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -1,4 +1,4 @@
-use css_parse::{Cursor, KindSet, Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
+use css_parse::{Cursor, Diagnostic, KindSet, Parse, Parser, Peek, Result as ParserResult, T};
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
 
 use super::NamespacePrefix;
@@ -114,7 +114,7 @@ impl<'a> Parse<'a> for AttributeModifier {
 				Ok(Self::Insensitive(p.parse::<T![Ident]>()?))
 			}
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/selector/moz.rs
+++ b/crates/css_ast/src/selector/moz.rs
@@ -1,6 +1,6 @@
-use crate::{DirValue, diagnostics};
+use crate::{CssDiagnostic, DirValue};
 use css_parse::{
-	Cursor, Parse, Parser, Result as ParserResult, T, function_set, pseudo_class, pseudo_element,
+	Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T, function_set, pseudo_class, pseudo_element,
 	syntax::CommaSeparated,
 };
 use csskit_derives::{ToCursors, Visitable};
@@ -194,7 +194,7 @@ impl<'a> Parse<'a> for MozFunctionalPseudoClass {
 			let close = p.parse_if_peek::<T![')']>()?;
 			Ok(Self::LocaleDir(MozLocaleDirFunctionalPseudoClass { colon, function, value, close }))
 		} else {
-			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c))?
+			Err(Diagnostic::new(c, Diagnostic::unexpected_function))?
 		}
 	}
 }

--- a/crates/css_ast/src/selector/ms.rs
+++ b/crates/css_ast/src/selector/ms.rs
@@ -1,4 +1,4 @@
-use css_parse::{pseudo_class, pseudo_element};
+use css_parse::{Diagnostic, pseudo_class, pseudo_element};
 use csskit_derives::Visitable;
 
 pseudo_element!(

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,4 +1,4 @@
-use css_parse::{KindSet, Parse, Parser, Result as ParserResult, T, diagnostics};
+use css_parse::{Diagnostic, KindSet, Parse, Parser, Result as ParserResult, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan, Visitable};
 
 use super::Tag;
@@ -82,7 +82,7 @@ impl<'a> Parse<'a> for NamespaceTag {
 		if p.peek::<Self>() {
 			if p.peek::<T![*]>() { Ok(Self::Wildcard(p.parse::<T![*]>()?)) } else { Ok(Self::Tag(p.parse::<Tag>()?)) }
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/selector/o.rs
+++ b/crates/css_ast/src/selector/o.rs
@@ -1,4 +1,4 @@
-use css_parse::{pseudo_class, pseudo_element};
+use css_parse::{Diagnostic, pseudo_class, pseudo_element};
 use csskit_derives::Visitable;
 
 pseudo_element!(

--- a/crates/css_ast/src/selector/pseudo_class.rs
+++ b/crates/css_ast/src/selector/pseudo_class.rs
@@ -1,5 +1,5 @@
-use crate::diagnostics;
-use css_parse::{Parse, Parser, Result as ParserResult, T, keyword_set};
+use crate::CssDiagnostic;
+use css_parse::{Diagnostic, Parse, Parser, Result as ParserResult, T, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 use super::{moz::MozPseudoClass, ms::MsPseudoClass, o::OPseudoClass, webkit::WebkitPseudoClass};
@@ -124,7 +124,7 @@ impl<'a> Parse<'a> for PseudoClass {
 						if let Ok(psuedo) = p.try_parse::<OPseudoClass>() {
 							return Ok(Self::O(psuedo));
 						}
-						Err(diagnostics::UnexpectedPseudoClass(p.parse_str(c).into(), c))?
+						Err(Diagnostic::new(c, Diagnostic::unexpected_pseudo_class))?
 					}
 				}
 			};

--- a/crates/css_ast/src/selector/pseudo_element.rs
+++ b/crates/css_ast/src/selector/pseudo_element.rs
@@ -1,5 +1,5 @@
-use crate::{MozPseudoElement, MsPseudoElement, OPseudoElement, WebkitPseudoElement, diagnostics};
-use css_parse::{KindSet, Parse, Parser, Result as ParserResult, T, keyword_set, pseudo_class};
+use crate::{CssDiagnostic, MozPseudoElement, MsPseudoElement, OPseudoElement, WebkitPseudoElement};
+use css_parse::{Diagnostic, KindSet, Parse, Parser, Result as ParserResult, T, keyword_set, pseudo_class};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 macro_rules! apply_pseudo_element {
@@ -82,7 +82,7 @@ impl<'a> Parse<'a> for PseudoElement {
 						if let Ok(psuedo) = p.try_parse::<OPseudoElement>() {
 							return Ok(Self::O(psuedo));
 						}
-						Err(diagnostics::UnexpectedPseudoElement(p.to_source_cursor(c).to_string(), c))?
+						Err(Diagnostic::new(c, Diagnostic::unexpected_pseudo_element))?
 					}
 				}
 			}

--- a/crates/css_ast/src/selector/tag.rs
+++ b/crates/css_ast/src/selector/tag.rs
@@ -1,4 +1,4 @@
-use css_parse::{Cursor, Parse, Parser, Peek, Result, T, diagnostics, keyword_set};
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Peek, Result, T, keyword_set};
 use csskit_derives::{IntoCursor, Parse, ToCursors, Visitable};
 
 #[derive(ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -39,7 +39,7 @@ impl<'a> Parse<'a> for Tag {
 				Ok(Self::Unknown(p.parse::<UnknownTag>()?))
 			}
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }
@@ -106,7 +106,11 @@ impl<'a> Peek<'a> for CustomElementTag {
 
 impl<'a> Parse<'a> for CustomElementTag {
 	fn parse(p: &mut Parser<'a>) -> Result<Self> {
-		if p.peek::<Self>() { p.parse::<T![Ident]>().map(Self) } else { Err(diagnostics::Unexpected(p.next()))? }
+		if p.peek::<Self>() {
+			p.parse::<T![Ident]>().map(Self)
+		} else {
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
+		}
 	}
 }
 

--- a/crates/css_ast/src/selector/webkit.rs
+++ b/crates/css_ast/src/selector/webkit.rs
@@ -1,5 +1,5 @@
-use crate::{CompoundSelector, diagnostics};
-use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, pseudo_class, pseudo_element};
+use crate::{CompoundSelector, CssDiagnostic};
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T, pseudo_class, pseudo_element};
 use csskit_derives::{ToCursors, Visitable};
 
 pseudo_element!(
@@ -90,7 +90,7 @@ impl<'a> Parse<'a> for WebkitFunctionalPseudoElement<'a> {
 			let close = p.parse_if_peek::<T![')']>()?;
 			Ok(Self::Distributed(WebkitDistrubutedFunctionalPseudoElement { colons, function, value, close }))
 		} else {
-			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c))?
+			Err(Diagnostic::new(c, Diagnostic::unexpected_function))?
 		}
 	}
 }
@@ -125,7 +125,7 @@ impl<'a> Parse<'a> for WebkitFunctionalPseudoClass<'a> {
 			let close = p.parse_if_peek::<T![')']>()?;
 			Ok(Self::Any(WebkitAnyFunctionalPseudoClass { colon, function, value, close }))
 		} else {
-			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c))?
+			Err(Diagnostic::new(c, Diagnostic::unexpected_function))?
 		}
 	}
 }

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -1,7 +1,7 @@
 use bumpalo::collections::Vec;
 use css_parse::{
-	AtRule, ComponentValues, Cursor, Parse, Parser, QualifiedRule, Result as ParserResult, RuleVariants,
-	StyleSheet as StyleSheetTrait, T, atkeyword_set, diagnostics,
+	AtRule, ComponentValues, Cursor, Diagnostic, Parse, Parser, QualifiedRule, Result as ParserResult, RuleVariants,
+	StyleSheet as StyleSheetTrait, T, atkeyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -115,7 +115,7 @@ impl<'a> RuleVariants<'a> for Rule<'a> {
 			)+ ) => {
 				match AtRuleKeywords::from_cursor(p, c) {
 					$(Some(AtRuleKeywords::$name(_)) => p.parse::<rules::$ty>().map(Self::$name),)+
-					None => Err(diagnostics::Unexpected(p.next()))?,
+					None => Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?,
 				}
 			}
 		}

--- a/crates/css_ast/src/types/animateable_feature.rs
+++ b/crates/css_ast/src/types/animateable_feature.rs
@@ -1,5 +1,4 @@
-use crate::diagnostics;
-use css_parse::{Parse, Parser, Result, T};
+use css_parse::{Diagnostic, Parse, Parser, Result, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors, Visitable};
 
 // https://drafts.csswg.org/css-will-change-1/#typedef-animateable-feature
@@ -129,7 +128,7 @@ impl<'a> Parse<'a> for AnimateableFeature {
 				_ => Ok(Self::CustomIdent(ident)),
 			}
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/types/auto_or.rs
+++ b/crates/css_ast/src/types/auto_or.rs
@@ -86,6 +86,21 @@ impl<T: ToNumberValue> ToNumberValue for AutoOr<T> {
 	}
 }
 
+impl<T: Copy> Copy for AutoOr<T> {}
+
+impl<T> From<AutoOr<T>> for Cursor
+where
+	T: Copy,
+	Cursor: From<T>,
+{
+	fn from(value: AutoOr<T>) -> Self {
+		match value {
+			AutoOr::Auto(ident) => ident.into(),
+			AutoOr::Some(t) => t.into(),
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/css_ast/src/types/autonone_or.rs
+++ b/crates/css_ast/src/types/autonone_or.rs
@@ -93,6 +93,22 @@ impl<T: ToNumberValue> ToNumberValue for AutoNoneOr<T> {
 	}
 }
 
+impl<T: Copy> Copy for AutoNoneOr<T> {}
+
+impl<T> From<AutoNoneOr<T>> for Cursor
+where
+	T: Copy,
+	Cursor: From<T>,
+{
+	fn from(value: AutoNoneOr<T>) -> Self {
+		match value {
+			AutoNoneOr::Auto(ident) => ident.into(),
+			AutoNoneOr::None(ident) => ident.into(),
+			AutoNoneOr::Some(t) => t.into(),
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/css_ast/src/types/bg_size.rs
+++ b/crates/css_ast/src/types/bg_size.rs
@@ -1,3 +1,4 @@
+use crate::CssDiagnostic;
 use css_parse::keyword_set;
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 use csskit_proc_macro::syntax;

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -1,8 +1,8 @@
 mod named;
 mod system;
 
-use crate::{ColorFunction, diagnostics};
-use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, T, keyword_set};
+use crate::{ColorFunction, CssDiagnostic};
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Peek, Result as ParserResult, T, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 pub use named::*;
@@ -99,7 +99,7 @@ impl<'a> Parse<'a> for Color {
 		} else if p.peek::<ColorFunction>() {
 			p.parse::<ColorFunction>().map(Color::Function)
 		} else {
-			Err(diagnostics::Unimplemented(p.peek_n(1)))?
+			Err(Diagnostic::new(p.peek_n(1), Diagnostic::unimplemented))?
 		}
 	}
 }

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -1,8 +1,6 @@
 #![allow(warnings)]
 use bumpalo::collections::Vec;
-use css_parse::{
-	Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set, keyword_set,
-};
+use css_parse::{Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set};
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
 use crate::{AttrFunction, ContentFunction, Counter, Image, LeaderFunction, Quote, StringFunction, Target};

--- a/crates/css_ast/src/types/font_weight_absolute.rs
+++ b/crates/css_ast/src/types/font_weight_absolute.rs
@@ -1,3 +1,4 @@
+use crate::diagnostics::CssDiagnostic;
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 use csskit_proc_macro::syntax;
 

--- a/crates/css_ast/src/types/grid_line.rs
+++ b/crates/css_ast/src/types/grid_line.rs
@@ -1,5 +1,5 @@
-use crate::{PositiveNonZeroInt, Visitable, diagnostics};
-use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, keyword_set, parse_optionals};
+use crate::{CssDiagnostic, PositiveNonZeroInt, Visitable};
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T, keyword_set, parse_optionals};
 use csskit_derives::{Peek, ToCursors, ToSpan};
 
 keyword_set!(pub enum GridLineKeywords { Auto: "auto", Span: "span" });
@@ -36,10 +36,10 @@ impl<'a> Parse<'a> for GridLine {
 		{
 			let c: Cursor = num.into();
 			if !num.is_int() {
-				Err(diagnostics::ExpectedInt(c))?
+				Err(Diagnostic::new(c, Diagnostic::expected_int))?
 			}
 			if num.value() == 0.0 {
-				Err(diagnostics::UnexpectedZero(c))?
+				Err(Diagnostic::new(c, Diagnostic::unexpected_zero))?
 			}
 		}
 

--- a/crates/css_ast/src/types/none_or.rs
+++ b/crates/css_ast/src/types/none_or.rs
@@ -86,6 +86,21 @@ impl<T: ToNumberValue> ToNumberValue for NoneOr<T> {
 	}
 }
 
+impl<T: Copy> Copy for NoneOr<T> {}
+
+impl<T> From<NoneOr<T>> for Cursor
+where
+	T: Copy,
+	Cursor: From<T>,
+{
+	fn from(value: NoneOr<T>) -> Self {
+		match value {
+			NoneOr::None(ident) => ident.into(),
+			NoneOr::Some(t) => t.into(),
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/css_ast/src/types/opacity_value.rs
+++ b/crates/css_ast/src/types/opacity_value.rs
@@ -1,3 +1,4 @@
+use crate::diagnostics::CssDiagnostic;
 use css_parse::T;
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 

--- a/crates/css_ast/src/types/or_keywords.rs
+++ b/crates/css_ast/src/types/or_keywords.rs
@@ -27,7 +27,7 @@ where
 {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		if p.peek::<AutoKeyword>() {
-			p.parse::<AutoKeyword>().map(|kw| Self::Auto(kw.into()))
+			p.parse::<AutoKeyword>().map(|kw| Self::Auto(kw)))
 		} else {
 			p.parse::<T>().map(Self::Some)
 		}

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -1,5 +1,5 @@
 use crate::LengthPercentage;
-use css_parse::{Cursor, Kind, Parse, Parser, Peek, Result as ParserResult, T, Token, diagnostics, keyword_set};
+use css_parse::{Cursor, Diagnostic, Kind, Parse, Parser, Peek, Result as ParserResult, T, Token, keyword_set};
 use csskit_derives::{IntoCursor, ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-values-4/#position
@@ -47,7 +47,7 @@ impl<'a> Parse<'a> for Position {
 				if let Some(vertical) = first.to_vertical() {
 					return Ok(Self::TwoValue(horizontal, vertical));
 				} else {
-					Err(diagnostics::Unexpected(second.into()))?
+					Err(Diagnostic::new(second.into(), Diagnostic::unexpected))?
 				}
 			}
 		}
@@ -55,12 +55,12 @@ impl<'a> Parse<'a> for Position {
 		if matches!(first, PositionSingleValue::Center(_) | PositionSingleValue::LengthPercentage(_))
 			|| !matches!(&second, PositionSingleValue::LengthPercentage(_))
 		{
-			Err(diagnostics::Unexpected(second.into()))?
+			Err(Diagnostic::new(second.into(), Diagnostic::unexpected))?
 		}
 		let third = p.parse::<PositionSingleValue>()?;
 		if third.to_horizontal_keyword().is_none() && third.to_vertical_keyword().is_none() {
 			let cursor: Cursor = third.into();
-			Err(diagnostics::UnexpectedIdent(p.parse_str(cursor).into(), cursor))?
+			Err(Diagnostic::new(cursor, Diagnostic::expected_ident))?
 		}
 		let fourth = p.parse::<LengthPercentage>()?;
 		if let PositionSingleValue::LengthPercentage(second) = second {
@@ -68,19 +68,19 @@ impl<'a> Parse<'a> for Position {
 				if let Some(vertical) = third.to_vertical_keyword() {
 					Ok(Self::FourValue(horizontal, second, vertical, fourth))
 				} else {
-					Err(diagnostics::Unexpected(third.into()))?
+					Err(Diagnostic::new(third.into(), Diagnostic::unexpected))?
 				}
 			} else if let Some(horizontal) = third.to_horizontal_keyword() {
 				if let Some(vertical) = first.to_vertical_keyword() {
 					Ok(Self::FourValue(horizontal, fourth, vertical, second))
 				} else {
-					Err(diagnostics::Unexpected(third.into()))?
+					Err(Diagnostic::new(third.into(), Diagnostic::unexpected))?
 				}
 			} else {
-				Err(diagnostics::Unexpected(third.into()))?
+				Err(Diagnostic::new(third.into(), Diagnostic::unexpected))?
 			}
 		} else {
-			Err(diagnostics::Unexpected(second.into()))?
+			Err(Diagnostic::new(second.into(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/types/position_area.rs
+++ b/crates/css_ast/src/types/position_area.rs
@@ -1,5 +1,4 @@
-use crate::diagnostics;
-use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, keyword_set};
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Peek, Result as ParserResult, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-anchor-position-1/#typedef-position-area
@@ -72,7 +71,7 @@ impl<'a> Parse<'a> for PositionArea {
 		} else if let Some(vertical) = p.parse_if_peek::<PositionAreaPhsyicalVertical>()? {
 			Ok(Self::Physical(p.parse_if_peek::<PositionAreaPhsyicalHorizontal>()?, Some(vertical)))
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/types/positive_non_zero_int.rs
+++ b/crates/css_ast/src/types/positive_non_zero_int.rs
@@ -1,5 +1,5 @@
-use crate::{CSSInt, diagnostics};
-use css_parse::{Parse, Parser, Result as ParserResult, ToSpan};
+use crate::{CSSInt, CssDiagnostic};
+use css_parse::{Diagnostic, Parse, Parser, Result as ParserResult};
 use csskit_derives::{Peek, ToCursors, ToSpan};
 
 #[derive(ToSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -10,7 +10,7 @@ impl<'a> Parse<'a> for PositiveNonZeroInt {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		let num = p.parse::<CSSInt>()?;
 		if 0.0f32 >= num.into() {
-			Err(diagnostics::NumberTooSmall(0.0, num.to_span()))?
+			Err(Diagnostic::new(num.into(), Diagnostic::number_too_small))?
 		}
 
 		Ok(Self(num))

--- a/crates/css_ast/src/types/shadow.rs
+++ b/crates/css_ast/src/types/shadow.rs
@@ -1,5 +1,6 @@
-use crate::{Color, Length, diagnostics};
-use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, T, ToSpan};
+use crate::CssDiagnostic;
+use crate::{Color, Length};
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Peek, Result as ParserResult, T};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-backgrounds-3/#typedef-shadow
@@ -32,7 +33,7 @@ impl<'a> Parse<'a> for Shadow {
 		let blur_radius = p.parse_if_peek::<Length>()?;
 		if let Some(blur) = blur_radius {
 			if 0.0f32 > blur.into() {
-				Err(diagnostics::NumberTooSmall(0.0f32, blur.to_span()))?
+				Err(Diagnostic::new(blur.into(), Diagnostic::number_too_small))?
 			}
 		}
 
@@ -42,8 +43,7 @@ impl<'a> Parse<'a> for Shadow {
 		if let Some(ident) = inset {
 			if !p.eq_ignore_ascii_case(ident.into(), "inset") {
 				let c: Cursor = x.into();
-				let source_cursor = p.to_source_cursor(c);
-				Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), c))?
+				Err(Diagnostic::new(c, Diagnostic::unexpected_ident))?
 			}
 		}
 

--- a/crates/css_ast/src/types/single_animation_iteration_count.rs
+++ b/crates/css_ast/src/types/single_animation_iteration_count.rs
@@ -1,3 +1,4 @@
+use crate::CssDiagnostic;
 use css_parse::{T, keyword_set};
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -1,4 +1,4 @@
-use css_parse::{DimensionUnit, Parse, Parser, Result as ParserResult, T, ToNumberValue, diagnostics};
+use css_parse::{Diagnostic, DimensionUnit, Parse, Parser, Result as ParserResult, T, ToNumberValue};
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 
 // https://drafts.csswg.org/css-values/#angles
@@ -53,7 +53,7 @@ impl<'a> Parse<'a> for Angle {
 			DimensionUnit::Rad => p.parse::<T![Dimension]>().map(Self::Rad),
 			DimensionUnit::Turn => p.parse::<T![Dimension]>().map(Self::Turn),
 			DimensionUnit::Deg => p.parse::<T![Dimension]>().map(Self::Deg),
-			_ => Err(diagnostics::Unexpected(p.next()))?,
+			_ => Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?,
 		}
 	}
 }

--- a/crates/css_ast/src/units/custom.rs
+++ b/crates/css_ast/src/units/custom.rs
@@ -1,4 +1,4 @@
-use css_parse::{Cursor, DimensionUnit, Parse, Parser, Peek, Result, T, diagnostics};
+use css_parse::{Cursor, Diagnostic, DimensionUnit, Parse, Parser, Peek, Result, T};
 use csskit_derives::{IntoCursor, ToCursors};
 
 #[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -23,7 +23,7 @@ impl<'a> Parse<'a> for CustomDimension {
 			let c = p.next();
 			Ok(Self(T![Dimension](c)))
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/units/float.rs
+++ b/crates/css_ast/src/units/float.rs
@@ -1,4 +1,4 @@
-use css_parse::{Cursor, Parse, Parser, Peek, Result, T, diagnostics};
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Peek, Result, T};
 use csskit_derives::{IntoCursor, ToCursors};
 
 #[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -34,7 +34,7 @@ impl<'a> Parse<'a> for CSSFloat {
 			let c = p.next();
 			Ok(Self(T![Number](c)))
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/units/frequency.rs
+++ b/crates/css_ast/src/units/frequency.rs
@@ -1,4 +1,4 @@
-use css_parse::{DimensionUnit, Parse, Parser, Result, T, diagnostics};
+use css_parse::{Diagnostic, DimensionUnit, Parse, Parser, Result, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors};
 
 // https://drafts.csswg.org/css-values/#resolution
@@ -24,7 +24,7 @@ impl<'a> Parse<'a> for Frequency {
 		match c.token().dimension_unit() {
 			DimensionUnit::Hz => p.parse::<T![Dimension]>().map(Self::Hz),
 			DimensionUnit::Khz => p.parse::<T![Dimension]>().map(Self::Khz),
-			_ => Err(diagnostics::Unexpected(p.next()))?,
+			_ => Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?,
 		}
 	}
 }

--- a/crates/css_ast/src/units/int.rs
+++ b/crates/css_ast/src/units/int.rs
@@ -1,4 +1,4 @@
-use css_parse::{Cursor, Parse, Parser, Peek, Result, T, ToNumberValue, diagnostics};
+use css_parse::{Cursor, Diagnostic, Parse, Parser, Peek, Result, T, ToNumberValue};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 #[derive(IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -41,7 +41,7 @@ impl<'a> Parse<'a> for CSSInt {
 			let c = p.next();
 			Ok(Self(T![Number](c)))
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -1,5 +1,5 @@
 use crate::{Flex, Percentage};
-use css_parse::{Cursor, DimensionUnit, Parse, Parser, Peek, Result, T, ToNumberValue, diagnostics};
+use css_parse::{Cursor, Diagnostic, DimensionUnit, Parse, Parser, Peek, Result, T, ToNumberValue};
 use csskit_derives::{IntoCursor, Peek, ToCursors, Visitable};
 
 macro_rules! apply_lengths {
@@ -218,7 +218,7 @@ impl<'a> Parse<'a> for LengthPercentageOrFlex {
 				Ok(Self::LengthPercentage(p.parse::<LengthPercentage>()?))
 			}
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }
@@ -257,7 +257,7 @@ impl<'a> Parse<'a> for NumberLength {
 				Ok(Self::Number(T![Number](c)))
 			}
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_ast/src/units/percentage.rs
+++ b/crates/css_ast/src/units/percentage.rs
@@ -1,7 +1,5 @@
-use css_parse::{Cursor, DimensionUnit, Parse, Parser, Peek, Result as ParserResult, T, ToNumberValue};
+use css_parse::{Cursor, Diagnostic, DimensionUnit, Parse, Parser, Peek, Result as ParserResult, T, ToNumberValue};
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
-
-use crate::diagnostics;
 
 #[derive(IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -40,7 +38,11 @@ impl<'a> Peek<'a> for Percentage {
 
 impl<'a> Parse<'a> for Percentage {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		if !p.peek::<Self>() { Err(diagnostics::Unexpected(p.next()))? } else { p.parse::<T![Dimension]>().map(Self) }
+		if !p.peek::<Self>() {
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
+		} else {
+			p.parse::<T![Dimension]>().map(Self)
+		}
 	}
 }
 

--- a/crates/css_ast/src/units/resolution.rs
+++ b/crates/css_ast/src/units/resolution.rs
@@ -1,4 +1,4 @@
-use css_parse::{DimensionUnit, Parse, Parser, Result, T, diagnostics};
+use css_parse::{Diagnostic, DimensionUnit, Parse, Parser, Result, T};
 use csskit_derives::{IntoCursor, Peek, ToCursors};
 
 // const DPPX_IN: f32 = 96.0;
@@ -33,7 +33,7 @@ impl<'a> Parse<'a> for Resolution {
 			DimensionUnit::Dpcm => p.parse::<T![Dimension]>().map(Self::Dpcm),
 			DimensionUnit::Dppx => p.parse::<T![Dimension]>().map(Self::Dppx),
 			DimensionUnit::X => p.parse::<T![Dimension]>().map(Self::X),
-			_ => Err(diagnostics::Unexpected(p.next()))?,
+			_ => Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?,
 		}
 	}
 }

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -1,4 +1,4 @@
-use css_parse::{Cursor, DimensionUnit, Parse, Parser, Peek, Result, T, ToNumberValue, diagnostics};
+use css_parse::{Cursor, Diagnostic, DimensionUnit, Parse, Parser, Peek, Result, T, ToNumberValue};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 // https://drafts.csswg.org/css-values/#resolution
@@ -41,7 +41,7 @@ impl<'a> Parse<'a> for Time {
 				if number.value() == 0.0 {
 					Ok(Self::Zero(number))
 				} else {
-					Err(diagnostics::Unexpected(number.into()).into())
+					Err(Diagnostic::new(number.into(), Diagnostic::unexpected))
 				}
 			})
 		} else {
@@ -49,7 +49,7 @@ impl<'a> Parse<'a> for Time {
 			match dimension.dimension_unit() {
 				DimensionUnit::S => Ok(Self::S(dimension)),
 				DimensionUnit::Ms => Ok(Self::Ms(dimension)),
-				_ => Err(diagnostics::Unexpected(dimension.into()))?,
+				_ => Err(Diagnostic::new(dimension.into(), Diagnostic::unexpected))?,
 			}
 		}
 	}

--- a/crates/css_ast/src/values/align/impls.rs
+++ b/crates/css_ast/src/values/align/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/anchor_position/impls.rs
+++ b/crates/css_ast/src/values/anchor_position/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/animations/impls.rs
+++ b/crates/css_ast/src/values/animations/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/backgrounds/impls.rs
+++ b/crates/css_ast/src/values/backgrounds/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/borders/impls.rs
+++ b/crates/css_ast/src/values/borders/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/box/impls.rs
+++ b/crates/css_ast/src/values/box/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/break/impls.rs
+++ b/crates/css_ast/src/values/break/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/cascade/impls.rs
+++ b/crates/css_ast/src/values/cascade/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/color/impls.rs
+++ b/crates/css_ast/src/values/color/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/color_adjust/impls.rs
+++ b/crates/css_ast/src/values/color_adjust/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/color_hdr/impls.rs
+++ b/crates/css_ast/src/values/color_hdr/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/conditional/impls.rs
+++ b/crates/css_ast/src/values/conditional/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/contain/impls.rs
+++ b/crates/css_ast/src/values/contain/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/content/impls.rs
+++ b/crates/css_ast/src/values/content/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/display/impls.rs
+++ b/crates/css_ast/src/values/display/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/exclusions/impls.rs
+++ b/crates/css_ast/src/values/exclusions/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/flexbox/impls.rs
+++ b/crates/css_ast/src/values/flexbox/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/fonts/mod.rs
+++ b/crates/css_ast/src/values/fonts/mod.rs
@@ -2,6 +2,8 @@
 //! CSS Fonts Module Level 5
 //! https://drafts.csswg.org/css-fonts-5/
 
+use crate::diagnostics::CssDiagnostic;
+
 mod impls;
 use impls::*;
 

--- a/crates/css_ast/src/values/forms/impls.rs
+++ b/crates/css_ast/src/values/forms/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/gaps/impls.rs
+++ b/crates/css_ast/src/values/gaps/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/gcpm/impls.rs
+++ b/crates/css_ast/src/values/gcpm/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/grid/impls.rs
+++ b/crates/css_ast/src/values/grid/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/images/impls.rs
+++ b/crates/css_ast/src/values/images/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/inline/impls.rs
+++ b/crates/css_ast/src/values/inline/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/line_grid/impls.rs
+++ b/crates/css_ast/src/values/line_grid/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/link_params/impls.rs
+++ b/crates/css_ast/src/values/link_params/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/lists/impls.rs
+++ b/crates/css_ast/src/values/lists/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/logical/impls.rs
+++ b/crates/css_ast/src/values/logical/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/multicol/impls.rs
+++ b/crates/css_ast/src/values/multicol/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/nav/impls.rs
+++ b/crates/css_ast/src/values/nav/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/overflow/impls.rs
+++ b/crates/css_ast/src/values/overflow/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/overscroll/impls.rs
+++ b/crates/css_ast/src/values/overscroll/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/page/impls.rs
+++ b/crates/css_ast/src/values/page/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/page_floats/impls.rs
+++ b/crates/css_ast/src/values/page_floats/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/position/impls.rs
+++ b/crates/css_ast/src/values/position/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/regions/impls.rs
+++ b/crates/css_ast/src/values/regions/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/rhythm/impls.rs
+++ b/crates/css_ast/src/values/rhythm/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/round_display/impls.rs
+++ b/crates/css_ast/src/values/round_display/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/ruby/impls.rs
+++ b/crates/css_ast/src/values/ruby/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/scroll_anchoring/impls.rs
+++ b/crates/css_ast/src/values/scroll_anchoring/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/scroll_snap/impls.rs
+++ b/crates/css_ast/src/values/scroll_snap/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/scrollbars/impls.rs
+++ b/crates/css_ast/src/values/scrollbars/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/shapes/impls.rs
+++ b/crates/css_ast/src/values/shapes/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/size_adjust/impls.rs
+++ b/crates/css_ast/src/values/size_adjust/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/sizing/impls.rs
+++ b/crates/css_ast/src/values/sizing/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/speech/impls.rs
+++ b/crates/css_ast/src/values/speech/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/tables/impls.rs
+++ b/crates/css_ast/src/values/tables/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/text/impls.rs
+++ b/crates/css_ast/src/values/text/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/text_decor/impls.rs
+++ b/crates/css_ast/src/values/text_decor/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/transforms/impls.rs
+++ b/crates/css_ast/src/values/transforms/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/transitions/impls.rs
+++ b/crates/css_ast/src/values/transitions/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/ui/impls.rs
+++ b/crates/css_ast/src/values/ui/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/values/impls.rs
+++ b/crates/css_ast/src/values/values/impls.rs
@@ -1,3 +1,3 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;

--- a/crates/css_ast/src/values/view_transitions/impls.rs
+++ b/crates/css_ast/src/values/view_transitions/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/viewport/impls.rs
+++ b/crates/css_ast/src/values/viewport/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/will_change/impls.rs
+++ b/crates/css_ast/src/values/will_change/impls.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 

--- a/crates/css_ast/src/values/writing_modes/impls.rs
+++ b/crates/css_ast/src/values/writing_modes/impls.rs
@@ -1,7 +1,6 @@
 use super::{GlyphOrientationVerticalKeywords, GlyphOrientationVerticalStyleValue};
-use css_parse::{Parse, Parser, Peek, Result as ParseResult, T};
-
-pub(crate) use crate::traits::StyleValue;
+pub(crate) use crate::{CssDiagnostic, traits::StyleValue};
+use css_parse::{Diagnostic, Parse, Parser, Peek, Result as ParseResult, T};
 pub(crate) use csskit_derives::*;
 pub(crate) use csskit_proc_macro::*;
 
@@ -22,7 +21,7 @@ impl<'a> Parse<'a> for GlyphOrientationVerticalStyleValue {
 					}
 				}
 				if let Some(tk) = p.parse_if_peek::<T![Dimension]>()? {
-					match tk.into() {
+					match (tk.into(), tk.dimension_unit()) {
 						(0f32, ::css_parse::DimensionUnit::Deg) => {
 							return Ok(Self::Literal0deg(tk));
 						}
@@ -32,7 +31,7 @@ impl<'a> Parse<'a> for GlyphOrientationVerticalStyleValue {
 						_ => {}
 					}
 				}
-				Err(crate::diagnostics::Unexpected(p.next()))?
+				Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 			}
 		}
 	}

--- a/crates/css_parse/Cargo.toml
+++ b/crates/css_parse/Cargo.toml
@@ -19,8 +19,8 @@ css_lexer = { workspace = true, features = ["miette"] }
 bumpalo = { workspace = true }
 smallvec = { workspace = true }
 
-miette = { workspace = true, features = ["derive"] }
-thiserror = { workspace = true }
+miette = { workspace = true, features = ["derive"], optional = true }
+thiserror = { workspace = true, optional = true }
 bitmask-enum = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -33,5 +33,6 @@ glob = { workspace = true }
 [features]
 default = []
 testing = []
+miette = ["dep:miette", "dep:thiserror", "css_lexer/miette"]
 serde = ["dep:serde", "dep:serde_json", "css_lexer/serde", "bumpalo/serde"]
-fancy = ["miette/fancy-no-backtrace"]
+fancy = ["miette", "miette/fancy-no-backtrace"]

--- a/crates/css_parse/src/comparison.rs
+++ b/crates/css_parse/src/comparison.rs
@@ -1,4 +1,4 @@
-use crate::{Parse, Parser, Result, T, ToCursors, diagnostics};
+use crate::{Diagnostic, Parse, Parser, Result, T, ToCursors};
 
 /// This enum represents a set of comparison operators, used in Ranged Media Features (see
 /// [RangedFeature][crate::RangedFeature]), and could be used in other parts of a CSS-alike language. This isn't a
@@ -44,8 +44,8 @@ impl<'a> Parse<'a> for Comparison {
 					p.parse::<T![<]>().map(Comparison::LessThan)
 				}
 			}
-			Some(char) => Err(diagnostics::UnexpectedDelim(char, p.next()))?,
-			_ => Err(diagnostics::Unexpected(p.next()))?,
+			Some(_) => Err(Diagnostic::new(p.next(), Diagnostic::unexpected_delim))?,
+			_ => Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?,
 		}
 	}
 }

--- a/crates/css_parse/src/diagnostics.rs
+++ b/crates/css_parse/src/diagnostics.rs
@@ -1,81 +1,263 @@
-use crate::{Cursor, Kind, Span};
-use miette::Diagnostic;
-use thiserror::Error;
+use crate::{Cursor, Kind};
+use css_lexer::Span;
+#[cfg(feature = "miette")]
+use miette::{MietteDiagnostic, Severity as MietteSeverity};
+use std::fmt::{Display, Formatter, Result};
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("This declaration wasn't understood, and so was disregarded.")]
-#[diagnostic(code(css_parse::BadDeclaration))]
-#[help("The declaration contains invalid syntax, and will be ignored.")]
-pub struct BadDeclaration(#[label("This is not valid syntax for a declaration.")] pub Span);
+type DiagnosticFormatter = fn(&Diagnostic, &str) -> DiagnosticMeta;
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected `{}`", Kind::from(self.0))]
-#[diagnostic(code(css_parse::Unexpected))]
-#[help("This is not correct CSS syntax.")]
-pub struct Unexpected(#[label("This wasn't expected here")] pub Cursor);
+/// An issue that occured during parse time.
+#[derive(Debug, Copy, Clone)]
+pub struct Diagnostic {
+	/// How severe this error is.
+	pub severity: Severity,
+	/// The first cursor where this error occured.
+	pub start_cursor: Cursor,
+	/// The last cursor that was consumed to recover from this error.
+	pub end_cursor: Cursor,
+	/// A cursor representing what was expected.
+	pub desired_cursor: Option<Cursor>,
+	/// Function pointer to format the message template with cursor/span data
+	pub formatter: DiagnosticFormatter,
+}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected identifier '{0}'")]
-#[diagnostic(code(css_parse::UnexpectedIdent))]
-#[help("There is an extra word which shouldn't be in this position.")]
-pub struct UnexpectedIdent(pub String, #[label("Try removing the word here.")] pub Cursor);
+pub struct DiagnosticMeta {
+	pub code: &'static str,
+	pub message: String,
+	pub help: String,
+	pub labels: Vec<(Span, String)>,
+}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected delimeter '{0}'")]
-#[diagnostic(code(css_parse::UnexpectedDelim))]
-#[help("Try removing the the character.")]
-pub struct UnexpectedDelim(pub char, #[label("This character wasn't understood")] pub Cursor);
+#[derive(Debug, Clone, Copy)]
+pub enum Severity {
+	Advice,
+	Warning,
+	Error,
+}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected tag name ':{0}'")]
-#[diagnostic(code(css_parse::UnexpectedTag))]
-#[help("This isn't a valid tag name.")]
-pub struct UnexpectedTag(pub String, #[label("This tag")] pub Cursor);
+impl Severity {
+	pub const fn as_str(&self) -> &str {
+		match *self {
+			Self::Advice => "Advice",
+			Self::Warning => "Warning",
+			Self::Error => "Error",
+		}
+	}
+}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected ID selector ':{0}'")]
-#[diagnostic(code(css_parse::UnexpectedId))]
-#[help("This isn't a valid ID.")]
-pub struct UnexpectedId(pub String, #[label("This ID")] pub Cursor);
+impl Display for Severity {
+	fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+		write!(f, "{}", self.as_str())
+	}
+}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Ignored property due to parse error.")]
-#[diagnostic(code(css_parse::UnknownDeclaration))]
-#[help("This property is going to be ignored because it doesn't look valid. If it is valid, please file an issue!")]
-pub struct UnknownDeclaration(#[label("This property was ignored.")] pub Span);
+#[cfg(feature = "miette")]
+impl From<Severity> for MietteSeverity {
+	fn from(value: Severity) -> Self {
+		match value {
+			Severity::Advice => MietteSeverity::Advice,
+			Severity::Warning => MietteSeverity::Warning,
+			Severity::Error => MietteSeverity::Error,
+		}
+	}
+}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected this to be the end of the file, but there was more content.")]
-#[diagnostic(code(css_parse::ExpectedEnd))]
-#[help("This is likely a problem with the parser. Please submit a bug report!")]
-pub struct ExpectedEnd(#[label("All of this extra content was ignored.")] pub Span);
+impl Diagnostic {
+	/// Create a new diagnostic
+	pub fn new(start_cursor: Cursor, formatter: DiagnosticFormatter) -> Self {
+		Self { severity: Severity::Error, start_cursor, end_cursor: start_cursor, desired_cursor: None, formatter }
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected more content but reached the end of the file.")]
-#[diagnostic(code(css_parse::UnexpectedEnd))]
-#[help("Perhaps this file isn't finished yet?")]
-pub struct UnexpectedEnd();
+	/// Apply a severity to the given Diagnostic.
+	pub fn with_severity(mut self, severity: Severity) -> Self {
+		self.severity = severity;
+		self
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected more content before this curly brace.")]
-#[diagnostic(code(css_parse::UnexpectedCloseCurly))]
-#[help("This needed more content here")]
-pub struct UnexpectedCloseCurly(pub Cursor);
+	/// Apply an end Cursor to the given Diagnostic.
+	pub fn with_end_cursor(mut self, end_cursor: Cursor) -> Self {
+		self.end_cursor = end_cursor;
+		self
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected an identifier but found `{}`", Kind::from(self.0))]
-#[diagnostic(code(css_parse::ExpectedIdent))]
-#[help("This is not correct CSS syntax.")]
-pub struct ExpectedIdent(#[label("This should be an identifier")] pub Cursor);
+	/// Get formatted message
+	pub fn message(&self, source: &str) -> String {
+		let DiagnosticMeta { message, .. } = (self.formatter)(self, source);
+		message
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected the identifier `{0}` but found `{1}`")]
-#[diagnostic(code(css_parse::ExpectedIdentOf))]
-#[help("Try changing `{1}` to `{0}`.")]
-pub struct ExpectedIdentOf(pub &'static str, pub String, #[label("This should be `{0}`")] pub Cursor);
+	/// Get diagnostic code
+	pub fn code(&self, source: &str) -> &'static str {
+		let DiagnosticMeta { code, .. } = (self.formatter)(self, source);
+		code
+	}
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected a delimiter but saw `{}`", Kind::from(self.0))]
-#[diagnostic(code(css_parse::ExpectedDelim))]
-#[help("This is not correct CSS syntax.")]
-pub struct ExpectedDelim(#[label("Here")] pub Cursor);
+	/// Get help text
+	pub fn help(&self, source: &str) -> String {
+		let DiagnosticMeta { help, .. } = (self.formatter)(self, source);
+		help
+	}
+
+	/// Add a desired cursor (what was expected)
+	pub fn with_desired_cursor(mut self, cursor: Cursor) -> Self {
+		self.desired_cursor = Some(cursor);
+		self
+	}
+
+	/// Convert to a full miette diagnostic for display
+	#[cfg(feature = "miette")]
+	pub fn into_diagnostic(self, source: &str) -> MietteDiagnostic {
+		use miette::LabeledSpan;
+		let DiagnosticMeta { code, message, help, mut labels } = (self.formatter)(&self, source);
+		let miette_labels = labels.drain(0..).map(|(span, label)| LabeledSpan::new_with_span(Some(label), span));
+		MietteDiagnostic::new(message)
+			.with_code(code)
+			.with_severity(self.severity.into())
+			.with_help(help)
+			.with_labels(miette_labels)
+	}
+
+	// Fomatting functions
+
+	pub fn unexpected(diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::Unexpected",
+			message: format!("Unexpected `{:?}`", Kind::from(diagnostic.start_cursor)),
+			help: "This is not correct CSS syntax.".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn unexpected_ident(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let start = cursor.offset().0 as usize;
+		let len = cursor.token().len() as usize;
+		let message = if start + len <= source.len() {
+			let text = &source[start..start + len];
+			format!("Unexpected identifier '{text}'")
+		} else {
+			"Unexpected identifier".to_string()
+		};
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedIdent",
+			message,
+			help: "There is an extra word which shouldn't be in this position.".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn unexpected_delim(diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let message = if let Some(char) = cursor.token().char() {
+			format!("Unexpected delimiter '{char}'")
+		} else {
+			"Unexpected delimiter".to_string()
+		};
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedDelim",
+			message,
+			help: "Try removing the character.".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn expected_ident(diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::ExpectedIdent",
+			message: format!("Expected an identifier but found `{:?}`", Kind::from(diagnostic.start_cursor)),
+			help: "This is not correct CSS syntax.".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn expected_delim(diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::ExpectedDelim",
+			message: format!("Expected a delimiter but saw `{:?}`", Kind::from(diagnostic.start_cursor)),
+			help: "This is not correct CSS syntax.".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn bad_declaration(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::BadDeclaration",
+			message: "This declaration wasn't understood, and so was disregarded.".to_string(),
+			help: "The declaration contains invalid syntax, and will be ignored.".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn unknown_declaration(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::UnknownDeclaration",
+			message: "Ignored property due to parse error.".to_string(),
+			help: "This property is going to be ignored because it doesn't look valid. If it is valid, please file an issue!"
+				.into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn expected_end(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::ExpectedEnd",
+			message: "Expected this to be the end of the file, but there was more content.".to_string(),
+			help: "This is likely a problem with the parser. Please submit a bug report!".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn unexpected_end(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedEnd",
+			message: "Expected more content but reached the end of the file.".to_string(),
+			help: "Perhaps this file isn't finished yet?".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn unexpected_close_curly(_diagnostic: &Diagnostic, _source: &str) -> DiagnosticMeta {
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedCloseCurly",
+			message: "Expected more content before this curly brace.".to_string(),
+			help: "This needed more content here".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn unexpected_tag(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let start = cursor.offset().0 as usize;
+		let len = cursor.token().len() as usize;
+		let message = if start + len <= source.len() {
+			let text = &source[start..start + len];
+			format!("Unexpected tag name '{text}'")
+		} else {
+			"Unexpected tag name".to_string()
+		};
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedTag",
+			message,
+			help: "This isn't a valid tag name.".into(),
+			labels: vec![],
+		}
+	}
+
+	pub fn unexpected_id(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let start = cursor.offset().0 as usize;
+		let len = cursor.token().len() as usize;
+		let message = if start + len <= source.len() {
+			let text = &source[start..start + len];
+			format!("Unexpected ID selector '{text}'")
+		} else {
+			"Unexpected ID selector".to_string()
+		};
+		DiagnosticMeta {
+			code: "css_parse::UnexpectedId",
+			message,
+			help: "This isn't a valid ID.".into(),
+			labels: vec![],
+		}
+	}
+}

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -296,14 +296,18 @@ pub mod test_helpers;
 pub mod token_macros;
 mod traits;
 
+pub type Result<T> = std::result::Result<T, diagnostics::Diagnostic>;
+
 pub use comparison::*;
 pub use cursor_compact_write_sink::*;
 pub use cursor_overlay_sink::*;
 pub use cursor_pretty_write_sink::*;
 pub use cursor_write_sink::*;
+pub use diagnostics::*;
 pub use feature::*;
 pub use macros::optionals::*;
-pub use miette::{Error, Result};
+#[cfg(feature = "miette")]
+pub use miette::Error;
 pub use parser::*;
 pub use parser_checkpoint::*;
 pub use parser_return::*;

--- a/crates/css_parse/src/macros/optionals.rs
+++ b/crates/css_parse/src/macros/optionals.rs
@@ -80,7 +80,7 @@ macro_rules! parse_optionals {
 			}
 
 			if $($name.is_none())&&+ {
-				Err($crate::diagnostics::Unexpected($p.next()))?
+				Err($crate::Diagnostic::new($p.next(), $crate::Diagnostic::unexpected))?
 			}
 
 			(($($name),+))

--- a/crates/css_parse/src/macros/pseudo_class.rs
+++ b/crates/css_parse/src/macros/pseudo_class.rs
@@ -64,7 +64,7 @@ macro_rules! pseudo_class {
 					}
 				} else {
 					use $crate::ToSpan;
-					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.into()))?
+					Err($crate::Diagnostic::new(ident.into(), $crate::Diagnostic::unexpected_ident))?
 				}
 			}
 		}

--- a/crates/css_parse/src/macros/pseudo_element.rs
+++ b/crates/css_parse/src/macros/pseudo_element.rs
@@ -62,7 +62,7 @@ macro_rules! pseudo_element {
 					}
 				} else {
 					use $crate::ToSpan;
-					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.into()))?
+					Err($crate::Diagnostic::new(ident.into(), Diagnostic::unexpected_ident))?
 				}
 			}
 		}

--- a/crates/css_parse/src/parser_return.rs
+++ b/crates/css_parse/src/parser_return.rs
@@ -1,4 +1,5 @@
-use crate::{Cursor, CursorSink, Error, ToCursors};
+use crate::{Cursor, CursorSink, Diagnostic, ToCursors};
+use bumpalo::collections::Vec;
 
 #[derive(Debug)]
 pub struct ParserReturn<'a, T>
@@ -7,13 +8,13 @@ where
 {
 	pub output: Option<T>,
 	pub source_text: &'a str,
-	pub errors: Vec<Error>,
-	pub trivia: Vec<Cursor>,
+	pub errors: Vec<'a, Diagnostic>,
+	pub trivia: Vec<'a, Cursor>,
 	with_trivia: bool,
 }
 
 impl<'a, T: ToCursors> ParserReturn<'a, T> {
-	pub fn new(output: Option<T>, source_text: &'a str, errors: Vec<Error>, trivia: Vec<Cursor>) -> Self {
+	pub fn new(output: Option<T>, source_text: &'a str, errors: Vec<'a, Diagnostic>, trivia: Vec<'a, Cursor>) -> Self {
 		Self { output, source_text, errors, trivia, with_trivia: false }
 	}
 

--- a/crates/css_parse/src/syntax/bang_important.rs
+++ b/crates/css_parse/src/syntax/bang_important.rs
@@ -1,4 +1,4 @@
-use crate::{Cursor, CursorSink, Kind, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan, diagnostics};
+use crate::{Cursor, CursorSink, Diagnostic, Kind, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan};
 
 /// Represents a two tokens, the first being [Kind::Delim] where the char is `!`, and the second being an `Ident` with
 /// the value `important`. [CSS defines this as]:
@@ -41,8 +41,7 @@ impl<'a> Parse<'a> for BangImportant {
 		let bang = p.parse::<T![!]>()?;
 		let important = p.parse::<T![Ident]>()?;
 		if !p.eq_ignore_ascii_case(important.into(), "important") {
-			let source_cursor = p.to_source_cursor(important.into());
-			Err(diagnostics::ExpectedIdentOf("important", source_cursor.to_string(), important.into()))?
+			Err(Diagnostic::new(important.into(), Diagnostic::unexpected_ident))?
 		}
 		Ok(Self { bang, important })
 	}

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -1,6 +1,6 @@
 use crate::{
-	AssociatedWhitespaceRules, Cursor, CursorSink, FunctionBlock, Kind, KindSet, Parse, Parser, Peek,
-	Result as ParserResult, SimpleBlock, Span, State, T, ToCursors, ToSpan, diagnostics,
+	AssociatedWhitespaceRules, Cursor, CursorSink, Diagnostic, FunctionBlock, Kind, KindSet, Parse, Parser, Peek,
+	Result as ParserResult, SimpleBlock, Span, State, T, ToCursors, ToSpan,
 };
 
 // https://drafts.csswg.org/css-syntax-3/#consume-component-value
@@ -93,7 +93,7 @@ impl<'a> Parse<'a> for ComponentValue<'a> {
 		} else if p.peek::<T![,]>() {
 			p.parse::<T![,]>().map(Self::Comma)
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_parse/src/syntax/declaration_rule_list.rs
+++ b/crates/css_parse/src/syntax/declaration_rule_list.rs
@@ -1,5 +1,5 @@
 use crate::{
-	Declaration, DeclarationValue, Kind, KindSet, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan, diagnostics,
+	Declaration, DeclarationValue, Diagnostic, Kind, KindSet, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan,
 	token_macros,
 };
 use bumpalo::collections::Vec;
@@ -68,7 +68,7 @@ where
 				let rule = p.parse::<Declaration<'a, D>>()?;
 				declarations.push(rule);
 			} else {
-				Err(diagnostics::Unexpected(p.next()))?;
+				Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?;
 			}
 		}
 	}

--- a/crates/css_parse/src/syntax/no_block_allowed.rs
+++ b/crates/css_parse/src/syntax/no_block_allowed.rs
@@ -1,4 +1,4 @@
-use crate::{Cursor, CursorSink, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan, diagnostics};
+use crate::{Cursor, CursorSink, Diagnostic, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan};
 
 /// A struct to provide to [AtRule][crate::AtRule] to disallow blocks.
 ///
@@ -16,7 +16,7 @@ impl<'a> Parse<'a> for NoBlockAllowed {
 		} else if let Some(semicolon) = p.parse_if_peek::<T![;]>()? {
 			Ok(Self(Some(semicolon)))
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_parse/src/syntax/no_prelude_allowed.rs
+++ b/crates/css_parse/src/syntax/no_prelude_allowed.rs
@@ -1,4 +1,4 @@
-use crate::{Cursor, CursorSink, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan, diagnostics};
+use crate::{Cursor, CursorSink, Diagnostic, Parse, Parser, Peek, Result, Span, T, ToCursors, ToSpan};
 
 /// A struct to provide to [AtRule][crate::AtRule] to disallow preludes.
 ///
@@ -14,7 +14,7 @@ impl<'a> Parse<'a> for NoPreludeAllowed {
 		if p.peek::<T![LeftCurly]>() || p.peek::<T![;]>() {
 			Ok(Self {})
 		} else {
-			Err(diagnostics::Unexpected(p.next()))?
+			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
 	}
 }

--- a/crates/css_parse/src/syntax/property.rs
+++ b/crates/css_parse/src/syntax/property.rs
@@ -50,7 +50,7 @@ impl<'a> Parse<'a> for Property<'a> {
 		let name = p.parse::<T![Ident]>()?;
 		let c: Cursor = name.into();
 		if !Self::valid_property(p, c) {
-			Err(diagnostics::UnknownDeclaration(c.into()))?;
+			Err(Diagnostic::unknown_declaration(c.into()))?;
 		}
 		let colon = p.parse::<T![:]>()?;
 		let value = Self::DeclarationValue::parse_declaration_value(p, c)?;

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -1,6 +1,6 @@
 use crate::Cursor;
 
-use crate::{Parser, Result, T, diagnostics};
+use crate::{Diagnostic, Parser, Result, T};
 
 /// This trait provides an implementation for parsing a ["Media Feature" in the "Boolean" context][1]. This is
 /// complementary to the other media features: [RangedFeature][crate::RangedFeature] and
@@ -54,7 +54,7 @@ pub trait BooleanFeature<'a>: Sized {
 		let ident = p.parse::<T![Ident]>()?;
 		let c: Cursor = ident.into();
 		if !p.eq_ignore_ascii_case(c, name) {
-			Err(diagnostics::ExpectedIdentOf(name, p.parse_str(c).into(), c))?
+			Err(Diagnostic::new(c, Diagnostic::unexpected_ident))?
 		}
 		if p.peek::<T![:]>() {
 			let colon = p.parse::<T![:]>()?;

--- a/crates/css_parse/src/traits/declaration_value.rs
+++ b/crates/css_parse/src/traits/declaration_value.rs
@@ -1,4 +1,4 @@
-use crate::{Cursor, KindSet, Parser, Peek, Result, T, diagnostics};
+use crate::{Cursor, Diagnostic, KindSet, Parser, Peek, Result, T};
 
 /// A trait that can be used for AST nodes representing a Declaration's Value. It offers some
 /// convenience functions for handling such values.
@@ -80,7 +80,7 @@ pub trait DeclarationValue<'a>: Sized {
 	/// The default implementation of this method is to return an Unexpected Err.
 	fn parse_custom_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c))?
+		Err(Diagnostic::new(c, Diagnostic::unexpected))?
 	}
 
 	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called before verifying that
@@ -91,7 +91,7 @@ pub trait DeclarationValue<'a>: Sized {
 	/// The default implementation of this method is to return an Unexpected Err.
 	fn parse_computed_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c))?
+		Err(Diagnostic::new(c, Diagnostic::unexpected))?
 	}
 
 	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called on values that are
@@ -104,7 +104,7 @@ pub trait DeclarationValue<'a>: Sized {
 	/// The default implementation of this method is to return an Unexpected Err.
 	fn parse_specified_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c))?
+		Err(Diagnostic::new(c, Diagnostic::unexpected))?
 	}
 
 	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called on values that are
@@ -114,7 +114,7 @@ pub trait DeclarationValue<'a>: Sized {
 	/// The default implementation of this method is to return an Unexpected Err.
 	fn parse_unknown_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c))?
+		Err(Diagnostic::new(c, Diagnostic::unexpected))?
 	}
 
 	// Like `parse()` but with the additional context of the `name` [Cursor] - the same [Cursor]

--- a/crates/css_parse/src/traits/discrete_feature.rs
+++ b/crates/css_parse/src/traits/discrete_feature.rs
@@ -1,6 +1,6 @@
 use crate::Cursor;
 
-use crate::{Parser, Result, T, diagnostics};
+use crate::{Diagnostic, Parser, Result, T};
 
 use super::Parse;
 
@@ -56,7 +56,7 @@ pub trait DiscreteFeature<'a>: Sized {
 		let ident = p.parse::<T![Ident]>()?;
 		let c: Cursor = ident.into();
 		if !p.eq_ignore_ascii_case(c, name) {
-			Err(diagnostics::ExpectedIdentOf(name, p.parse_str(c).into(), c))?
+			Err(Diagnostic::new(c, Diagnostic::unexpected_ident))?
 		}
 		if p.peek::<T![:]>() {
 			let colon = p.parse::<T![:]>()?;

--- a/crates/css_parse/src/traits/lists/feature_condition_list.rs
+++ b/crates/css_parse/src/traits/lists/feature_condition_list.rs
@@ -1,4 +1,4 @@
-use crate::{Parse, Parser, Peek, Result, diagnostics, keyword_set};
+use crate::{Diagnostic, Parse, Parser, Peek, Result, keyword_set};
 use bumpalo::collections::Vec;
 
 keyword_set!(
@@ -94,8 +94,7 @@ where
 			if matches!(keyword, ConditionKeyword::Not(_)) {
 				return Ok(Self::build_not(keyword, p.parse::<Self::FeatureCondition>()?));
 			}
-			let source_cursor = p.to_source_cursor(c);
-			Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), c))?
+			Err(Diagnostic::new(c, Diagnostic::unexpected_ident))?
 		}
 		let mut feature = p.parse::<Self::FeatureCondition>()?;
 		let keyword = p.parse_if_peek::<ConditionKeyword>()?;

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -1,4 +1,4 @@
-use crate::{Comparison, Parse, Parser, Peek, Result, T, diagnostics};
+use crate::{Comparison, Diagnostic, Parse, Parser, Peek, Result, T};
 
 pub trait RangedFeatureKeyword {
 	fn is_legacy(&self) -> bool {
@@ -130,8 +130,7 @@ pub trait RangedFeature<'a>: Sized {
 				let close = p.parse::<T![')']>()?;
 				return Self::new_legacy(open, name, colon, value, close);
 			} else if name.is_legacy() {
-				let source_cursor = p.to_source_cursor(c);
-				Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), c))?
+				Err(Diagnostic::new(c, Diagnostic::unexpected_ident))?
 			}
 			let comparison = p.parse::<Comparison>()?;
 			let value = p.parse::<Self::Value>()?;
@@ -144,7 +143,7 @@ pub trait RangedFeature<'a>: Sized {
 		let c = p.peek_next();
 		let name = p.parse::<Self::FeatureName>()?;
 		if name.is_legacy() {
-			Err(diagnostics::Unexpected(c))?
+			Err(Diagnostic::new(c, Diagnostic::unexpected))?
 		}
 		if !p.peek::<T![Delim]>() {
 			let close = p.parse::<T![')']>()?;

--- a/crates/css_parse/src/traits/rule_variants.rs
+++ b/crates/css_parse/src/traits/rule_variants.rs
@@ -1,4 +1,4 @@
-use crate::{BadDeclaration, Cursor, Parser, Peek, Result, State, T, ToCursors, ToSpan, diagnostics};
+use crate::{BadDeclaration, Cursor, Diagnostic, Parser, Peek, Result, State, T, ToCursors, ToSpan};
 
 /// A trait that can be used for AST nodes representing a Declaration's Value. It offers some
 /// convenience functions for handling such values.
@@ -11,7 +11,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 	/// The default implementation of this method is to return an Unexpected [Err].
 	fn parse_at_rule(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c))?
+		Err(Diagnostic::new(c, Diagnostic::unexpected))?
 	}
 
 	/// Like [crate::Parse::parse()] but with the additional context of the `name` [Cursor]. This cursor is known to be
@@ -21,7 +21,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 	/// The default implementation of this method is to return an Unexpected [Err].
 	fn parse_unknown_at_rule(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c))?
+		Err(Diagnostic::new(c, Diagnostic::unexpected))?
 	}
 
 	/// Like [crate::Parse::parse()] but with the additional context that the next cursor is _not_ an
@@ -31,7 +31,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 	/// The default implementation of this method is to return an Unexpected [Err].
 	fn parse_qualified_rule(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c))?
+		Err(Diagnostic::new(c, Diagnostic::unexpected))?
 	}
 
 	/// Like [crate::Parse::parse()] but with the additional context that the next cursor is _not_ an
@@ -41,7 +41,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 	/// The default implementation of this method is to return an Unexpected [Err].
 	fn parse_unknown_qualified_rule(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c))?
+		Err(Diagnostic::new(c, Diagnostic::unexpected))?
 	}
 
 	/// If all of the parse steps have failed, including parsing the Unknown Qualified Rule, we may want to consume a bad
@@ -78,7 +78,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 					if let Some(s) = Self::bad_declaration(declaration?) {
 						Ok(s)
 					} else {
-						Err(diagnostics::Unexpected(c))?
+						Err(Diagnostic::new(c, Diagnostic::unexpected))?
 					}
 				})
 		}

--- a/crates/css_parse/src/traits/selectors.rs
+++ b/crates/css_parse/src/traits/selectors.rs
@@ -1,4 +1,4 @@
-use crate::{Cursor, Kind, KindSet, Parse, Parser, Peek, Result, diagnostics};
+use crate::{Cursor, Diagnostic, Kind, KindSet, Parse, Parser, Peek, Result};
 use bumpalo::collections::Vec;
 
 pub trait CompoundSelector<'a>: Sized + Parse<'a> {
@@ -66,7 +66,7 @@ pub trait SelectorComponent<'a>: Sized {
 					if Self::Type::peek(p, c) {
 						Ok(Self::build_type(p.parse::<Self::Type>()?))
 					} else {
-						Err(diagnostics::UnexpectedTag(p.parse_str_lower(c).to_owned(), c))?
+						Err(Diagnostic::new(c, Diagnostic::unexpected_tag))?
 					}
 				}
 			},
@@ -75,7 +75,7 @@ pub trait SelectorComponent<'a>: Sized {
 				if Self::Id::peek(p, c) {
 					Ok(Self::build_id(p.parse::<Self::Id>()?))
 				} else {
-					Err(diagnostics::UnexpectedId(p.parse_str_lower(c).to_owned(), c))?
+					Err(Diagnostic::new(c, Diagnostic::unexpected_id))?
 				}
 			}
 			Kind::LeftSquare => {
@@ -88,7 +88,7 @@ pub trait SelectorComponent<'a>: Sized {
 					p.set_skip(skip);
 					match c.token().kind() {
 						Kind::Ident => p.parse::<Self::Class>().map(Self::build_class),
-						_ => Err(diagnostics::ExpectedIdent(c))?,
+						_ => Err(Diagnostic::new(c, Diagnostic::expected_ident))?,
 					}
 				}
 				'*' => {
@@ -116,7 +116,7 @@ pub trait SelectorComponent<'a>: Sized {
 							Kind::Function => {
 								p.parse::<Self::FunctionalPseudoElement>().map(Self::build_functional_pseudo_element)
 							}
-							_ => Err(diagnostics::Unexpected(c3))?,
+							_ => Err(Diagnostic::new(c3, Diagnostic::unexpected))?,
 						}
 					}
 					Kind::Ident => {
@@ -131,7 +131,7 @@ pub trait SelectorComponent<'a>: Sized {
 						p.set_skip(skip);
 						p.parse::<Self::FunctionalPseudoClass>().map(Self::build_functional_pseudo_class)
 					}
-					_ => Err(diagnostics::Unexpected(c2))?,
+					_ => Err(Diagnostic::new(c2, Diagnostic::unexpected))?,
 				}
 			}
 			_ => {

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -33,8 +33,9 @@ tracing-subscriber = { workspace = true }
 
 [features]
 default = ["fancy"]
-serde = ["dep:serde", "dep:serde_json", "css_lexer/serde"] 
-fancy = ["css_ast/fancy", "css_parse/fancy", "miette/fancy"]
+serde = ["dep:serde", "dep:serde_json", "css_lexer/serde"]
+miette = ["css_parse/miette", "css_ast/miette"]
+fancy = ["miette", "miette/fancy"]
 
 [[bin]]
 name = "csskit"

--- a/crates/csskit/src/commands/build.rs
+++ b/crates/csskit/src/commands/build.rs
@@ -3,7 +3,6 @@ use bumpalo::Bump;
 use clap::Args;
 use css_ast::StyleSheet;
 use css_parse::{CursorCompactWriteSink, Parser, ToCursors};
-use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use std::io::Read;
 
 /// Convert one or more CSS files into production ready CSS.
@@ -34,12 +33,8 @@ impl Build {
 			if result.output.is_some() {
 				result.to_cursors(&mut stream);
 			} else {
-				let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
-				for err in result.errors {
-					let mut report = String::new();
-					let named = NamedSource::new(file_name, source_string.clone());
-					let err = err.with_source_code(named);
-					handler.render_report(&mut report, err.as_ref())?;
+				for compact_err in result.errors {
+					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
 					println!("{report}");
 				}
 				Err(CliError::ParseFailed)?;

--- a/crates/csskit/src/commands/colors.rs
+++ b/crates/csskit/src/commands/colors.rs
@@ -7,7 +7,6 @@ use clap::Args;
 use css_ast::{Color as ASTColor, StyleSheet, ToChromashift, Visitable};
 use css_parse::{Parser, Span, ToSpan};
 use itertools::Itertools;
-use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use std::{collections::HashSet, io::Read};
 
 struct ColorExtractor {
@@ -263,12 +262,8 @@ impl ColorCommand {
 				if let Some(stylesheet) = result.output {
 					stylesheet.accept(&mut color_visitor);
 				} else {
-					let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
-					for err in result.errors {
-						let mut report = String::new();
-						let named = NamedSource::new(file_name, source_string.clone());
-						let err = err.with_source_code(named);
-						handler.render_report(&mut report, err.as_ref())?;
+					for compact_err in result.errors {
+						let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
 						println!("{report}");
 					}
 				}

--- a/crates/csskit/src/commands/dbg_parse.rs
+++ b/crates/csskit/src/commands/dbg_parse.rs
@@ -3,7 +3,6 @@ use bumpalo::Bump;
 use clap::Args;
 use css_ast::StyleSheet;
 use css_parse::Parser;
-use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use std::io::Read;
 
 /// Show the debug output for a parsed file
@@ -26,12 +25,8 @@ impl DbgParse {
 			if let Some(stylesheet) = &result.output {
 				println!("{stylesheet:#?}");
 			} else {
-				let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
-				for err in result.errors {
-					let mut report = String::new();
-					let named = NamedSource::new(file_name, source_string.clone());
-					let err = err.with_source_code(named);
-					handler.render_report(&mut report, err.as_ref())?;
+				for compact_err in result.errors {
+					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
 					println!("{report}");
 				}
 			}

--- a/crates/csskit/src/commands/fmt.rs
+++ b/crates/csskit/src/commands/fmt.rs
@@ -5,7 +5,6 @@ use css_ast::{StyleSheet, Visitable};
 use css_lexer::QuoteStyle;
 use css_parse::{CursorPrettyWriteSink, Parser, ToCursors};
 use csskit_highlight::{AnsiHighlightCursorStream, DefaultAnsiTheme, TokenHighlighter};
-use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use std::io::Read;
 
 /// Format CSS files to make them more readable.
@@ -72,12 +71,8 @@ impl Fmt {
 					println!("{str}");
 				}
 			} else {
-				let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
-				for err in result.errors {
-					let mut report = String::new();
-					let named = NamedSource::new(file_name, source_string.clone());
-					let err = err.with_source_code(named);
-					handler.render_report(&mut report, err.as_ref())?;
+				for compact_err in result.errors {
+					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
 					println!("{report}");
 				}
 			}

--- a/crates/csskit/src/commands/min.rs
+++ b/crates/csskit/src/commands/min.rs
@@ -4,7 +4,6 @@ use clap::Args;
 use css_ast::{StyleSheet, Visitable};
 use css_parse::{CursorCompactWriteSink, Parser, ToCursors};
 use csskit_highlight::{AnsiHighlightCursorStream, DefaultAnsiTheme, TokenHighlighter};
-use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
 use std::io::Read;
 
 /// Minify CSS files to compress them optimized delivery.
@@ -63,12 +62,8 @@ impl Min {
 					println!("{str}");
 				}
 			} else {
-				let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
-				for err in result.errors {
-					let mut report = String::new();
-					let named = NamedSource::new(file_name, source_string.clone());
-					let err = err.with_source_code(named);
-					handler.render_report(&mut report, err.as_ref())?;
+				for compact_err in result.errors {
+					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
 					println!("{report}");
 				}
 			}

--- a/crates/csskit/src/commands/mod.rs
+++ b/crates/csskit/src/commands/mod.rs
@@ -1,5 +1,6 @@
 use crate::{CliResult, GlobalConfig};
 use clap::Subcommand;
+use css_parse::{Diagnostic, DiagnosticMeta};
 
 mod build;
 mod check;
@@ -51,4 +52,21 @@ impl Commands {
 			Commands::Lsp(cmd) => cmd.run(config),
 		}
 	}
+}
+
+pub fn format_diagnostic_error(err: &Diagnostic, source: &str, file_name: &str) -> String {
+	#[cfg(feature = "miette")]
+	{
+		use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
+		let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
+		let mut report = String::new();
+		let named = NamedSource::new(file_name, source.to_string());
+		let miette_err = err.into_diagnostic(source);
+		let err_with_source = miette::Report::new(miette_err).with_source_code(named);
+		if handler.render_report(&mut report, &*err_with_source).is_ok() {
+			return report;
+		}
+	}
+	let DiagnosticMeta { code, message, help, .. } = (err.formatter)(err, source);
+	format!("Error [{code}]: {message}\nHelp: {help}\n")
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
@@ -19,21 +19,29 @@ impl<'a> ::css_parse::Parse<'a> for FlexValue {
                     continue;
                 }
                 if max.is_none() && <Length>::peek(p, c) {
-                    let val = p.parse::<Length>()?;
-                    if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&val) {
+                    let inner = p.parse::<Length>()?;
+                    if let Some(i) = ::css_parse::ToNumberValue::to_number_value(
+                        &inner,
+                    ) {
+                        let c: ::css_parse::Cursor = inner.into();
                         if 0 > i {
                             use ::css_parse::ToSpan;
-                            Err(crate::diagnostics::NumberTooSmall(0, val.to_span()))?
+                            Err(
+                                crate::Diagnostic::new(
+                                    c,
+                                    crate::Diagnostic::number_too_small,
+                                ),
+                            )?
                         }
                     }
-                    max = Some(val);
+                    max = Some(inner);
                     continue;
                 }
                 break;
             }
             if min.is_none() || max.is_none() {
                 let c = p.peek_n(1);
-                Err(crate::diagnostics::Unexpected(c))?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
             }
             Ok(Self::MinMax {
                 min: min.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
@@ -9,29 +9,31 @@ impl<'a> ::css_parse::Parse<'a> for Transform {
         if p.peek::<Number>() {
             let x = p.parse::<Number>()?;
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&x) {
+                let c: ::css_parse::Cursor = x.into();
                 if 0 > i {
                     use ::css_parse::ToSpan;
-                    Err(crate::diagnostics::NumberTooSmall(0, x.to_span()))?
+                    Err(crate::Diagnostic::new(c, crate::Diagnostic::number_too_small))?
                 }
             }
             let y = p.parse::<Number>()?;
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&y) {
+                let c: ::css_parse::Cursor = y.into();
                 if 0 > i {
                     use ::css_parse::ToSpan;
-                    Err(crate::diagnostics::NumberTooSmall(0, y.to_span()))?
+                    Err(crate::Diagnostic::new(c, crate::Diagnostic::number_too_small))?
                 }
             }
             Ok(Self::Scale { x: x, y: y })
         } else if p.peek::<Number>() {
             let angle = p.parse::<Number>()?;
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&angle) {
+                let c: ::css_parse::Cursor = angle.into();
                 if !(-360..=360).contains(&i) {
                     use ::css_parse::ToSpan;
                     Err(
-                        crate::diagnostics::NumberOutOfBounds(
-                            i,
-                            format!("{}..={}", - 360, 360),
-                            angle.to_span(),
+                        crate::Diagnostic::new(
+                            c,
+                            crate::Diagnostic::number_out_of_bounds,
                         ),
                     )?
                 }
@@ -41,13 +43,13 @@ impl<'a> ::css_parse::Parse<'a> for Transform {
             let x = p.parse::<Length>()?;
             let y = p.parse::<Percentage>()?;
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&y) {
+                let c: ::css_parse::Cursor = y.into();
                 if !(-100..=100).contains(&i) {
                     use ::css_parse::ToSpan;
                     Err(
-                        crate::diagnostics::NumberOutOfBounds(
-                            i,
-                            format!("{}..={}", - 100, 100),
-                            y.to_span(),
+                        crate::Diagnostic::new(
+                            c,
+                            crate::Diagnostic::number_out_of_bounds,
                         ),
                     )?
                 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
@@ -41,7 +41,7 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurEnum {
             }
             if auto_field.is_none() || none_field.is_none() || length.is_none() {
                 let c = p.peek_n(1);
-                Err(crate::diagnostics::Unexpected(c))?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
             }
             Ok(Self::Complex {
                 auto_field: auto_field.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
@@ -26,7 +26,7 @@ impl<'a> ::css_parse::Parse<'a> for Value {
             }
             if auto.is_none() || length.is_none() {
                 let c = p.peek_n(1);
-                Err(crate::diagnostics::Unexpected(c))?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
             }
             Ok(Self::Complex {
                 auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
@@ -16,27 +16,29 @@ impl<'a> ::css_parse::Parse<'a> for Value {
                     continue;
                 }
                 if percentage.is_none() && <Number>::peek(p, c) {
-                    let val = p.parse::<Number>()?;
-                    if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&val) {
+                    let inner = p.parse::<Number>()?;
+                    if let Some(i) = ::css_parse::ToNumberValue::to_number_value(
+                        &inner,
+                    ) {
+                        let c: ::css_parse::Cursor = inner.into();
                         if !(0..=100).contains(&i) {
                             use ::css_parse::ToSpan;
                             Err(
-                                crate::diagnostics::NumberOutOfBounds(
-                                    i,
-                                    format!("{}..={}", 0, 100),
-                                    val.to_span(),
+                                crate::Diagnostic::new(
+                                    c,
+                                    crate::Diagnostic::number_out_of_bounds,
                                 ),
                             )?
                         }
                     }
-                    percentage = Some(val);
+                    percentage = Some(inner);
                     continue;
                 }
                 break;
             }
             if auto.is_none() || percentage.is_none() {
                 let c = p.peek_n(1);
-                Err(crate::diagnostics::Unexpected(c))?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
             }
             Ok(Self::WithRange {
                 auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
@@ -19,10 +19,14 @@ impl<'a> ::css_parse::Parse<'a> for TestEnum {
                     ) {
                         Some(p.parse::<::css_parse::T![Ident]>()?)
                     } else {
-                        return Err(crate::diagnostics::Unexpected(c))?;
+                        return Err(
+                            crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
+                        )?;
                     }
                 } else {
-                    return Err(crate::diagnostics::Unexpected(c))?;
+                    return Err(
+                        crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
+                    )?;
                 }
             };
             let other_field = p.parse::<Length>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
@@ -15,7 +15,7 @@ impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
             let f0 = p.parse::<Ident>()?;
             Ok(Self::Bar { 0: f0 })
         } else {
-            return Err(crate::diagnostics::Unexpected(c))?;
+            return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
@@ -9,13 +9,13 @@ impl<'a> ::css_parse::Parse<'a> for Value {
         if p.peek::<Number>() {
             let f0 = p.parse::<Number>()?;
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&f0) {
+                let c: ::css_parse::Cursor = f0.into();
                 if !(0..=100).contains(&i) {
                     use ::css_parse::ToSpan;
                     Err(
-                        crate::diagnostics::NumberOutOfBounds(
-                            i,
-                            format!("{}..={}", 0, 100),
-                            f0.to_span(),
+                        crate::Diagnostic::new(
+                            c,
+                            crate::Diagnostic::number_out_of_bounds,
                         ),
                     )?
                 }
@@ -24,9 +24,10 @@ impl<'a> ::css_parse::Parse<'a> for Value {
         } else {
             let f0 = p.parse::<Number>()?;
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&f0) {
+                let c: ::css_parse::Cursor = f0.into();
                 if 0.1 > i {
                     use ::css_parse::ToSpan;
-                    Err(crate::diagnostics::NumberTooSmall(0.1, f0.to_span()))?
+                    Err(crate::Diagnostic::new(c, crate::Diagnostic::number_too_small))?
                 }
             }
             Ok(Self::Scale { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
@@ -29,7 +29,7 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurNewtypeTest {
         }
         if auto_value.is_none() || none_value.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(crate::diagnostics::Unexpected(c))?
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
         }
         Ok(Self {
             auto_value: auto_value.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_one_must_occur_with_optionals.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_one_must_occur_with_optionals.snap
@@ -22,7 +22,7 @@ impl<'a> ::css_parse::Parse<'a> for OneMustOccurTest {
         }
         if foo.is_none() && bar.is_none() {
             let c = p.peek_n(1);
-            Err(crate::diagnostics::Unexpected(c))?
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
         }
         Ok(Self { foo: foo, bar: bar })
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
@@ -12,10 +12,12 @@ impl<'a> ::css_parse::Parse<'a> for RegularKeywordTest {
                 if let Some(FooKeywords::Auto(ident)) = FooKeywords::from_cursor(p, c) {
                     Some(p.parse::<::css_parse::T![Ident]>()?)
                 } else {
-                    return Err(crate::diagnostics::Unexpected(c))?;
+                    return Err(
+                        crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
+                    )?;
                 }
             } else {
-                return Err(crate::diagnostics::Unexpected(c))?;
+                return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
             }
         };
         let length = p.parse::<Length>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
@@ -22,7 +22,7 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLength {
         }
         if auto.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(crate::diagnostics::Unexpected(c))?
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
         }
         Ok(Self {
             auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
@@ -15,27 +15,27 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLengthWithRange {
                 continue;
             }
             if length.is_none() && <Length>::peek(p, c) {
-                let val = p.parse::<Length>()?;
-                if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&val) {
+                let inner = p.parse::<Length>()?;
+                if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&inner) {
+                    let c: ::css_parse::Cursor = inner.into();
                     if !(0..=100).contains(&i) {
                         use ::css_parse::ToSpan;
                         Err(
-                            crate::diagnostics::NumberOutOfBounds(
-                                i,
-                                format!("{}..={}", 0, 100),
-                                val.to_span(),
+                            crate::Diagnostic::new(
+                                c,
+                                crate::Diagnostic::number_out_of_bounds,
                             ),
                         )?
                     }
                 }
-                length = Some(val);
+                length = Some(inner);
                 continue;
             }
             break;
         }
         if auto.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(crate::diagnostics::Unexpected(c))?
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
         }
         Ok(Self {
             auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
@@ -24,7 +24,7 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLengthInState {
         p.set_state(state);
         if auto.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(crate::diagnostics::Unexpected(c))?
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
         }
         Ok(Self {
             auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
@@ -31,7 +31,7 @@ impl<'a> ::css_parse::Parse<'a> for SpecificKeywordTest {
         }
         if auto_field.is_none() || none_field.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(crate::diagnostics::Unexpected(c))?
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
         }
         Ok(Self {
             auto_field: auto_field.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
@@ -17,27 +17,27 @@ impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
                 }
             }
             if percentage.is_none() && <Number>::peek(p, c) {
-                let val = p.parse::<Number>()?;
-                if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&val) {
+                let inner = p.parse::<Number>()?;
+                if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&inner) {
+                    let c: ::css_parse::Cursor = inner.into();
                     if !(0..=100).contains(&i) {
                         use ::css_parse::ToSpan;
                         Err(
-                            crate::diagnostics::NumberOutOfBounds(
-                                i,
-                                format!("{}..={}", 0, 100),
-                                val.to_span(),
+                            crate::Diagnostic::new(
+                                c,
+                                crate::Diagnostic::number_out_of_bounds,
                             ),
                         )?
                     }
                 }
-                percentage = Some(val);
+                percentage = Some(inner);
                 continue;
             }
             break;
         }
         if auto_value.is_none() || percentage.is_none() {
             let c = p.peek_n(1);
-            Err(crate::diagnostics::Unexpected(c))?
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
         }
         Ok(Self {
             auto_value: auto_value.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
@@ -8,54 +8,34 @@ impl<'a> ::css_parse::Parse<'a> for Color {
         use css_parse::{Parse, Peek};
         let red = p.parse::<CSSInt>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&red) {
+            let c: ::css_parse::Cursor = red.into();
             if !(0..=255).contains(&i) {
                 use ::css_parse::ToSpan;
-                Err(
-                    crate::diagnostics::NumberOutOfBounds(
-                        i,
-                        format!("{}..={}", 0, 255),
-                        red.to_span(),
-                    ),
-                )?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::number_out_of_bounds))?
             }
         }
         let green = p.parse::<CSSInt>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&green) {
+            let c: ::css_parse::Cursor = green.into();
             if !(0..=255).contains(&i) {
                 use ::css_parse::ToSpan;
-                Err(
-                    crate::diagnostics::NumberOutOfBounds(
-                        i,
-                        format!("{}..={}", 0, 255),
-                        green.to_span(),
-                    ),
-                )?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::number_out_of_bounds))?
             }
         }
         let blue = p.parse::<CSSInt>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&blue) {
+            let c: ::css_parse::Cursor = blue.into();
             if !(0..=255).contains(&i) {
                 use ::css_parse::ToSpan;
-                Err(
-                    crate::diagnostics::NumberOutOfBounds(
-                        i,
-                        format!("{}..={}", 0, 255),
-                        blue.to_span(),
-                    ),
-                )?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::number_out_of_bounds))?
             }
         }
         let alpha = p.parse::<Number>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&alpha) {
+            let c: ::css_parse::Cursor = alpha.into();
             if !(0..=1).contains(&i) {
                 use ::css_parse::ToSpan;
-                Err(
-                    crate::diagnostics::NumberOutOfBounds(
-                        i,
-                        format!("{}..={}", 0, 1),
-                        alpha.to_span(),
-                    ),
-                )?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::number_out_of_bounds))?
             }
         }
         Ok(Self {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
@@ -26,7 +26,7 @@ impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
         }
         if auto_value.is_none() && none_value.is_none() {
             let c = p.peek_n(1);
-            Err(crate::diagnostics::Unexpected(c))?
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
         }
         Ok(Self {
             auto_value: auto_value,

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
@@ -8,15 +8,10 @@ impl<'a> ::css_parse::Parse<'a> for Volume {
         use css_parse::{Parse, Peek};
         let level = p.parse::<Number>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&level) {
+            let c: ::css_parse::Cursor = level.into();
             if !(0.0f32..=100.0f32).contains(&i) {
                 use ::css_parse::ToSpan;
-                Err(
-                    crate::diagnostics::NumberOutOfBounds(
-                        i,
-                        format!("{}..={}", 0.0f32, 100.0f32),
-                        level.to_span(),
-                    ),
-                )?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::number_out_of_bounds))?
             }
         }
         Ok(Self { level: level })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
@@ -8,9 +8,10 @@ impl<'a> ::css_parse::Parse<'a> for PositiveValue {
         use css_parse::{Parse, Peek};
         let value = p.parse::<CSSInt>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&value) {
+            let c: ::css_parse::Cursor = value.into();
             if 1.0f32 > i {
                 use ::css_parse::ToSpan;
-                Err(crate::diagnostics::NumberTooSmall(1.0f32, value.to_span()))?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::number_too_small))?
             }
         }
         Ok(Self { value: value })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
@@ -8,9 +8,10 @@ impl<'a> ::css_parse::Parse<'a> for Probability {
         use css_parse::{Parse, Peek};
         let value = p.parse::<Number>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&value) {
+            let c: ::css_parse::Cursor = value.into();
             if 1.0f32 < i {
                 use ::css_parse::ToSpan;
-                Err(crate::diagnostics::NumberTooLarge(1.0f32, value.to_span()))?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::number_too_large))?
             }
         }
         Ok(Self { value: value })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
@@ -8,15 +8,10 @@ impl<'a> ::css_parse::Parse<'a> for Scale {
         use css_parse::{Parse, Peek};
         let f0 = p.parse::<Number>()?;
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&f0) {
+            let c: ::css_parse::Cursor = f0.into();
             if !(0.1..=10.0).contains(&i) {
                 use ::css_parse::ToSpan;
-                Err(
-                    crate::diagnostics::NumberOutOfBounds(
-                        i,
-                        format!("{}..={}", 0.1, 10.0),
-                        f0.to_span(),
-                    ),
-                )?
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::number_out_of_bounds))?
             }
         }
         Ok(Self { 0: f0 })

--- a/crates/csskit_wasm/Cargo.toml
+++ b/crates/csskit_wasm/Cargo.toml
@@ -14,7 +14,8 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["console_error_panic_hook", "serde", "fancy"]
 serde = ["css_lexer/serde", "css_ast/serde", "css_parse/serde", "bumpalo/serde"]
-fancy = ["miette/fancy-no-syscall"]
+miette = ["css_parse/miette", "css_ast/miette"]
+fancy = ["miette", "miette/fancy-no-syscall"]
 
 [dependencies]
 css_lexer = { workspace = true }


### PR DESCRIPTION
One issue we've had with the Parser is that it performs allocations on the heap to build errors & trivia. This is effectively unavoidable due to the variable amount of these, but we use the bumpalo memory arena to try and amortize allocation costs. The only issue is that historically the Trivia & Error Vecs _haven't_ used the arena. For Trivia, this is mostly incidental, but for Errors this is due to the fact that Miette Boxes its Error type so it can be dyn (I think?). The result is that even if we used Bumpalo's Vec, we'd still be heap allocating.

This is made worse because some parser steps will iterate through a Parse step only to produce an Error, (therefore allocate) only to rewind, discard the newly allocated error, and branch down a different path to not error, meaning a complete AST can be built whilst allocating data that didn't need to be allocated!

This rather unfortunately large change alters our Diagnostics such that they're defined in a compact struct which is easy to build (it comprises of a few cursors and a function pointer) and it can be Sized, meaning no heap allocation to _build_ an error, which means Parse results can be allocation free! This and this allows us to very easily move the allocation into the errors Vec to use a Bumpalo Vec instead, relying on the pre-allocated Arena instead of potential new allocations on each push.

This change sees a modest improvement in some parse times, likely because the files being parsed are hitting errors. This change wasn't done so much to see parse time improvements on its own, but is part of an (even larger) set of changes around the parser mechanics...