### PR TITLE
css_parse: switch from p.peek::<T> to <T>::peek(p, p.next_n(1))

### DIFF
--- a/crates/css_parse/src/comparison.rs
+++ b/crates/css_parse/src/comparison.rs
@@ -1,4 +1,4 @@
-use crate::{Diagnostic, Parse, Parser, Result, T, ToCursors};
+use crate::{Diagnostic, Parse, Parser, Peek, Result, T, ToCursors};
 
 /// This enum represents a set of comparison operators, used in Ranged Media Features (see
 /// [RangedFeature][crate::RangedFeature]), and could be used in other parts of a CSS-alike language. This isn't a
@@ -31,14 +31,14 @@ impl<'a> Parse<'a> for Comparison {
 		match c.token().char() {
 			Some('=') => p.parse::<T![=]>().map(Comparison::Equal),
 			Some('>') => {
-				if p.peek::<T![>=]>() {
+				if <T![>=]>::peek(p, c) {
 					p.parse::<T![>=]>().map(Comparison::GreaterThanEqual)
 				} else {
 					p.parse::<T![>]>().map(Comparison::GreaterThan)
 				}
 			}
 			Some('<') => {
-				if p.peek::<T![<=]>() {
+				if <T![<=]>::peek(p, c) {
 					p.parse::<T![<=]>().map(Comparison::LessThanEqual)
 				} else {
 					p.parse::<T![<]>().map(Comparison::LessThan)

--- a/crates/css_parse/src/syntax/bad_declaration.rs
+++ b/crates/css_parse/src/syntax/bad_declaration.rs
@@ -1,5 +1,5 @@
 use crate::{
-	CursorSink, Parse, Parser, Result as ParserResult, Span, State, T, ToCursors, ToSpan, syntax::ComponentValue,
+	CursorSink, Parse, Parser, Peek, Result as ParserResult, Span, State, T, ToCursors, ToSpan, syntax::ComponentValue,
 };
 use bumpalo::collections::Vec;
 
@@ -22,7 +22,8 @@ impl<'a> Parse<'a> for BadDeclaration<'a> {
 			if p.at_end() {
 				return Ok(Self(values));
 			}
-			if p.peek::<T![;]>() {
+			let c = p.peek_n(1);
+			if <T![;]>::peek(p, c) {
 				values.push(p.parse::<ComponentValue>()?);
 				return Ok(Self(values));
 			}
@@ -30,7 +31,7 @@ impl<'a> Parse<'a> for BadDeclaration<'a> {
 			// <}-token>
 			//
 			//     If nested is true, return nothing. Otherwise, discard a token.
-			if p.peek::<T!['}']>() {
+			if <T!['}']>::peek(p, c) {
 				if p.is(State::Nested) {
 					return Ok(Self(values));
 				} else {

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -56,11 +56,12 @@ where
 			if p.at_end() {
 				break;
 			}
-			if p.peek::<T!['}']>() {
+			let c = p.peek_n(1);
+			if <T!['}']>::peek(p, c) {
 				break;
 			}
 			let old_state = p.set_state(State::Nested);
-			if p.peek::<T![AtKeyword]>() {
+			if <T![AtKeyword]>::peek(p, c) {
 				let rule = p.parse::<R>();
 				p.set_state(old_state);
 				rules.push(rule?);

--- a/crates/css_parse/src/syntax/comma_separated.rs
+++ b/crates/css_parse/src/syntax/comma_separated.rs
@@ -60,7 +60,7 @@ impl<'a, T: Peek<'a>, const MIN: usize> Peek<'a> for CommaSeparated<'a, T, MIN> 
 impl<'a, T: Parse<'a> + Peek<'a>, const MIN: usize> Parse<'a> for CommaSeparated<'a, T, MIN> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		let mut items = Self::new_in(p.bump());
-		if MIN == 0 && !p.peek::<T>() {
+		if MIN == 0 && !<T>::peek(p, p.peek_n(1)) {
 			return Ok(items);
 		}
 		loop {

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -52,30 +52,31 @@ impl<'a> Peek<'a> for ComponentValue<'a> {
 // https://drafts.csswg.org/css-syntax-3/#consume-component-value
 impl<'a> Parse<'a> for ComponentValue<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		if p.peek::<T![' ']>() {
-			p.parse::<T![' ']>().map(Self::Whitespace)
-		} else if p.peek::<T![PairWiseStart]>() {
+		let c = p.peek_n(1);
+		Ok(if <T![' ']>::peek(p, c) {
+			Self::Whitespace(p.parse::<T![' ']>()?)
+		} else if <T![PairWiseStart]>::peek(p, c) {
 			let old_state = p.set_state(State::Nested);
 			let block = p.parse::<SimpleBlock>();
 			p.set_state(old_state);
-			Ok(Self::SimpleBlock(block?))
-		} else if p.peek::<T![Function]>() {
-			p.parse::<FunctionBlock>().map(Self::Function)
-		} else if p.peek::<T![Number]>() {
-			p.parse::<T![Number]>().map(Self::Number)
-		} else if p.peek::<T![Dimension]>() {
-			p.parse::<T![Dimension]>().map(Self::Dimension)
-		} else if p.peek::<T![Ident]>() {
-			p.parse::<T![Ident]>().map(Self::Ident)
-		} else if p.peek::<T![AtKeyword]>() {
-			p.parse::<T![AtKeyword]>().map(Self::AtKeyword)
-		} else if p.peek::<T![Hash]>() {
-			p.parse::<T![Hash]>().map(Self::Hash)
-		} else if p.peek::<T![String]>() {
-			p.parse::<T![String]>().map(Self::String)
-		} else if p.peek::<T![Url]>() {
-			p.parse::<T![Url]>().map(Self::Url)
-		} else if p.peek::<T![Delim]>() {
+			Self::SimpleBlock(block?)
+		} else if <T![Function]>::peek(p, c) {
+			Self::Function(p.parse::<FunctionBlock>()?)
+		} else if <T![Number]>::peek(p, c) {
+			Self::Number(p.parse::<T![Number]>()?)
+		} else if <T![Dimension]>::peek(p, c) {
+			Self::Dimension(p.parse::<T![Dimension]>()?)
+		} else if <T![Ident]>::peek(p, c) {
+			Self::Ident(p.parse::<T![Ident]>()?)
+		} else if <T![AtKeyword]>::peek(p, c) {
+			Self::AtKeyword(p.parse::<T![AtKeyword]>()?)
+		} else if <T![Hash]>::peek(p, c) {
+			Self::Hash(p.parse::<T![Hash]>()?)
+		} else if <T![String]>::peek(p, c) {
+			Self::String(p.parse::<T![String]>()?)
+		} else if <T![Url]>::peek(p, c) {
+			Self::Url(p.parse::<T![Url]>()?)
+		} else if <T![Delim]>::peek(p, c) {
 			p.parse::<T![Delim]>().map(|delim| {
 				// Carefully handle Whitespace rules to ensure whitespace isn't lost when re-serializing
 				let mut rules = AssociatedWhitespaceRules::none();
@@ -85,16 +86,16 @@ impl<'a> Parse<'a> for ComponentValue<'a> {
 					rules |= AssociatedWhitespaceRules::BanAfter;
 				}
 				Self::Delim(delim.with_associated_whitespace(rules))
-			})
-		} else if p.peek::<T![:]>() {
-			p.parse::<T![:]>().map(Self::Colon)
-		} else if p.peek::<T![;]>() {
-			p.parse::<T![;]>().map(Self::Semicolon)
-		} else if p.peek::<T![,]>() {
-			p.parse::<T![,]>().map(Self::Comma)
+			})?
+		} else if <T![:]>::peek(p, c) {
+			Self::Colon(p.parse::<T![:]>()?)
+		} else if <T![;]>::peek(p, c) {
+			Self::Semicolon(p.parse::<T![;]>()?)
+		} else if <T![,]>::peek(p, c) {
+			Self::Comma(p.parse::<T![,]>()?)
 		} else {
 			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
-		}
+		})
 	}
 }
 

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -31,7 +31,8 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
 			if p.next_is_stop() {
 				break;
 			}
-			if p.peek::<ComponentValue>() {
+			let c = p.peek_n(1);
+			if <ComponentValue>::peek(p, c) {
 				let mut value = p.parse::<ComponentValue>()?;
 				if let ComponentValue::Delim(d) = value
 					&& last_was_whitespace

--- a/crates/css_parse/src/syntax/declaration_rule_list.rs
+++ b/crates/css_parse/src/syntax/declaration_rule_list.rs
@@ -61,9 +61,10 @@ where
 			if close_curly.is_some() {
 				return Ok(Self { open_curly, declarations, at_rules, close_curly });
 			}
-			if p.peek::<T![AtKeyword]>() {
+			let c = p.peek_n(1);
+			if <T![AtKeyword]>::peek(p, c) {
 				at_rules.push(p.parse::<R>()?);
-			} else if p.peek::<T![Ident]>() {
+			} else if <T![Ident]>::peek(p, c) {
 				let rule = p.parse::<Declaration<'a, D>>()?;
 				declarations.push(rule);
 			} else {

--- a/crates/css_parse/src/syntax/qualified_rule.rs
+++ b/crates/css_parse/src/syntax/qualified_rule.rs
@@ -33,6 +33,7 @@ where
 	R: Parse<'a>,
 {
 	fn parse(p: &mut Parser<'a>) -> Result<Self> {
+		let c = p.peek_n(1);
 		// Let rule be a new qualified rule with its prelude, declarations, and child rules all initially set to empty lists.
 
 		// Process input:
@@ -46,16 +47,16 @@ where
 
 		// <}-token>
 		//   This is a parse error. If nested is true, return nothing. Otherwise, consume a token and append the result to rule’s prelude.
-		if p.is(State::Nested) && p.peek::<T!['}']>() {
-			Err(Diagnostic::new(p.peek_n(1), Diagnostic::unexpected_close_curly))?;
+		if p.is(State::Nested) && <T!['}']>::peek(p, c) {
+			Err(Diagnostic::new(c, Diagnostic::unexpected_close_curly))?;
 		}
 
 		// <{-token>
 		//	If the first two non-<whitespace-token> values of rule’s prelude are an <ident-token> whose value starts with "--" followed by a <colon-token>, then:
 		let checkpoint = p.checkpoint();
-		if p.peek::<T![DashedIdent]>() {
+		if <T![DashedIdent]>::peek(p, c) {
 			p.parse::<T![DashedIdent]>().ok();
-			if p.peek::<T![:]>() {
+			if <T![:]>::peek(p, p.peek_n(1)) {
 				// If nested is true, consume the remnants of a bad declaration from input, with nested set to true, and return nothing.
 				if p.is(State::Nested) {
 					p.rewind(checkpoint);

--- a/crates/css_parse/src/syntax/simple_block.rs
+++ b/crates/css_parse/src/syntax/simple_block.rs
@@ -1,5 +1,6 @@
 use crate::{
-	CursorSink, KindSet, Parse, Parser, Result as ParserResult, Span, T, ToCursors, ToSpan, syntax::ComponentValues,
+	CursorSink, KindSet, Parse, Parser, Peek, Result as ParserResult, Span, T, ToCursors, ToSpan,
+	syntax::ComponentValues,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -18,7 +19,7 @@ impl<'a> Parse<'a> for SimpleBlock<'a> {
 		let values = p.parse::<ComponentValues>();
 		p.set_stop(stop);
 		let values = values?;
-		if p.peek::<T![PairWiseEnd]>() {
+		if <T![PairWiseEnd]>::peek(p, p.peek_n(1)) {
 			return Ok(Self { open, values, close: p.parse::<T![PairWiseEnd]>().ok() });
 		}
 		Ok(Self { open, values, close: None })

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -64,11 +64,8 @@ macro_rules! define_kinds {
 
 		impl<'a> $crate::Parse<'a> for $ident {
 			fn parse(p: &mut $crate::Parser<'a>) -> $crate::Result<Self> {
-				if p.peek::<Self>() {
-					Ok(Self(p.next()))
-				} else {
-					Err($crate::Diagnostic::new(p.next(), $crate::Diagnostic::unexpected))?
-				}
+				let c = p.next();
+				if Self::peek(p, c) { Ok(Self(c)) } else { Err($crate::Diagnostic::new(c, $crate::Diagnostic::unexpected))? }
 			}
 		}
 
@@ -116,11 +113,8 @@ macro_rules! define_kind_idents {
 
 		impl<'a> $crate::Parse<'a> for $ident {
 			fn parse(p: &mut $crate::Parser<'a>) -> $crate::Result<Self> {
-				if p.peek::<Self>() {
-					Ok(Self(p.next()))
-				} else {
-					Err($crate::Diagnostic::new(p.next(), $crate::Diagnostic::unexpected))?
-				}
+				let c = p.next();
+				if Self::peek(p, c) { Ok(Self(c)) } else { Err($crate::Diagnostic::new(c, $crate::Diagnostic::unexpected))? }
 			}
 		}
 
@@ -199,11 +193,12 @@ macro_rules! custom_delim {
 
 		impl<'a> $crate::Parse<'a> for $ident {
 			fn parse(p: &mut $crate::Parser<'a>) -> $crate::Result<Self> {
-				if p.peek::<Self>() {
-					let delim = p.parse::<$crate::T![Delim]>()?;
+				use $crate::Peek;
+				let delim = p.parse::<$crate::T![Delim]>()?;
+				if Self::peek(p, delim.into()) {
 					Ok(Self(delim))
 				} else {
-					Err($crate::Diagnostic::new(p.next(), $crate::Diagnostic::unexpected))?
+					Err($crate::Diagnostic::new(delim.into(), $crate::Diagnostic::unexpected))?
 				}
 			}
 		}
@@ -416,11 +411,11 @@ impl<'a> Peek<'a> for DashedIdent {
 
 impl<'a> Parse<'a> for DashedIdent {
 	fn parse(p: &mut Parser<'a>) -> Result<Self> {
-		if p.peek::<Self>() {
-			let c = p.next();
+		let c = p.next();
+		if Self::peek(p, c) {
 			Ok(Self(Ident(c)))
 		} else {
-			Err(crate::Diagnostic::new(p.next(), crate::Diagnostic::unexpected))?
+			Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
 		}
 	}
 }
@@ -445,12 +440,8 @@ impl<'a> Peek<'a> for Dimension {
 
 impl<'a> Parse<'a> for Dimension {
 	fn parse(p: &mut Parser<'a>) -> Result<Self> {
-		if p.peek::<Self>() {
-			let c = p.next();
-			Ok(Self(c))
-		} else {
-			Err(crate::Diagnostic::new(p.next(), crate::Diagnostic::unexpected))?
-		}
+		let c = p.next();
+		if Self::peek(p, c) { Ok(Self(c)) } else { Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))? }
 	}
 }
 
@@ -509,12 +500,8 @@ impl<'a> Peek<'a> for Number {
 
 impl<'a> Parse<'a> for Number {
 	fn parse(p: &mut Parser<'a>) -> Result<Self> {
-		if p.peek::<Self>() {
-			let c = p.next();
-			Ok(Self(c))
-		} else {
-			Err(crate::Diagnostic::new(p.next(), crate::Diagnostic::unexpected))?
-		}
+		let c = p.next();
+		if Self::peek(p, c) { Ok(Self(c)) } else { Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))? }
 	}
 }
 
@@ -804,12 +791,8 @@ impl<'a> Peek<'a> for PairWiseStart {
 
 impl<'a> Parse<'a> for PairWiseStart {
 	fn parse(p: &mut Parser<'a>) -> Result<Self> {
-		if p.peek::<Self>() {
-			let c = p.next();
-			Ok(Self(c))
-		} else {
-			Err(crate::Diagnostic::new(p.next(), crate::Diagnostic::unexpected))?
-		}
+		let c = p.next();
+		if Self::peek(p, c) { Ok(Self(c)) } else { Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))? }
 	}
 }
 
@@ -841,12 +824,8 @@ impl<'a> Peek<'a> for PairWiseEnd {
 
 impl<'a> Parse<'a> for PairWiseEnd {
 	fn parse(p: &mut Parser<'a>) -> Result<Self> {
-		if p.peek::<Self>() {
-			let c = p.next();
-			Ok(Self(c))
-		} else {
-			Err(crate::Diagnostic::new(p.next(), crate::Diagnostic::unexpected))?
-		}
+		let c = p.next();
+		if Self::peek(p, c) { Ok(Self(c)) } else { Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))? }
 	}
 }
 

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -1,5 +1,5 @@
 use crate::Cursor;
-use crate::{Diagnostic, Parser, Result, T};
+use crate::{Diagnostic, Parser, Peek, Result, T};
 use css_lexer::DynAtomSet;
 
 /// This trait provides an implementation for parsing a ["Media Feature" in the "Boolean" context][1]. This is
@@ -56,7 +56,7 @@ pub trait BooleanFeature<'a>: Sized {
 		if !p.equals_atom(c, name) {
 			Err(Diagnostic::new(c, Diagnostic::unexpected_ident))?
 		}
-		if p.peek::<T![:]>() {
+		if <T![:]>::peek(p, p.peek_n(1)) {
 			let colon = p.parse::<T![:]>()?;
 			let value = p.parse::<T![Any]>()?;
 			let close = p.parse::<T![')']>()?;

--- a/crates/css_parse/src/traits/declaration_value.rs
+++ b/crates/css_parse/src/traits/declaration_value.rs
@@ -126,16 +126,17 @@ pub trait DeclarationValue<'a>: Sized {
 		if !Self::valid_declaration_name(p, name) {
 			return Self::parse_unknown_declaration_value(p, name);
 		}
-		if p.peek::<Self::ComputedValue>() {
+		if <Self::ComputedValue>::peek(p, p.peek_n(1)) {
 			return Self::parse_computed_declaration_value(p, name);
 		}
 		let checkpoint = p.checkpoint();
-		if let Ok(val) = Self::parse_specified_declaration_value(p, name)
-			&& (p.at_end() || p.peek_n(1) == KindSet::RIGHT_CURLY_OR_SEMICOLON || p.peek::<T![!]>())
-		{
-			return Ok(val);
+		if let Ok(val) = Self::parse_specified_declaration_value(p, name) {
+			let c = p.peek_n(1);
+			if p.at_end() || c == KindSet::RIGHT_CURLY_OR_SEMICOLON || <T![!]>::peek(p, c) {
+				return Ok(val);
+			}
 		}
-		if p.peek::<Self::ComputedValue>() {
+		if <Self::ComputedValue>::peek(p, p.peek_n(1)) {
 			p.rewind(checkpoint);
 			if let Ok(val) = Self::parse_computed_declaration_value(p, name) {
 				return Ok(val);

--- a/crates/css_parse/src/traits/discrete_feature.rs
+++ b/crates/css_parse/src/traits/discrete_feature.rs
@@ -1,6 +1,6 @@
 use css_lexer::DynAtomSet;
 
-use crate::{Cursor, Diagnostic, Parse, Parser, Result, T};
+use crate::{Cursor, Diagnostic, Parse, Parser, Peek, Result, T};
 
 /// This trait provides an implementation for parsing a ["Media Feature" that has a discrete keyword][1]. This is
 /// complementary to the other media features: [BooleanFeature][crate::BooleanFeature] and
@@ -55,7 +55,7 @@ pub trait DiscreteFeature<'a>: Sized {
 		if !p.equals_atom(c, atom) {
 			Err(Diagnostic::new(c, Diagnostic::unexpected_ident))?
 		}
-		if p.peek::<T![:]>() {
+		if <T![:]>::peek(p, p.peek_n(1)) {
 			let colon = p.parse::<T![:]>()?;
 			let value = p.parse::<Self::Value>()?;
 			let close = p.parse::<T![')']>()?;

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -144,7 +144,7 @@ pub trait RangedFeature<'a>: Sized {
 		if <T![Ident]>::peek(p, c) {
 			let atom = p.to_atom::<A>(c);
 			let ident = p.parse::<T![Ident]>()?;
-			if p.peek::<T![:]>() {
+			if <T![:]>::peek(p, p.peek_n(1)) {
 				let colon = p.parse::<T![:]>()?;
 				let value = p.parse::<Self::Value>()?;
 				let close = p.parse::<T![')']>()?;
@@ -174,7 +174,7 @@ pub trait RangedFeature<'a>: Sized {
 		if &p.to_atom::<A>(ident.into()) != name {
 			Err(Diagnostic::new(c, Diagnostic::unexpected))?
 		}
-		if !p.peek::<T![Delim]>() {
+		if !<T![Delim]>::peek(p, p.peek_n(1)) {
 			let close = p.parse::<T![')']>()?;
 			return Self::new_right(open, left, left_comparison, ident, close);
 		}


### PR DESCRIPTION
As explained in https://github.com/csskit/csskit/pull/494, many functions repeatedly call `p.peek` which fetches the
same cursor over and over. It is perhaps preferable to call `p.peek::<T>(p, c)` as that encourages us to re-use the
cursor.

This change temporarily deleted the `peek` fn from parser, which showed all the places it was used in css_parse. All
those callsites then got refactored to use the Peek trait instead.
