### PR TITLE
css_ast/css_parse/css_lexer: Add allocation tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "csskit_derives",
  "csskit_proc_macro",
  "csskit_source_finder",
+ "dhat",
  "glob",
  "heck",
  "insta",
@@ -512,6 +513,7 @@ dependencies = [
  "bumpalo",
  "console 0.16.1",
  "criterion",
+ "dhat",
  "glob",
  "insta",
  "miette",
@@ -529,6 +531,7 @@ dependencies = [
  "bumpalo",
  "css_lexer",
  "csskit_derives",
+ "dhat",
  "glob",
  "miette",
  "phf",
@@ -697,6 +700,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1148,6 +1167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1253,16 @@ name = "owo-colors"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot_core"
@@ -1467,6 +1502,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1790,6 +1831,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ pprof = { version = "0.15.0" }
 flate2 = { version = "1.1.2" }
 insta = { version = "1.43.1" }
 prettyplease = { version = "0.2.36" }
+dhat = { version = "0.3.3" }
 
 # String interning
 string_cache = { version = "0.9.0" }

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -45,6 +45,7 @@ criterion = { workspace = true, features = ["html_reports"] }
 insta = { workspace = true, features = ["json"] }
 similar = { workspace = true }
 console = { workspace = true }
+dhat = { workspace = true }
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 pprof = { workspace = true, features = ["flamegraph", "criterion"] }
@@ -56,6 +57,8 @@ miette = ["css_parse/miette"]
 fancy = ["miette", "miette/fancy-no-backtrace"]
 css_feature_data = ["dep:css_feature_data"]
 chromashift = ["dep:chromashift"]
+# Test only features
+_dhat-heap-testing = []
 
 [[bench]]
 name = "parse_popular"

--- a/crates/css_ast/tests/allocations.rs
+++ b/crates/css_ast/tests/allocations.rs
@@ -1,0 +1,64 @@
+use bumpalo::Bump;
+use css_ast::StyleSheet;
+use css_parse::Parser;
+#[cfg(feature = "_dhat-heap-testing")]
+use dhat::{Alloc, HeapStats, Profiler, assert_eq};
+use std::fs::read_to_string;
+
+#[cfg(feature = "_dhat-heap-testing")]
+#[global_allocator]
+static ALLOC: Alloc = Alloc;
+
+#[test]
+fn allocation_test() {
+	let simple_bump_size = 1984;
+	let simple_bump = Bump::with_capacity(simple_bump_size);
+	let simple_str = "body{color:blue}";
+	let mut simple_parser = Parser::new(&simple_bump, &simple_str);
+
+	let escaped_bump_size = 16320;
+	let escaped_bump = Bump::with_capacity(escaped_bump_size);
+	let escaped_str = "bo\\d y{background-image:\\75\\52\\6c(a);width:1\\70\\78}";
+	let mut escape_parser = Parser::new(&escaped_bump, &escaped_str);
+
+	let big_bump_size = 331_222_976;
+	let big_bump = Bump::with_capacity(big_bump_size);
+	let big_str = read_to_string("../../coverage/popular/tailwind.2.2.19.min.css").unwrap();
+	let mut big_parser = Parser::new(&big_bump, &big_str);
+
+	#[cfg(feature = "_dhat-heap-testing")]
+	let _profiler = Profiler::builder()
+		.testing()
+		.file_name(format!("../../target/css_ast_allocations_test-{}.json", std::process::id()))
+		.build();
+
+	simple_parser.parse_entirely::<StyleSheet>();
+	#[cfg(feature = "_dhat-heap-testing")]
+	{
+		let stats = HeapStats::get();
+		assert_eq!(stats.total_blocks, 0);
+		assert_eq!(stats.total_bytes, 0);
+	}
+
+	escape_parser.parse_entirely::<StyleSheet>();
+	#[cfg(feature = "_dhat-heap-testing")]
+	{
+		let stats = HeapStats::get();
+		assert_eq!(stats.total_blocks, 0);
+		assert_eq!(stats.total_bytes, 0);
+	}
+
+	big_parser.parse_entirely::<StyleSheet>();
+	#[cfg(feature = "_dhat-heap-testing")]
+	{
+		let stats = HeapStats::get();
+		// These are due to allocations in `eq_ignore_ascii_case` debug_asserts!
+		assert_eq!(stats.total_blocks, 61354);
+		assert_eq!(stats.total_bytes, 246910);
+	}
+
+	// XXX: If these fail because the numbers go down, great! If they go up, investigate why.
+	assert_eq!(simple_bump.allocated_bytes(), simple_bump_size);
+	assert_eq!(escaped_bump.allocated_bytes(), escaped_bump_size);
+	assert_eq!(big_bump.allocated_bytes(), big_bump_size);
+}

--- a/crates/css_lexer/Cargo.toml
+++ b/crates/css_lexer/Cargo.toml
@@ -29,6 +29,7 @@ criterion = { workspace = true, features = ["html_reports"] }
 insta = { workspace = true, features = ["json"] }
 similar = { workspace = true }
 console = { workspace = true }
+dhat = { workspace = true }
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 pprof = { workspace = true, features = ["flamegraph", "criterion"] }
@@ -38,6 +39,8 @@ default = []
 # Provides `From<>` implementations for the [SourceSpan] into [miette::SourceSpan] and [Span] into [miette::Span]
 miette = ["dep:miette"]
 serde = ["dep:serde", "dep:serde_json", "bumpalo/serde", "miette/serde"]
+# Test only features
+_dhat-heap-testing = []
 
 [[bench]]
 name = "lex_popular"

--- a/crates/css_lexer/tests/allocations.rs
+++ b/crates/css_lexer/tests/allocations.rs
@@ -1,0 +1,62 @@
+use css_lexer::{Kind, Lexer};
+#[cfg(feature = "_dhat-heap-testing")]
+use dhat::{Alloc, HeapStats, Profiler, assert_eq};
+#[cfg(not(feature = "_dhat-heap-testing"))]
+use std::assert_eq;
+use std::fs::read_to_string;
+
+#[cfg(feature = "_dhat-heap-testing")]
+#[global_allocator]
+static ALLOC: Alloc = Alloc;
+
+#[test]
+fn ensure_no_allocations_during_lex() {
+	let str = "body{color:blue}";
+	let mut lexer = Lexer::new(&str);
+	let mut token_count = 0;
+
+	let str2 = "bo\\d y{\\75\\52\\6c(a);width:1\\70\\78}";
+	let mut token_count2 = 0;
+	let mut lexer2 = Lexer::new(&str2);
+
+	let big = read_to_string("../../coverage/popular/tailwind.2.2.19.min.css").unwrap();
+	let mut lexer_big = Lexer::new(&big);
+
+	#[cfg(feature = "_dhat-heap-testing")]
+	let _profiler = Profiler::builder()
+		.testing()
+		.file_name(format!("../../target/css_lexer_allocations_test-{}.json", std::process::id()))
+		.build();
+
+	loop {
+		let cursor = lexer.advance();
+		token_count += 1;
+		if cursor.kind() == Kind::Eof {
+			break;
+		}
+	}
+	assert_eq!(token_count, 7);
+
+	loop {
+		let cursor = lexer2.advance();
+		token_count2 += 1;
+		if cursor.kind() == Kind::Eof {
+			break;
+		}
+	}
+	assert_eq!(token_count2, 9);
+
+	loop {
+		let cursor = lexer_big.advance();
+		if cursor.kind() == Kind::Eof {
+			break;
+		}
+	}
+
+	#[cfg(feature = "_dhat-heap-testing")]
+	{
+		let stats = HeapStats::get();
+		assert_eq!(stats.total_blocks, 0);
+		assert_eq!(stats.total_bytes, 0);
+	}
+}

--- a/crates/css_parse/Cargo.toml
+++ b/crates/css_parse/Cargo.toml
@@ -29,6 +29,7 @@ phf = { workspace = true, features = ["macros"] }
 [dev-dependencies]
 csskit_derives = { workspace = true }
 glob = { workspace = true }
+dhat = { workspace = true }
 
 [features]
 default = []
@@ -36,3 +37,5 @@ testing = []
 miette = ["dep:miette", "dep:thiserror", "css_lexer/miette"]
 serde = ["dep:serde", "dep:serde_json", "css_lexer/serde", "bumpalo/serde"]
 fancy = ["miette", "miette/fancy-no-backtrace"]
+# Test only features
+_dhat-heap-testing = []

--- a/crates/css_parse/tests/allocations.rs
+++ b/crates/css_parse/tests/allocations.rs
@@ -1,0 +1,63 @@
+use bumpalo::Bump;
+use css_parse::ComponentValues;
+use css_parse::Parser;
+#[cfg(feature = "_dhat-heap-testing")]
+use dhat::{Alloc, HeapStats, Profiler, assert_eq};
+use std::fs::read_to_string;
+
+#[cfg(feature = "_dhat-heap-testing")]
+#[global_allocator]
+static ALLOC: Alloc = Alloc;
+
+#[test]
+fn allocation_test() {
+	let simple_bump_size = 960;
+	let simple_bump = Bump::with_capacity(simple_bump_size);
+	let simple_str = "body{color:blue}";
+	let mut simple_parser = Parser::new(&simple_bump, &simple_str);
+
+	let escaped_bump_size = 960;
+	let escaped_bump = Bump::with_capacity(escaped_bump_size);
+	let escaped_str = "bo\\d y{background-image:\\75\\52\\6c(a);width:1\\70\\78}";
+	let mut escape_parser = Parser::new(&escaped_bump, &escaped_str);
+
+	let big_bump_size = 100_003_776;
+	let big_bump = Bump::with_capacity(big_bump_size);
+	let big_str = read_to_string("../../coverage/popular/tailwind.2.2.19.min.css").unwrap();
+	let mut big_parser = Parser::new(&big_bump, &big_str);
+
+	#[cfg(feature = "_dhat-heap-testing")]
+	let _profiler = Profiler::builder()
+		.testing()
+		.file_name(format!("../../target/css_parse_allocations_test-{}.json", std::process::id()))
+		.build();
+
+	simple_parser.parse_entirely::<ComponentValues>();
+	#[cfg(feature = "_dhat-heap-testing")]
+	{
+		let stats = HeapStats::get();
+		assert_eq!(stats.total_blocks, 0);
+		assert_eq!(stats.total_bytes, 0);
+	}
+
+	escape_parser.parse_entirely::<ComponentValues>();
+	#[cfg(feature = "_dhat-heap-testing")]
+	{
+		let stats = HeapStats::get();
+		assert_eq!(stats.total_blocks, 0);
+		assert_eq!(stats.total_bytes, 0);
+	}
+
+	big_parser.parse_entirely::<ComponentValues>();
+	#[cfg(feature = "_dhat-heap-testing")]
+	{
+		let stats = HeapStats::get();
+		assert_eq!(stats.total_blocks, 0);
+		assert_eq!(stats.total_bytes, 0);
+	}
+
+	// XXX: If these fail because the numbers go down, great! If they go up, investigate why.
+	assert_eq!(simple_bump.allocated_bytes(), simple_bump_size);
+	assert_eq!(escaped_bump.allocated_bytes(), escaped_bump_size);
+	assert_eq!(big_bump.allocated_bytes(), big_bump_size);
+}


### PR DESCRIPTION
These tests confirm that the only allocations that should be happening are within the memory arena and not in the
general purpose allocator. They also are beneficial for helping manage exactly how much memory certain test files will
consume.
