### PR TITLE
css_parse: add trivia output

### DIFF
--- a/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
+++ b/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
@@ -42,7 +42,7 @@ mod tests {
 			CssAtomSet::ATOMS,
 			DynamicRangeLimitMixFunction,
 			"dynamic-range-limit-mix(80% constrained,20% standard)",
-			"dynamic-range-limit-mix(constrained 80%,standard 20%)"
+			"dynamic-range-limit-mix( constrained 80%, standard 20%)"
 		);
 		assert_parse!(
 			CssAtomSet::ATOMS,

--- a/crates/css_ast/src/functions/stripes_function.rs
+++ b/crates/css_ast/src/functions/stripes_function.rs
@@ -68,13 +68,13 @@ mod tests {
 			CssAtomSet::ATOMS,
 			StripesFunction,
 			"stripes(0.1fr red,0.2fr green,100px blue)",
-			"stripes(red 0.1fr,green 0.2fr,blue 100px)"
+			"stripes( red 0.1fr, green 0.2fr, blue 100px)"
 		);
 		assert_parse!(
 			CssAtomSet::ATOMS,
 			StripesFunction,
 			"stripes(red 1fr,2fr green,blue 100px)",
-			"stripes(red 1fr,green 2fr,blue 100px)"
+			"stripes(red 1fr, green 2fr,blue 100px)"
 		);
 	}
 }

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -205,11 +205,11 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, Nth, "-n");
 		assert_parse!(CssAtomSet::ATOMS, Nth, "N");
 		assert_parse!(CssAtomSet::ATOMS, Nth, "+n+3");
-		assert_parse!(CssAtomSet::ATOMS, Nth, "+n + 7 ", "+n+ 7");
+		assert_parse!(CssAtomSet::ATOMS, Nth, "+n + 7 ", "+n + 7");
 		assert_parse!(CssAtomSet::ATOMS, Nth, "N- 123");
 		assert_parse!(CssAtomSet::ATOMS, Nth, "n- 10");
-		assert_parse!(CssAtomSet::ATOMS, Nth, "-n\n- 1", "-n - 1");
-		assert_parse!(CssAtomSet::ATOMS, Nth, " 23n\n\n+\n\n123 ", "23n+ 123");
+		assert_parse!(CssAtomSet::ATOMS, Nth, "-n\n- 1", "-n\n- 1");
+		assert_parse!(CssAtomSet::ATOMS, Nth, " 23n\n\n+\n\n123 ", "23n\n\n+\n\n123");
 	}
 
 	#[test]

--- a/crates/css_ast/src/types/image_1d.rs
+++ b/crates/css_ast/src/types/image_1d.rs
@@ -25,17 +25,5 @@ mod tests {
 	#[test]
 	fn test_writes() {
 		assert_parse!(CssAtomSet::ATOMS, Image1D, "stripes(red 1fr,green 2fr,blue 100px)");
-		assert_parse!(
-			CssAtomSet::ATOMS,
-			Image1D,
-			"stripes(0.1fr red,0.2fr green,100px blue)",
-			"stripes(red 0.1fr,green 0.2fr,blue 100px)"
-		);
-		assert_parse!(
-			CssAtomSet::ATOMS,
-			Image1D,
-			"stripes(red 1fr,2fr green,blue 100px)",
-			"stripes(red 1fr,green 2fr,blue 100px)"
-		);
 	}
 }

--- a/crates/css_ast/src/values/scrollbars/impls.rs
+++ b/crates/css_ast/src/values/scrollbars/impls.rs
@@ -13,7 +13,7 @@ mod tests {
 	fn test_parse() {
 		assert_parse!(CssAtomSet::ATOMS, ScrollbarColorStyleValue, "red red");
 		assert_parse!(CssAtomSet::ATOMS, ScrollbarColorStyleValue, "auto");
-		assert_parse!(CssAtomSet::ATOMS, ScrollbarColorStyleValue, "red #eee", "red#eee");
+		assert_parse!(CssAtomSet::ATOMS, ScrollbarColorStyleValue, "red #eee");
 	}
 
 	#[test]

--- a/crates/css_parse/src/cursor_interleave_sink.rs
+++ b/crates/css_parse/src/cursor_interleave_sink.rs
@@ -1,0 +1,39 @@
+use crate::{Cursor, CursorSink};
+
+/// This is a [CursorSink] that wraps a Sink (`impl CursorSink`) and a slice of [Cursor]s to interleave. On each
+/// [CursorSink::append()] call, will append to the delegate sink, while also interleaving any of the Cursors from the
+/// slice of [Cursor]s, in the right places.
+///
+/// This is useful as way to interleave ancilliary cursors, for example trivia.
+pub struct CursorInterleaveSink<'a, S> {
+	sink: &'a mut S,
+	interleave: &'a [(bumpalo::collections::Vec<'a, Cursor>, Cursor)],
+	current_index: usize,
+}
+
+impl<'a, S: CursorSink> CursorInterleaveSink<'a, S> {
+	pub fn new(sink: &'a mut S, interleave: &'a [(bumpalo::collections::Vec<'a, Cursor>, Cursor)]) -> Self {
+		Self { sink, interleave, current_index: 0 }
+	}
+}
+
+impl<'a, S: CursorSink> CursorSink for CursorInterleaveSink<'a, S> {
+	fn append(&mut self, c: Cursor) {
+		// Check if this content cursor has associated trivia
+		while self.current_index < self.interleave.len() {
+			let (trivia, associated_cursor) = &self.interleave[self.current_index];
+			if *associated_cursor == c {
+				for cursor in trivia {
+					self.sink.append(*cursor);
+				}
+				self.current_index += 1;
+				break;
+			}
+			if associated_cursor.span().start() > c.span().start() {
+				break;
+			}
+			self.current_index += 1;
+		}
+		self.sink.append(c);
+	}
+}

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -275,6 +275,7 @@ pub use css_lexer::{
 
 mod comparison;
 mod cursor_compact_write_sink;
+mod cursor_interleave_sink;
 mod cursor_overlay_sink;
 mod cursor_pretty_write_sink;
 mod cursor_write_sink;
@@ -297,6 +298,7 @@ pub type Result<T> = std::result::Result<T, diagnostics::Diagnostic>;
 
 pub use comparison::*;
 pub use cursor_compact_write_sink::*;
+pub use cursor_interleave_sink::*;
 pub use cursor_overlay_sink::*;
 pub use cursor_pretty_write_sink::*;
 pub use cursor_write_sink::*;

--- a/crates/css_parse/src/macros/optionals.rs
+++ b/crates/css_parse/src/macros/optionals.rs
@@ -135,13 +135,7 @@ mod tests {
 		assert_parse!(EmptyAtomSet::ATOMS, CaseA, "123", Optionals2(Some(_), None));
 		assert_parse!(EmptyAtomSet::ATOMS, CaseA, "foo", Optionals2(None, Some(_)));
 
-		assert_parse!(
-			EmptyAtomSet::ATOMS,
-			CaseB,
-			"123 foo 'bar'",
-			"123 foo'bar'",
-			Optionals3(Some(_), Some(_), Some(_))
-		);
+		assert_parse!(EmptyAtomSet::ATOMS, CaseB, "123 foo 'bar'", Optionals3(Some(_), Some(_), Some(_)));
 		assert_parse!(
 			EmptyAtomSet::ATOMS,
 			CaseB,
@@ -156,7 +150,7 @@ mod tests {
 			EmptyAtomSet::ATOMS,
 			CaseC,
 			"foo 123 bar 'bar'",
-			"123 foo'bar'bar",
+			"123 foo 'bar'bar",
 			Optionals4(Some(_), Some(_), Some(_), Some(_))
 		);
 	}
@@ -203,7 +197,7 @@ mod tests {
 			EmptyAtomSet::ATOMS,
 			CaseD,
 			"foo 123 40px bar 'bar'",
-			"123 foo'bar'bar 40px",
+			"123 foo 'bar'bar 40px",
 			Optionals5(Some(_), Some(_), Some(_), Some(_), Some(_))
 		);
 	}

--- a/crates/css_parse/src/parser_return.rs
+++ b/crates/css_parse/src/parser_return.rs
@@ -1,4 +1,4 @@
-use crate::{Cursor, CursorSink, Diagnostic, ToCursors};
+use crate::{Cursor, CursorInterleaveSink, CursorSink, Diagnostic, ToCursors};
 use bumpalo::collections::Vec;
 
 #[derive(Debug)]
@@ -9,12 +9,17 @@ where
 	pub output: Option<T>,
 	pub source_text: &'a str,
 	pub errors: Vec<'a, Diagnostic>,
-	pub trivia: Vec<'a, Cursor>,
+	pub trivia: Vec<'a, (Vec<'a, Cursor>, Cursor)>,
 	with_trivia: bool,
 }
 
 impl<'a, T: ToCursors> ParserReturn<'a, T> {
-	pub fn new(output: Option<T>, source_text: &'a str, errors: Vec<'a, Diagnostic>, trivia: Vec<'a, Cursor>) -> Self {
+	pub fn new(
+		output: Option<T>,
+		source_text: &'a str,
+		errors: Vec<'a, Diagnostic>,
+		trivia: Vec<'a, (Vec<'a, Cursor>, Cursor)>,
+	) -> Self {
 		Self { output, source_text, errors, trivia, with_trivia: false }
 	}
 
@@ -27,8 +32,12 @@ impl<'a, T: ToCursors> ParserReturn<'a, T> {
 impl<T: ToCursors> ToCursors for ParserReturn<'_, T> {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		if let Some(output) = &self.output {
-			let sink = if self.with_trivia { todo!() } else { s };
-			ToCursors::to_cursors(output, sink);
+			if self.with_trivia {
+				let mut sink = CursorInterleaveSink::new(s, &self.trivia);
+				ToCursors::to_cursors(output, &mut sink);
+			} else {
+				ToCursors::to_cursors(output, s);
+			}
 		}
 	}
 }

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -117,4 +117,15 @@ mod tests {
 		assert_parse!(EmptyAtomSet::ATOMS, ComponentValues, "body{color:black}");
 		assert_parse!(EmptyAtomSet::ATOMS, ComponentValues, "body");
 	}
+
+	#[test]
+	fn test_writes_with_trivia() {
+		assert_parse!(EmptyAtomSet::ATOMS, ComponentValues, "/*comment*/foo");
+		assert_parse!(EmptyAtomSet::ATOMS, ComponentValues, " /*comment*/ foo");
+		assert_parse!(EmptyAtomSet::ATOMS, ComponentValues, "/*a*/foo/*b*/bar");
+		assert_parse!(EmptyAtomSet::ATOMS, ComponentValues, "foo/*comment*/bar");
+		assert_parse!(EmptyAtomSet::ATOMS, ComponentValues, " \t foo");
+		assert_parse!(EmptyAtomSet::ATOMS, ComponentValues, " /*start*/ foo /*mid*/ bar");
+		assert_parse!(EmptyAtomSet::ATOMS, ComponentValues, "/*comment*/foo");
+	}
 }


### PR DESCRIPTION
Trivia tokens have so far been swallowed up by the parser, never to be emitted back out as cursors. This change attempts
to address this by making sure the ParserReturn properly emits trivia cursors when `with_trivia()` is enabled.

This needed some architectural changes, as trivia was simply collected into a Vec without association, but this causes
issues for example a function like `foo(/*bar*/ bar, baz)` might be re-tokenised as `foo(/*bar*/ baz, bar)` which is
likely wrong. Instead we introduce an associated cursor with each vec of trivia, this way trivia such as comments are
attached to the trailing token, meaning in the above example the `/*bar*/` comment and whitespace token after that (` `)
are both attached to the `bar` token.

Sadly, this has the unfortunate side effect that the whitespace is also attached, which means if a node restructures the
cursors, we might end up with for e.g. `foo(bar, baz)` becoming `foo( baz, bar)` (note the additional whitespace after
`foo(`). This is because the whitespace in the token stream `, baz`. This can be resoled two ways: simply avoiding the
CursorWriteSink and always using it in combination with the Compact/Format write sink which handles whitespace more
sensibly, but also eventually perhaps writing a OrderedCursorSink which buffers cursors so it is able to emit them in
source order (which is likely necessary to handle IDE code actions without incidentally formatting code).
