### PR TITLE
drop derives & ToCursors/ToSpan from _feature! macros

### DIFF
--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -11,7 +11,8 @@ keyword_set!(pub enum WidthContainerFeatureKeyword { Width: "width" });
 impl RangedFeatureKeyword for WidthContainerFeatureKeyword {}
 
 ranged_feature!(
-	#[derive(Visitable)]
+	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum WidthContainerFeature<WidthContainerFeatureKeyword, Length>
 );
@@ -20,7 +21,8 @@ keyword_set!(pub enum HeightContainerFeatureKeyword { Height: "height" });
 impl RangedFeatureKeyword for HeightContainerFeatureKeyword {}
 
 ranged_feature!(
-	#[derive(Visitable)]
+	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum HeightContainerFeature<HeightContainerFeatureKeyword, Length>
 );
@@ -29,7 +31,8 @@ keyword_set!(pub enum InlineSizeContainerFeatureKeyword { InlineSize: "inline-si
 impl RangedFeatureKeyword for InlineSizeContainerFeatureKeyword {}
 
 ranged_feature!(
-	#[derive(Visitable)]
+	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum InlineSizeContainerFeature<InlineSizeContainerFeatureKeyword, Length>
 );
@@ -38,7 +41,8 @@ keyword_set!(pub enum BlockSizeContainerFeatureKeyword { BlockSize: "block-size"
 impl RangedFeatureKeyword for BlockSizeContainerFeatureKeyword {}
 
 ranged_feature!(
-	#[derive(Visitable)]
+	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum BlockSizeContainerFeature<BlockSizeContainerFeatureKeyword, Length>
 );
@@ -47,7 +51,8 @@ keyword_set!(pub enum AspectRatioContainerFeatureKeyword { AspectRatio: "aspect-
 impl RangedFeatureKeyword for AspectRatioContainerFeatureKeyword {}
 
 ranged_feature!(
-	#[derive(Visitable)]
+	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum AspectRatioContainerFeature<AspectRatioContainerFeatureKeyword, Ratio>
 );
@@ -55,7 +60,8 @@ ranged_feature!(
 keyword_set!(pub enum OrientationContainerFeatureKeyword { Portrait: "portrait", Landscape: "landscape" });
 
 discrete_feature!(
-	#[derive(Visitable)]
+	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum OrientationContainerFeature<"orientation", OrientationContainerFeatureKeyword>
 );
@@ -231,7 +237,8 @@ impl<'a> Parse<'a> for ScrollStateFeature {
 }
 
 discrete_feature!(
-	#[derive(Visitable)]
+	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum ScrollableScrollStateFeature<"scrollable", ScrollableScrollStateFeatureKeyword>
 );
@@ -254,7 +261,8 @@ keyword_set!(pub enum ScrollableScrollStateFeatureKeyword {
 });
 
 discrete_feature!(
-	#[derive(Visitable)]
+	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum SnappedScrollStateFeature<"snapped", SnappedScrollStateFeatureKeyword>
 );
@@ -270,7 +278,8 @@ keyword_set!(pub enum SnappedScrollStateFeatureKeyword {
 });
 
 discrete_feature!(
-	#[derive(Visitable)]
+	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum StuckScrollStateFeature<"stuck", StuckScrollStateFeatureKeyword>
 );

--- a/crates/css_ast/src/rules/media/features/any_hover.rs
+++ b/crates/css_ast/src/rules/media/features/any_hover.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum AnyHoverMediaFeature<"any-hover", AnyHoverMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum AnyHoverMediaFeature<"any-hover", AnyHoverMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum AnyHoverMediaFeatureKeyword { None: "none", Hover: "hover" });
 

--- a/crates/css_ast/src/rules/media/features/any_pointer.rs
+++ b/crates/css_ast/src/rules/media/features/any_pointer.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum AnyPointerMediaFeature<"any-pointer", AnyPointerMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum AnyPointerMediaFeature<"any-pointer", AnyPointerMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum AnyPointerMediaFeatureKeyword { None: "none", Coarse: "coarse", Fine: "fine" });
 

--- a/crates/css_ast/src/rules/media/features/color.rs
+++ b/crates/css_ast/src/rules/media/features/color.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::CSSInt;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum ColorMediaFeatureKeyword { Color: "color", MaxColor: "max-color", MinColor: "min-color" });
 
@@ -9,7 +9,11 @@ impl RangedFeatureKeyword for ColorMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum ColorMediaFeature<ColorMediaFeatureKeyword, CSSInt>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum ColorMediaFeature<ColorMediaFeatureKeyword, CSSInt>
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/media/features/color_gamut.rs
+++ b/crates/css_ast/src/rules/media/features/color_gamut.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum ColorGamutMediaFeature<"color-gamut", ColorGamutMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum ColorGamutMediaFeature<"color-gamut", ColorGamutMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum ColorGamutMediaFeatureKeyword { Srgb: "srgb", P3: "p3", Rec2020: "rec2020" });
 

--- a/crates/css_ast/src/rules/media/features/color_index.rs
+++ b/crates/css_ast/src/rules/media/features/color_index.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::CSSInt;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum ColorIndexMediaFeatureKeyword {
 	ColorIndex: "color-index",
@@ -13,7 +13,11 @@ impl RangedFeatureKeyword for ColorIndexMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum ColorIndexMediaFeature<ColorIndexMediaFeatureKeyword, CSSInt>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum ColorIndexMediaFeature<ColorIndexMediaFeatureKeyword, CSSInt>
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/media/features/device_height.rs
+++ b/crates/css_ast/src/rules/media/features/device_height.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::Length;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum DeviceHeightMediaFeatureKeyword {
 	DeviceHeight: "device-height",
@@ -13,7 +13,11 @@ impl RangedFeatureKeyword for DeviceHeightMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum DeviceHeightMediaFeature<DeviceHeightMediaFeatureKeyword, Length>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum DeviceHeightMediaFeature<DeviceHeightMediaFeatureKeyword, Length>
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/media/features/device_width.rs
+++ b/crates/css_ast/src/rules/media/features/device_width.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::Length;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum DeviceWidthMediaFeatureKeyword {
 	DeviceWidth: "device-width",
@@ -13,7 +13,11 @@ impl RangedFeatureKeyword for DeviceWidthMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum DeviceWidthMediaFeature<DeviceWidthMediaFeatureKeyword, Length>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum DeviceWidthMediaFeature<DeviceWidthMediaFeatureKeyword, Length>
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/media/features/display_mode.rs
+++ b/crates/css_ast/src/rules/media/features/display_mode.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum DisplayModeMediaFeature<"display-mode", DisplayModeMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum DisplayModeMediaFeature<"display-mode", DisplayModeMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum DisplayModeMediaFeatureKeyword {
 	Fullscreen: "fullscreen",

--- a/crates/css_ast/src/rules/media/features/dynamic_range.rs
+++ b/crates/css_ast/src/rules/media/features/dynamic_range.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum DynamicRangeMediaFeature<"dynamic-range", DynamicRangeMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum DynamicRangeMediaFeature<"dynamic-range", DynamicRangeMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum DynamicRangeMediaFeatureKeyword { Standard: "standard", High: "high" });
 

--- a/crates/css_ast/src/rules/media/features/environment_blending.rs
+++ b/crates/css_ast/src/rules/media/features/environment_blending.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum EnvironmentBlendingMediaFeature<"environment-blending", EnvironmentBlendingMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum EnvironmentBlendingMediaFeature<"environment-blending", EnvironmentBlendingMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum EnvironmentBlendingMediaFeatureKeyword {
 	Opaque: "opaque",

--- a/crates/css_ast/src/rules/media/features/forced_colors.rs
+++ b/crates/css_ast/src/rules/media/features/forced_colors.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum ForcedColorsMediaFeature<"forced-colors", ForcedColorsMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum ForcedColorsMediaFeature<"forced-colors", ForcedColorsMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum ForcedColorsMediaFeatureKeyword { None: "none", Active: "active" });
 

--- a/crates/css_ast/src/rules/media/features/grid.rs
+++ b/crates/css_ast/src/rules/media/features/grid.rs
@@ -1,6 +1,10 @@
-use css_parse::boolean_feature;
+use super::prelude::*;
 
-boolean_feature!(pub enum GridMediaFeature<"grid">);
+boolean_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum GridMediaFeature<"grid">
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/media/features/height.rs
+++ b/crates/css_ast/src/rules/media/features/height.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::Length;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum HeightMediaFeatureKeyword { Height: "height", MaxHeight: "max-height", MinHeight: "min-height" });
 
@@ -9,7 +9,11 @@ impl RangedFeatureKeyword for HeightMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum HeightMediaFeature<HeightMediaFeatureKeyword, Length>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum HeightMediaFeature<HeightMediaFeatureKeyword, Length>
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/media/features/horizontal_viewport_segments.rs
+++ b/crates/css_ast/src/rules/media/features/horizontal_viewport_segments.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::CSSInt;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum HorizontalViewportSegmentsMediaFeatureKeyword {
 	HorizontalViewportSegments: "horizontal-viewport-segments",
@@ -13,7 +13,11 @@ impl RangedFeatureKeyword for HorizontalViewportSegmentsMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum HorizontalViewportSegmentsMediaFeature<HorizontalViewportSegmentsMediaFeatureKeyword, CSSInt>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum HorizontalViewportSegmentsMediaFeature<HorizontalViewportSegmentsMediaFeatureKeyword, CSSInt>
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/media/features/hover.rs
+++ b/crates/css_ast/src/rules/media/features/hover.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum HoverMediaFeature<"hover", HoverMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum HoverMediaFeature<"hover", HoverMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum HoverMediaFeatureKeyword { None: "none", Hover: "hover" });
 

--- a/crates/css_ast/src/rules/media/features/inverted_colors.rs
+++ b/crates/css_ast/src/rules/media/features/inverted_colors.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum InvertedColorsMediaFeature<"inverted-colors", InvertedColorsMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum InvertedColorsMediaFeature<"inverted-colors", InvertedColorsMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum InvertedColorsMediaFeatureKeyword { None: "none", Inverted: "inverted" });
 

--- a/crates/css_ast/src/rules/media/features/mod.rs
+++ b/crates/css_ast/src/rules/media/features/mod.rs
@@ -83,3 +83,8 @@ pub use video_color_gamut::*;
 pub use video_dynamic_range::*;
 pub use webkit::*;
 pub use width::*;
+
+mod prelude {
+	pub(crate) use css_parse::{RangedFeatureKeyword, boolean_feature, discrete_feature, keyword_set, ranged_feature};
+	pub(crate) use csskit_derives::{ToCursors, ToSpan};
+}

--- a/crates/css_ast/src/rules/media/features/monochrome.rs
+++ b/crates/css_ast/src/rules/media/features/monochrome.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::CSSInt;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum MonochromeMediaFeatureKeyword {
 	Monochrome: "monochrome",
@@ -13,7 +13,11 @@ impl RangedFeatureKeyword for MonochromeMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum MonochromeMediaFeature<MonochromeMediaFeatureKeyword, CSSInt>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MonochromeMediaFeature<MonochromeMediaFeatureKeyword, CSSInt>
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/media/features/moz.rs
+++ b/crates/css_ast/src/rules/media/features/moz.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::CSSFloat;
-use css_parse::{RangedFeatureKeyword, boolean_feature, discrete_feature, keyword_set, ranged_feature};
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#media_features
 
@@ -15,17 +15,37 @@ impl RangedFeatureKeyword for MozDevicePixelRatioMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum MozDevicePixelRatioMediaFeature<MozDevicePixelRatioMediaFeatureKeyword, CSSFloat>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MozDevicePixelRatioMediaFeature<MozDevicePixelRatioMediaFeatureKeyword, CSSFloat>
+);
 
 keyword_set!(pub enum MozDeviceOrientationMediaFeatureKeyword { Portrait: "portrait", Landscape: "landscape" });
 
-discrete_feature!(pub enum MozDeviceOrientationMediaFeature<"-moz-device-orientation", MozDeviceOrientationMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MozDeviceOrientationMediaFeature<"-moz-device-orientation", MozDeviceOrientationMediaFeatureKeyword>
+);
 
-boolean_feature!(pub enum MozMacGraphiteThemeMediaFeature<"-moz-mac-graphite-theme">);
+boolean_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MozMacGraphiteThemeMediaFeature<"-moz-mac-graphite-theme">
+);
 
-boolean_feature!(pub enum MozMaemoClassicMediaFeature<"-moz-maemo-classic-theme">);
+boolean_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MozMaemoClassicMediaFeature<"-moz-maemo-classic-theme">
+);
 
-boolean_feature!(pub enum MozImagesInMenusMediaFeature<"-moz-maemo-classic-theme">);
+boolean_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MozImagesInMenusMediaFeature<"-moz-maemo-classic-theme">
+);
 
 keyword_set!(pub enum MozOsVersionMediaFeatureKeyword {
 	WindowsVista: "windows-vista",
@@ -35,6 +55,14 @@ keyword_set!(pub enum MozOsVersionMediaFeatureKeyword {
 	WindowsWin10: "windows-win10",
 });
 
-discrete_feature!(pub enum MozOsVersionMediaFeature<"-moz-os-version", MozOsVersionMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MozOsVersionMediaFeature<"-moz-os-version", MozOsVersionMediaFeatureKeyword>
+);
 
-boolean_feature!(pub enum MozTouchEnabledMediaFeature<"-moz-touch-enabled">);
+boolean_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MozTouchEnabledMediaFeature<"-moz-touch-enabled">
+);

--- a/crates/css_ast/src/rules/media/features/ms.rs
+++ b/crates/css_ast/src/rules/media/features/ms.rs
@@ -1,9 +1,13 @@
+use super::prelude::*;
 use crate::units::{CSSFloat, CSSInt};
-use css_parse::{RangedFeatureKeyword, discrete_feature, keyword_set, ranged_feature};
 
 keyword_set!(pub enum MsHighContrastMediaFeatureKeyword { None: "none", Active: "active" });
 
-discrete_feature!(pub enum MsHighContrastMediaFeature<"-ms-high-contrast", MsHighContrastMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MsHighContrastMediaFeature<"-ms-high-contrast", MsHighContrastMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum MsViewStateMediaFeatureKeyword {
 	Snapped: "snapped",
@@ -11,11 +15,19 @@ keyword_set!(pub enum MsViewStateMediaFeatureKeyword {
 	FullscreenLandscape: "fullscreen-landscape",
 });
 
-discrete_feature!(pub enum MsViewStateMediaFeature<"-ms-view-state", MsViewStateMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MsViewStateMediaFeature<"-ms-view-state", MsViewStateMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum MsImeAlignMediaFeatureKeyword { Auto: "auto" });
 
-discrete_feature!(pub enum MsImeAlignMediaFeature<"-ms-ime-align", MsImeAlignMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MsImeAlignMediaFeature<"-ms-ime-align", MsImeAlignMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum MsDevicePixelRatioMediaFeatureKeyword {
 	DevicePixelRatio: "-ms-device-pixel-ratio",
@@ -29,7 +41,11 @@ impl RangedFeatureKeyword for MsDevicePixelRatioMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum MsDevicePixelRatioMediaFeature<MsDevicePixelRatioMediaFeatureKeyword, CSSFloat>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MsDevicePixelRatioMediaFeature<MsDevicePixelRatioMediaFeatureKeyword, CSSFloat>
+);
 
 keyword_set!(pub enum MsColumnCountMediaFeatureKeyword {
 	ColumnCount: "-ms-column-count",
@@ -43,4 +59,8 @@ impl RangedFeatureKeyword for MsColumnCountMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum MsColumnCountMediaFeature<MsColumnCountMediaFeatureKeyword, CSSInt>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum MsColumnCountMediaFeature<MsColumnCountMediaFeatureKeyword, CSSInt>
+);

--- a/crates/css_ast/src/rules/media/features/nav_controls.rs
+++ b/crates/css_ast/src/rules/media/features/nav_controls.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum NavControlsMediaFeature<"nav-controls", NavControlsMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum NavControlsMediaFeature<"nav-controls", NavControlsMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum NavControlsMediaFeatureKeyword { None: "none", Back: "back" });
 

--- a/crates/css_ast/src/rules/media/features/o.rs
+++ b/crates/css_ast/src/rules/media/features/o.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::CSSFloat;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum ODevicePixelRatioMediaFeatureKeyword {
 	DevicePixelRatio: "-o-device-pixel-ratio",
@@ -13,4 +13,8 @@ impl RangedFeatureKeyword for ODevicePixelRatioMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum ODevicePixelRatioMediaFeature<ODevicePixelRatioMediaFeatureKeyword, CSSFloat>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum ODevicePixelRatioMediaFeature<ODevicePixelRatioMediaFeatureKeyword, CSSFloat>
+);

--- a/crates/css_ast/src/rules/media/features/orientation.rs
+++ b/crates/css_ast/src/rules/media/features/orientation.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum OrientationMediaFeature<"orientation", OrientationMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum OrientationMediaFeature<"orientation", OrientationMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum OrientationMediaFeatureKeyword { Portrait: "portrait", Landscape: "landscape" });
 

--- a/crates/css_ast/src/rules/media/features/overflow_block.rs
+++ b/crates/css_ast/src/rules/media/features/overflow_block.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum OverflowBlockMediaFeature<"overflow-block", OverflowBlockMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum OverflowBlockMediaFeature<"overflow-block", OverflowBlockMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum OverflowBlockMediaFeatureKeyword { None: "none", Scroll: "scroll", Paged: "paged" });
 

--- a/crates/css_ast/src/rules/media/features/overflow_inline.rs
+++ b/crates/css_ast/src/rules/media/features/overflow_inline.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum OverflowInlineMediaFeature<"overflow-inline", OverflowInlineMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum OverflowInlineMediaFeature<"overflow-inline", OverflowInlineMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum OverflowInlineMediaFeatureKeyword { None: "none", Scroll: "scroll" });
 

--- a/crates/css_ast/src/rules/media/features/pointer.rs
+++ b/crates/css_ast/src/rules/media/features/pointer.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum PointerMediaFeature<"pointer", PointerMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum PointerMediaFeature<"pointer", PointerMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum PointerMediaFeatureKeyword { None: "none", Coarse: "coarse", Fine: "fine" });
 

--- a/crates/css_ast/src/rules/media/features/prefers_color_scheme.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_color_scheme.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum PrefersColorSchemeMediaFeature<"prefers-color-scheme", PrefersColorSchemeMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum PrefersColorSchemeMediaFeature<"prefers-color-scheme", PrefersColorSchemeMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum PrefersColorSchemeMediaFeatureKeyword { Light: "light", Dark: "dark" });
 

--- a/crates/css_ast/src/rules/media/features/prefers_contrast.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_contrast.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum PrefersContrastMediaFeature<"prefers-contrast", PrefersContrastMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum PrefersContrastMediaFeature<"prefers-contrast", PrefersContrastMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum PrefersContrastMediaFeatureKeyword {
 	NoPreference: "no-preference",

--- a/crates/css_ast/src/rules/media/features/prefers_reduced_data.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_reduced_data.rs
@@ -1,6 +1,8 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
 discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	pub enum PrefersReducedDataMediaFeature<"prefers-reduced-data", PrefersReducedDataMediaFeatureKeyword>
 );
 

--- a/crates/css_ast/src/rules/media/features/prefers_reduced_motion.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_reduced_motion.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum PrefersReducedMotionMediaFeature<"prefers-reduced-motion", PrefersReducedMotionMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum PrefersReducedMotionMediaFeature<"prefers-reduced-motion", PrefersReducedMotionMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum PrefersReducedMotionMediaFeatureKeyword { NoPreference: "no-preference", Reduce: "reduce" });
 

--- a/crates/css_ast/src/rules/media/features/prefers_reduced_transparency.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_reduced_transparency.rs
@@ -1,6 +1,8 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
 discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	pub enum PrefersReducedTransparencyMediaFeature<"prefers-reduced-transparency", PrefersReducedTransparencyMediaFeatureKeyword>
 );
 

--- a/crates/css_ast/src/rules/media/features/scan.rs
+++ b/crates/css_ast/src/rules/media/features/scan.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum ScanMediaFeature<"scan", ScanMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum ScanMediaFeature<"scan", ScanMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum ScanMediaFeatureKeyword { Interlace: "interlace", Progressive: "progressive" });
 

--- a/crates/css_ast/src/rules/media/features/scripting.rs
+++ b/crates/css_ast/src/rules/media/features/scripting.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum ScriptingMediaFeature<"scripting", ScriptingMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum ScriptingMediaFeature<"scripting", ScriptingMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum ScriptingMediaFeatureKeyword { None: "none", InitialOnly: "initial-only", Enabled: "enabled" });
 

--- a/crates/css_ast/src/rules/media/features/vertical_viewport_segments.rs
+++ b/crates/css_ast/src/rules/media/features/vertical_viewport_segments.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::CSSInt;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum VerticalViewportSegmentsMediaFeatureKeyword {
 	VerticalViewportSegments: "vertical-viewport-segments",
@@ -13,7 +13,11 @@ impl RangedFeatureKeyword for VerticalViewportSegmentsMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum VerticalViewportSegmentsMediaFeature<VerticalViewportSegmentsMediaFeatureKeyword, CSSInt>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum VerticalViewportSegmentsMediaFeature<VerticalViewportSegmentsMediaFeatureKeyword, CSSInt>
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/rules/media/features/video_color_gamut.rs
+++ b/crates/css_ast/src/rules/media/features/video_color_gamut.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum VideoColorGamutMediaFeature<"video-color-gamut", VideoColorGamutMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum VideoColorGamutMediaFeature<"video-color-gamut", VideoColorGamutMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum VideoColorGamutMediaFeatureKeyword { Srgb: "srgb", P3: "p3", Rec2020: "rec2020" });
 

--- a/crates/css_ast/src/rules/media/features/video_dynamic_range.rs
+++ b/crates/css_ast/src/rules/media/features/video_dynamic_range.rs
@@ -1,6 +1,10 @@
-use css_parse::{discrete_feature, keyword_set};
+use super::prelude::*;
 
-discrete_feature!(pub enum VideoDynamicRangeMediaFeature<"video-dynamic-range", VideoDynamicRangeMediaFeatureKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum VideoDynamicRangeMediaFeature<"video-dynamic-range", VideoDynamicRangeMediaFeatureKeyword>
+);
 
 keyword_set!(pub enum VideoDynamicRangeMediaFeatureKeyword { Standard: "standard", Hight: "high" });
 

--- a/crates/css_ast/src/rules/media/features/webkit.rs
+++ b/crates/css_ast/src/rules/media/features/webkit.rs
@@ -1,17 +1,37 @@
+use super::prelude::*;
 use crate::units::CSSFloat;
-use css_parse::{RangedFeatureKeyword, discrete_feature, keyword_set, ranged_feature};
 
 keyword_set!(pub enum BooleanKeyword { True: "true", False: "false" });
 
-discrete_feature!(pub enum WebkitAnimationMediaFeature<"-webkit-animation", BooleanKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum WebkitAnimationMediaFeature<"-webkit-animation", BooleanKeyword>
+);
 
-discrete_feature!(pub enum WebkitTransform2dMediaFeature<"-webkit-transform-2d", BooleanKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum WebkitTransform2dMediaFeature<"-webkit-transform-2d", BooleanKeyword>
+);
 
-discrete_feature!(pub enum WebkitTransform3dMediaFeature<"-webkit-transform-3d", BooleanKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum WebkitTransform3dMediaFeature<"-webkit-transform-3d", BooleanKeyword>
+);
 
-discrete_feature!(pub enum WebkitTransitionMediaFeature<"-webkit-transition", BooleanKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum WebkitTransitionMediaFeature<"-webkit-transition", BooleanKeyword>
+);
 
-discrete_feature!(pub enum WebkitVideoPlayableInlineMediaFeature<"-webkit-video-playable-inline", BooleanKeyword>);
+discrete_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum WebkitVideoPlayableInlineMediaFeature<"-webkit-video-playable-inline", BooleanKeyword>
+);
 
 keyword_set!(pub enum WebkitDevicePixelRatioMediaFeatureKeyword {
 	DevicePixelRatio: "-webkit-device-pixel-ratio",
@@ -25,4 +45,8 @@ impl RangedFeatureKeyword for WebkitDevicePixelRatioMediaFeatureKeyword {
 	}
 }
 
-ranged_feature!(pub enum WebkitDevicePixelRatioMediaFeature<WebkitDevicePixelRatioMediaFeatureKeyword, CSSFloat>);
+ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+	pub enum WebkitDevicePixelRatioMediaFeature<WebkitDevicePixelRatioMediaFeatureKeyword, CSSFloat>
+);

--- a/crates/css_ast/src/rules/media/features/width.rs
+++ b/crates/css_ast/src/rules/media/features/width.rs
@@ -1,5 +1,5 @@
+use super::prelude::*;
 use crate::units::Length;
-use css_parse::{RangedFeatureKeyword, keyword_set, ranged_feature};
 
 keyword_set!(pub enum WidthMediaFeatureKeyword { Width: "width", MaxWidth: "max-width", MinWidth: "min-width" });
 
@@ -10,6 +10,8 @@ impl RangedFeatureKeyword for WidthMediaFeatureKeyword {
 }
 
 ranged_feature!(
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	pub enum WidthMediaFeature<WidthMediaFeatureKeyword, Length>
 );
 

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -76,10 +76,12 @@ pub trait BooleanFeature<'a>: Sized {
 /// ```
 /// use css_parse::*;
 /// use bumpalo::Bump;
+/// use csskit_derives::{ToCursors, ToSpan};
 ///
 /// // Define the Boolean Feature.
 /// boolean_feature! {
 ///     /// A boolean media feature: `(test-feature)`
+///     #[derive(ToCursors, ToSpan, Debug)]
 ///     pub enum TestFeature<"test-feature">
 /// }
 ///
@@ -98,40 +100,9 @@ pub trait BooleanFeature<'a>: Sized {
 macro_rules! boolean_feature {
 	($(#[$meta:meta])* $vis:vis enum $feature: ident<$feature_name: tt>) => {
 		$(#[$meta])*
-		#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		$vis enum $feature {
 			WithValue($crate::T!['('], $crate::T![Ident], $crate::T![:], $crate::T![Any], $crate::T![')']),
 			Bare($crate::T!['('], $crate::T![Ident], $crate::T![')']),
-		}
-
-		impl $crate::ToCursors for $feature {
-			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
-			use $crate::ToCursors;
-				match self {
-					Self::WithValue(a, b, c, d, e) => {
-						ToCursors::to_cursors(a, s);
-						ToCursors::to_cursors(b, s);
-						ToCursors::to_cursors(c, s);
-						ToCursors::to_cursors(d, s);
-						ToCursors::to_cursors(e, s);
-					},
-					Self::Bare(a, b, c) => {
-						ToCursors::to_cursors(a, s);
-						ToCursors::to_cursors(b, s);
-						ToCursors::to_cursors(c, s);
-					}
-				}
-			}
-		}
-
-		impl $crate::ToSpan for $feature {
-			fn to_span(&self) -> $crate::Span {
-				match self {
-					Self::WithValue(start, _, _, _, end) => start.to_span() + end.to_span(),
-					Self::Bare(start, _, end) => start.to_span() + end.to_span(),
-				}
-			}
 		}
 
 		impl<'a> $crate::Parse<'a> for $feature {

--- a/crates/css_parse/src/traits/discrete_feature.rs
+++ b/crates/css_parse/src/traits/discrete_feature.rs
@@ -78,6 +78,7 @@ pub trait DiscreteFeature<'a>: Sized {
 /// ```
 /// use css_parse::*;
 /// use bumpalo::Bump;
+/// use csskit_derives::{ToCursors, ToSpan};
 ///
 /// keyword_set!(
 ///     /// A keyword that defines text-feature options
@@ -90,6 +91,7 @@ pub trait DiscreteFeature<'a>: Sized {
 /// // Define the Discrete Feature.
 /// discrete_feature! {
 ///     /// A discrete media feature: `(test-feature: big)`, `(test-feature: small)`
+///     #[derive(ToCursors, ToSpan, Debug)]
 ///     pub enum TestFeature<"test-feature", FeatureKeywords>
 /// }
 ///
@@ -108,40 +110,9 @@ pub trait DiscreteFeature<'a>: Sized {
 macro_rules! discrete_feature {
 	($(#[$meta:meta])* $vis:vis enum $feature: ident<$feature_name: tt, $value: ty>) => {
 		$(#[$meta])*
-		#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		$vis enum $feature {
 			WithValue($crate::T!['('], $crate::T![Ident], $crate::T![:], $value, $crate::T![')']),
 			Bare($crate::T!['('], $crate::T![Ident], $crate::T![')']),
-		}
-
-		impl $crate::ToCursors for $feature {
-			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
-			use $crate::ToCursors;
-				match self {
-					Self::WithValue(a, b, c, d, e) => {
-						ToCursors::to_cursors(a, s);
-						ToCursors::to_cursors(b, s);
-						ToCursors::to_cursors(c, s);
-						ToCursors::to_cursors(d, s);
-						ToCursors::to_cursors(e, s);
-					},
-					Self::Bare(a, b, c) => {
-						ToCursors::to_cursors(a, s);
-						ToCursors::to_cursors(b, s);
-						ToCursors::to_cursors(c, s);
-					}
-				}
-			}
-		}
-
-		impl $crate::ToSpan for $feature {
-			fn to_span(&self) -> $crate::Span {
-				match self {
-					Self::WithValue(start, _, _, _, end) => start.to_span() + end.to_span(),
-					Self::Bare(start, _, end) => start.to_span() + end.to_span(),
-				}
-			}
 		}
 
 		impl<'a> $crate::Parse<'a> for $feature {

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -164,6 +164,7 @@ pub trait RangedFeature<'a>: Sized {
 /// ```
 /// use css_parse::*;
 /// use bumpalo::Bump;
+/// use csskit_derives::{ToCursors, ToSpan};
 ///
 /// // Defined the "FeatureName"
 /// keyword_set!(pub enum TestKeyword { Thing: "thing", MaxThing: "max-thing", MinThing: "min-thing" });
@@ -176,6 +177,7 @@ pub trait RangedFeature<'a>: Sized {
 /// // Define the Ranged Feature.
 /// ranged_feature! {
 ///   /// A ranged media feature: (thing: 1), or (1 <= thing < 10)
+///   #[derive(ToCursors, ToSpan, Debug)]
 ///   pub enum TestFeature<TestKeyword, T![Number]>
 /// }
 ///
@@ -194,62 +196,11 @@ pub trait RangedFeature<'a>: Sized {
 macro_rules! ranged_feature {
 	($(#[$meta:meta])* $vis:vis enum $feature: ident<$feature_name: ty, $value: ty>) => {
 		$(#[$meta])*
-		#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		$vis enum $feature {
 			Left($crate::T!['('], $feature_name, $crate::Comparison, $value, $crate::T![')']),
 			Right($crate::T!['('], $value, $crate::Comparison, $feature_name, $crate::T![')']),
 			Range($crate::T!['('], $value, $crate::Comparison, $feature_name, $crate::Comparison, $value, $crate::T![')']),
 			Legacy($crate::T!['('], $feature_name, $crate::T![:], $value, $crate::T![')']),
-		}
-
-		impl $crate::ToCursors for $feature {
-			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
-			use $crate::ToCursors;
-				match self {
-					Self::Left(a, b, c, d, e) => {
-						ToCursors::to_cursors(a, s);
-						ToCursors::to_cursors(b, s);
-						ToCursors::to_cursors(c, s);
-						ToCursors::to_cursors(d, s);
-						ToCursors::to_cursors(e, s);
-					},
-					Self::Right(a, b, c, d, e) => {
-						ToCursors::to_cursors(a, s);
-						ToCursors::to_cursors(b, s);
-						ToCursors::to_cursors(c, s);
-						ToCursors::to_cursors(d, s);
-						ToCursors::to_cursors(e, s);
-					}
-					Self::Range(a, b, c, d, e, f, g) => {
-						ToCursors::to_cursors(a, s);
-						ToCursors::to_cursors(b, s);
-						ToCursors::to_cursors(c, s);
-						ToCursors::to_cursors(d, s);
-						ToCursors::to_cursors(e, s);
-						ToCursors::to_cursors(f, s);
-						ToCursors::to_cursors(g, s);
-					}
-					Self::Legacy(a, b, c, d, e) => {
-						ToCursors::to_cursors(a, s);
-						ToCursors::to_cursors(b, s);
-						ToCursors::to_cursors(c, s);
-						ToCursors::to_cursors(d, s);
-						ToCursors::to_cursors(e, s);
-					}
-				}
-			}
-		}
-
-		impl $crate::ToSpan for $feature {
-			fn to_span(&self) -> $crate::Span {
-				match self {
-					Self::Left(start, _, _, _, end) => start.to_span() + end.to_span(),
-					Self::Right(start, _, _, _, end) => start.to_span() + end.to_span(),
-					Self::Range(start, _, _, _, _, _, end) => start.to_span() + end.to_span(),
-					Self::Legacy(start, _, _, _, end) => start.to_span() + end.to_span(),
-				}
-			}
 		}
 
 		impl<'a> $crate::Parse<'a> for $feature {


### PR DESCRIPTION
The feature macros (discrete_feature, boolean_feature, ranged_feature) all by default derive a whole bunch such as
PartialEq, Debug, Clone, etc. In addition they also implicitly add ToCursors and ToSpan implementations. These are all
sensible choices as it's highly likely we want these on our types, but adding them implicitly restricts us and makes
things less flexible.

This change makes it such that by default these macros will _only_ implement Parse, and their respective trait type.
This requires us to define the other derives in the various callsites, but will hopefully make future modifications to
these types easier to handle.

Lastly, as a consequence of this, media/features/mod.rs now includes a prelude for the various features to use.
