### PR TITLE
css_parse: enable the bumpalo feature for css_lexer

### DIFF
--- a/crates/css_parse/Cargo.toml
+++ b/crates/css_parse/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests/*", "bench/*"]
 bench = false
 
 [dependencies]
-css_lexer = { workspace = true, features = ["miette"] }
+css_lexer = { workspace = true, features = ["bumpalo"] }
 
 bumpalo = { workspace = true }
 smallvec = { workspace = true }


### PR DESCRIPTION
This fixes the release that got broken in https://github.com/csskit/csskit/pull/519
