### PR TITLE
CI: fix release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,9 @@ jobs:
           key: release-${{ matrix.target }}
       - name: Rustup target
         run: rustup target add ${{ matrix.target }}
+      - name: Install arm64 toolchain
+        if: matrix.code-target == 'linux-arm64'
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Build Binary
         # strip debug symbols from std, see https://github.com/johnthagen/min-sized-rust#remove-panic-string-formatting-with-panic_immediate_abort
         run: cargo build --release --target ${{ matrix.target }} -p csskit


### PR DESCRIPTION
Somewhere along the way I seem to have accidentally deleted the instal step for gcc-aarch64-linux-gnu
