### PR TITLE
CI: ensure website builds on main, move benchmark-compare to nightly.

### DIFF
--- a/.github/workflows/benchmark-tracking.yml
+++ b/.github/workflows/benchmark-tracking.yml
@@ -1,8 +1,8 @@
 name: Benchmark Tracking
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
+  schedule:
+    - cron: "0 2 * * *"
 jobs:
   benchmark:
     name: Collect and Track Benchmarks
@@ -22,14 +22,9 @@ jobs:
         uses: ./.github/actions/setup
       - name: Run benchmark collection
         run: mise run collect-benchmarks
-      - name: Commit and push to website
-        run: |
-          git config user.name "Keith Cirkel"
-          git config user.email "keithamus@users.noreply.github.com"
-          git add website/_data/benchmark-history.json
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "Update benchmark results"
-            git push --force origin HEAD:refs/heads/website
-          fi
+      - name: Upload benchmark history artifact
+        uses: actions/upload-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.6.2
+        with:
+          name: benchmark-history
+          path: website/_data/benchmark-history.json
+          retention-days: 90

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,10 @@
 name: Pages
 on:
   push:
-    branches: [website]
+    branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
 permissions:
   contents: read
   pages: write
@@ -21,6 +23,12 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: "true"
+      - name: Download benchmark history
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: benchmark-history
+          path: website/_data
+        continue-on-error: true
       - name: Setup
         uses: ./.github/actions/setup
         with:


### PR DESCRIPTION
Having benchmarks run on every commit to main is a little silly considering we commit a lot per day. But also the
current build means the website is a manual deploy job (because actions commits don't kick off other actions).

Instead this change moves the website back to building on main, and moves the benchmark job to a nightly one. The
website also builds nightly, just in case we haven't made any commits to main but we want fresh benchmark data.
