### PR TITLE
css_ast: Support custom scroll state queries

### DIFF
--- a/crates/css_ast/src/css_atom_set.rs
+++ b/crates/css_ast/src/css_atom_set.rs
@@ -1716,6 +1716,7 @@ pub enum CssAtomSet {
 	ScrollbarGutter,
 	ScrollbarWidth,
 	Scrolled,
+	ScrollState,
 	Sdev,
 	SeResize,
 	Seagreen,

--- a/crates/css_ast/src/css_atom_set.rs
+++ b/crates/css_ast/src/css_atom_set.rs
@@ -1716,7 +1716,6 @@ pub enum CssAtomSet {
 	ScrollbarGutter,
 	ScrollbarWidth,
 	Scrolled,
-	ScrollState,
 	Sdev,
 	SeResize,
 	Seagreen,

--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -66,14 +66,36 @@ discrete_feature!(
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum StyleQuery<'a> {
-	Is(Declaration<'a, StyleValue<'a>, CssMetadata>),
-	Not(T![Ident], Declaration<'a, StyleValue<'a>, CssMetadata>),
-	And(Vec<'a, (Declaration<'a, StyleValue<'a>, CssMetadata>, Option<T![Ident]>)>),
-	Or(Vec<'a, (Declaration<'a, StyleValue<'a>, CssMetadata>, Option<T![Ident]>)>),
+	Is(StyleFeature<'a>),
+	Not(T![Ident], StyleFeature<'a>),
+	And(Vec<'a, (StyleFeature<'a>, Option<T![Ident]>)>),
+	Or(Vec<'a, (StyleFeature<'a>, Option<T![Ident]>)>),
+}
+
+#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[derive(csskit_derives::NodeWithMetadata)]
+pub enum StyleFeature<'a> {
+	Declaration(Declaration<'a, StyleValue<'a>, CssMetadata>),
+	CustomProperty(T![Ident]),
+}
+
+impl<'a> Parse<'a> for StyleFeature<'a> {
+	fn parse<I>(p: &mut Parser<'a, I>) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		let c = p.peek_n(1);
+		if c == Kind::Ident && c.token().is_dashed_ident() && p.peek_n(2) != Kind::Colon {
+			return Ok(Self::CustomProperty(p.parse::<T![Ident]>()?));
+		}
+		Ok(Self::Declaration(p.parse::<Declaration<'a, StyleValue<'a>, CssMetadata>>()?))
+	}
 }
 
 impl<'a> FeatureConditionList<'a> for StyleQuery<'a> {
-	type FeatureCondition = Declaration<'a, StyleValue<'a>, CssMetadata>;
+	type FeatureCondition = StyleFeature<'a>;
 	fn keyword_is_not<I>(p: &Parser<'a, I>, c: Cursor) -> bool
 	where
 		I: Iterator<Item = Cursor> + Clone,
@@ -364,6 +386,11 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, HeightContainerFeature, "(height>=1400px)");
 		assert_parse!(CssAtomSet::ATOMS, HeightContainerFeature, "(100px<=height)");
 		assert_parse!(CssAtomSet::ATOMS, HeightContainerFeature, "(100px<=height>1400px)");
+		assert_parse!(CssAtomSet::ATOMS, StyleQuery, "--x");
+		assert_parse!(CssAtomSet::ATOMS, StyleQuery, "--x:10px");
+		assert_parse!(CssAtomSet::ATOMS, StyleQuery, "--x and --y:20px");
+		assert_parse!(CssAtomSet::ATOMS, ScrollStateQuery, "stuck:top");
+		assert_parse!(CssAtomSet::ATOMS, ScrollStateQuery, "scrollable:y and snapped:block");
 	}
 
 	#[test]

--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -72,6 +72,7 @@ pub enum StyleQuery<'a> {
 	Or(Vec<'a, (StyleFeature<'a>, Option<T![Ident]>)>),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -267,14 +267,22 @@ mod tests {
 		// Style queries
 		assert_parse!(CssAtomSet::ATOMS, ContainerFeature, "style(--x:10px)");
 		assert_parse!(CssAtomSet::ATOMS, ContainerFeature, "style(--x: 10px)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerFeature, "style(--x)");
 		assert_parse!(CssAtomSet::ATOMS, ContainerQuery, "style(--x:10px)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerQuery, "style(--x)");
 		assert_parse!(CssAtomSet::ATOMS, ContainerCondition, "style(--x:10px)");
 		assert_parse!(CssAtomSet::ATOMS, ContainerCondition, "style(--x: 10px)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerCondition, "style(--x)");
 		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container style(--x:10px){}");
 		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container style(--x: 10px){}");
+		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container style(--x){}");
 		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container style(--x:10px){body{color:green}}");
 		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container style(--x: 10px){body{color:green}}");
 		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container foo style(--x:10px){}");
+		// Scroll-state queries
+		assert_parse!(CssAtomSet::ATOMS, ContainerFeature, "scroll-state(stuck:top)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerFeature, "scroll-state(scrollable:y and snapped:block)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container sticky scroll-state(stuck: top){}");
 	}
 
 	#[test]

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -165,11 +165,10 @@ impl<'a> Peek<'a> for ContainerFeature<'a> {
 	where
 		I: Iterator<Item = Cursor> + Clone,
 	{
-		if c == Kind::Function && matches!(p.to_atom::<CssAtomSet>(c), CssAtomSet::Style | CssAtomSet::ScrollState) {
-			return true;
-		}
 		let c2 = p.peek_n(2);
-		c == Kind::LeftParen && c2 == KindSet::new(&[Kind::Ident, Kind::Dimension])
+		(c == Kind::LeftParen && c2 == KindSet::new(&[Kind::Ident, Kind::Dimension]))
+			|| (c == Kind::Function
+				&& matches!(p.to_atom::<CssAtomSet>(c), CssAtomSet::Style | CssAtomSet::ScrollState))
 	}
 }
 
@@ -265,6 +264,17 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container foo (width:2px){}");
 		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container foo (10em<width<10em){}");
 		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container foo (width:2px){body{color:black}}");
+		// Style queries
+		assert_parse!(CssAtomSet::ATOMS, ContainerFeature, "style(--x:10px)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerFeature, "style(--x: 10px)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerQuery, "style(--x:10px)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerCondition, "style(--x:10px)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerCondition, "style(--x: 10px)");
+		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container style(--x:10px){}");
+		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container style(--x: 10px){}");
+		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container style(--x:10px){body{color:green}}");
+		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container style(--x: 10px){body{color:green}}");
+		assert_parse!(CssAtomSet::ATOMS, ContainerRule, "@container foo style(--x:10px){}");
 	}
 
 	#[test]

--- a/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
+++ b/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
@@ -357,6 +357,7 @@ expression: "matches.iter().map(|node|\nnode.input.to_token_stream().to_string()
   "pub enum StrokeLinecapStyleValue { }",
   "pub enum StrokeOriginStyleValue { }",
   "pub enum StuckScrollStateFeatureKeyword { }",
+  "pub enum StyleFeature < \'a > { }",
   "pub enum StyleQuery < \'a > { }",
   "pub enum StyleValue < \'a > { }",
   "pub enum SupportsCondition < \'a > { }",


### PR DESCRIPTION
Replace the `todo!()` in `ContainerFeature::parse()` with actual parsing logic for `style()` and `scroll-state()` functional notation in `@container` rules. Previously, inputs like `@container style(--x: 10px) {}` would panic.

Changes:
- Add `ScrollState` atom to `CssAtomSet` for `scroll-state()` recognition
- Update `ContainerFeature` enum to store function token and close paren alongside `StyleQuery`/`ScrollStateQuery` for correct serialization
- Extend `ContainerFeature::peek()` and `ContainerCondition::peek()` to accept `Kind::Function` tokens

Related issue: #868