### PR TITLE
CI: try to use benchmark-tracking for PR benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,20 +10,102 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout PR
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: "true"
+      - name: Setup mise
+        uses: jdx/mise-action@v3
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Cache CI Benchmarks
-        id: cache-target
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 #v4.2.4
+      - name: Download benchmark history
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
         with:
-          key: ${{ runner.os }}-${{ github.ref }}
-          path: |
-            ./target/criterion
-      - name: Criterion Compare PRs
-        uses: boa-dev/criterion-compare-action@adfd3a94634fe2041ce5613eb7df09d247555b87 #v3.2.4
+          name: benchmark-history
+          workflow: benchmark-tracking.yml
+          workflow_conclusion: success
+          branch: main
+          search_artifacts: true
+          path: website/_data
+      - name: Run PR branch benchmarks
+        run: mise run collect-benchmarks
+      - name: Compare benchmark results
+        id: compare
+        run: |
+          HISTORY="website/_data/benchmark-history.json"
+
+          # Extract the latest entry from each
+          PR_ENTRY=$(jq '.[0]' "$HISTORY")
+          BASE_ENTRY=$(jq '.[1]' "$HISTORY")
+
+          # Generate comparison report
+          REPORT_FILE="benchmark-comparison.md"
+          echo "# Benchmark Comparison" > "$REPORT_FILE"
+          echo "" >> "$REPORT_FILE"
+          echo "**Base:** \`${{ github.base_ref }}\` @ $(echo "$BASE_ENTRY" | jq -r '.git_commit[:7]')" >> "$REPORT_FILE"
+          echo "**PR:** \`${{ github.head_ref }}\` @ $(echo "$PR_ENTRY" | jq -r '.git_commit[:7]')" >> "$REPORT_FILE"
+          echo "" >> "$REPORT_FILE"
+
+          # Compare criterion results
+          echo "## Criterion Benchmarks" >> "$REPORT_FILE"
+          echo "" >> "$REPORT_FILE"
+          echo "$BASE_ENTRY" "$PR_ENTRY" | jq -rs '
+            .[0] as $base | .[1] as $pr |
+            $base.criterion_results as $base_crit |
+            $pr.criterion_results as $pr_crit |
+            $pr_crit | keys | sort[] | . as $bench_name |
+            $base_crit[$bench_name] // null | . as $base_result |
+            $pr_crit[$bench_name] | . as $pr_result |
+            if $base_result != null then
+              ($pr_result.mean.point_estimate / $base_result.mean.point_estimate - 1) * 100 | . as $change |
+              ($change | if . > 5 then ":chart_with_upwards_trend:" elif . < -5 then ":chart_with_downwards_trend:" else ":left_right_arrow:" end) as $icon |
+              "- **\($bench_name)**: \($pr_result.mean.point_estimate / 1000000 * 1000 | round / 1000)ms (base: \($base_result.mean.point_estimate / 1000000 * 1000 | round / 1000)ms) \($icon) **\($change * 100 | round / 100)%**"
+            else
+              "- **\($bench_name)**: \($pr_result.mean.point_estimate / 1000000 * 1000 | round / 1000)ms :sparkles: (new benchmark)"
+            end
+          ' >> "$REPORT_FILE"
+
+          # Compare hyperfine results
+          echo "" >> "$REPORT_FILE"
+          echo "## Hyperfine Benchmarks" >> "$REPORT_FILE"
+          echo "" >> "$REPORT_FILE"
+          echo "$BASE_ENTRY" "$PR_ENTRY" | jq -rs '
+            .[0] as $base | .[1] as $pr |
+            $base.hyperfine_results as $base_hyper |
+            $pr.hyperfine_results as $pr_hyper |
+            $pr_hyper | keys | sort[] | . as $file_name |
+            $base_hyper[$file_name] // null | . as $base_result |
+            $pr_hyper[$file_name] | . as $pr_result |
+            if $base_result != null and ($base_result.results | length > 0) and ($pr_result.results | length > 0) then
+              ($pr_result.results[0].mean / $base_result.results[0].mean - 1) * 100 | . as $change |
+              ($change | if . > 5 then ":chart_with_upwards_trend:" elif . < -5 then ":chart_with_downwards_trend:" else ":left_right_arrow:" end) as $icon |
+              "- **\($file_name)**: \($pr_result.results[0].mean * 1000 | round / 1000)s (base: \($base_result.results[0].mean * 1000 | round / 1000)s) \($icon) **\($change * 100 | round / 100)%**"
+            elif ($pr_result.results | length > 0) then
+              "- **\($file_name)**: \($pr_result.results[0].mean * 1000 | round / 1000)s :sparkles: (new benchmark)"
+            else
+              empty
+            end
+          ' >> "$REPORT_FILE"
+
+          cat "$REPORT_FILE"
+      - name: Upload benchmark history artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          branchName: ${{ github.base_ref }}
+          name: benchmark-history
+          path: website/_data/benchmark-history.json
+      - name: Comment PR
+        if: success()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = 'benchmark-comparison.md';
+            if (fs.existsSync(reportPath)) {
+              const report = fs.readFileSync(reportPath, 'utf8');
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: report
+              });
+            }


### PR DESCRIPTION
Our PR benchmarking scripts use a criterion-compare action which is useful, but slow because it runs the whole suite twice - once for main, then again for the PR. Considering we benchmark nightly, we could use that data to build a table. In addition the nightly job runs more benchmarks, e.g. hyperfine. We can benefit from this in PR stats.

This change downloads the benchmark-history artifact and runs the full bench suite against it, then compares the latest result (the PR) with the 2nd entry (last nightly run) to determine the delta.