### PR TITLE
CI: test in nightly, make more build modes required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,20 @@ jobs:
           key: global-rust-cache
       - run: cargo test
 
+  build_nightly:
+    name: Build & Test with nightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: "true"
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          key: global-rust-cache
+      - run: cargo +nightly test --all-features
+
   clippy:
     runs-on: ubuntu-latest
     steps:
@@ -134,7 +148,7 @@ jobs:
       pull-requests: write
     if: always()
     runs-on: ubuntu-latest
-    needs: [build, fmt, clippy, docs]
+    needs: [build, build_default, fmt, clippy, docs, acceptance]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -3,7 +3,6 @@ use css_parse::{
 	BadDeclaration, Cursor, Diagnostic, Parse, Parser, QualifiedRule, Result as ParserResult, RuleVariants,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
-use csskit_proc_macro::visit;
 
 /// Represents a "Style Rule", such as `body { width: 100% }`. See also the CSS-OM [CSSStyleRule][1] interface.
 ///


### PR DESCRIPTION
This should give us more insight into what we need to do to get our codebase passing in new stable releases, without
having to do larger migrations for each stable release.
