### PR TITLE
derive_atom_set: optimise key lookup performance

### DIFF
--- a/crates/derive_atom_set/benches/atom_set_bench.rs
+++ b/crates/derive_atom_set/benches/atom_set_bench.rs
@@ -12,6 +12,7 @@ fn bench(c: &mut Criterion) {
 		// Short strings (tuple matching)
 		("1_char", vec!["a", "b", "c", "d", "e"]),
 		("2_char", vec!["px", "em", "ex", "pt", "pc", "pp", "qq"]),
+		("3_char", vec!["dpx", "dpi", "dpc", "ppx", "swi", "qqq"]),
 		("4_char", vec!["auto", "none", "left", "flex", "grid", "blob", "dont"]),
 		("5_char", vec!["block", "table", "fixed", "style", "missd", "match"]),
 		// Medium strings (u64 lookup)

--- a/crates/derive_atom_set/tests/test.rs
+++ b/crates/derive_atom_set/tests/test.rs
@@ -18,8 +18,10 @@ enum TestAtomSet {
 	_None,
 
 	// Tuple matching (1-5 chars)
-	A,     // 1 char
-	Px,    // 2 chars
+	A,  // 1 char
+	Px, // 2 chars
+	Dpx,
+	Dpi,   // 3 Chars
 	Auto,  // 4 chars
 	Block, // 5 chars
 
@@ -50,6 +52,8 @@ fn test() {
 	assert_eq!(TestAtomSet::from_str("a"), TestAtomSet::A);
 	assert_eq!(TestAtomSet::from_str("A"), TestAtomSet::A);
 	assert_eq!(TestAtomSet::from_str("px"), TestAtomSet::Px);
+	assert_eq!(TestAtomSet::from_str("dpx"), TestAtomSet::Dpx);
+	assert_eq!(TestAtomSet::from_str("dpi"), TestAtomSet::Dpi);
 	assert_eq!(TestAtomSet::from_str("auto"), TestAtomSet::Auto);
 	assert_eq!(TestAtomSet::from_str("block"), TestAtomSet::Block);
 


### PR DESCRIPTION
This change goes through derive_atom_set running an optimisation pass to ensure all lookups are <20ns (at least on my
machine) and are relatively stable regardless of key length.
