### PR TITLE
chromashift: Update to support wide-gamut color spaces, out of gamut colors

### DIFF
--- a/crates/chromashift/src/a98_rgb.rs
+++ b/crates/chromashift/src/a98_rgb.rs
@@ -17,12 +17,7 @@ pub struct A98Rgb {
 
 impl A98Rgb {
 	pub fn new(red: f64, green: f64, blue: f64, alpha: f32) -> Self {
-		Self {
-			red: red.clamp(0.0, 1.0),
-			green: green.clamp(0.0, 1.0),
-			blue: blue.clamp(0.0, 1.0),
-			alpha: alpha.clamp(0.0, 100.0),
-		}
+		Self { red, green, blue, alpha: alpha.clamp(0.0, 100.0) }
 	}
 }
 

--- a/crates/chromashift/src/conversion.rs
+++ b/crates/chromashift/src/conversion.rs
@@ -36,6 +36,94 @@ simple_from!(A98Rgb to Srgb, via LinearRgb);
 simple_from!(A98Rgb to XyzD50, via LinearRgb);
 simple_from!(A98Rgb to XyzD65, via LinearRgb);
 
+// DisplayP3 converts through XyzD65
+simple_from!(A98Rgb to DisplayP3, via XyzD65);
+simple_from!(Hex to DisplayP3, via XyzD65);
+simple_from!(Hsv to DisplayP3, via XyzD65);
+simple_from!(Hsl to DisplayP3, via XyzD65);
+simple_from!(Hwb to DisplayP3, via XyzD65);
+simple_from!(Lab to DisplayP3, via XyzD65);
+simple_from!(Lch to DisplayP3, via XyzD65);
+simple_from!(LinearRgb to DisplayP3, via XyzD65);
+simple_from!(Named to DisplayP3, via XyzD65);
+simple_from!(Oklab to DisplayP3, via XyzD65);
+simple_from!(Oklch to DisplayP3, via XyzD65);
+simple_from!(Srgb to DisplayP3, via XyzD65);
+simple_from!(XyzD50 to DisplayP3, via XyzD65);
+
+simple_from!(DisplayP3 to A98Rgb, via XyzD65);
+simple_from!(DisplayP3 to Hex, via XyzD65);
+simple_from!(DisplayP3 to Hsv, via XyzD65);
+simple_from!(DisplayP3 to Hsl, via XyzD65);
+simple_from!(DisplayP3 to Hwb, via XyzD65);
+simple_from!(DisplayP3 to Lab, via XyzD65);
+simple_from!(DisplayP3 to Lch, via XyzD65);
+simple_from!(DisplayP3 to LinearRgb, via XyzD65);
+simple_from!(DisplayP3 to Oklab, via XyzD65);
+simple_from!(DisplayP3 to Oklch, via XyzD65);
+simple_from!(DisplayP3 to Srgb, via XyzD65);
+simple_from!(DisplayP3 to XyzD50, via XyzD65);
+simple_from!(DisplayP3 to ProphotoRgb, via XyzD65);
+simple_from!(DisplayP3 to Rec2020, via XyzD65);
+
+// ProphotoRgb converts through XyzD50
+simple_from!(A98Rgb to ProphotoRgb, via XyzD50);
+simple_from!(Hex to ProphotoRgb, via XyzD50);
+simple_from!(Hsv to ProphotoRgb, via XyzD50);
+simple_from!(Hsl to ProphotoRgb, via XyzD50);
+simple_from!(Hwb to ProphotoRgb, via XyzD50);
+simple_from!(Lab to ProphotoRgb, via XyzD50);
+simple_from!(Lch to ProphotoRgb, via XyzD50);
+simple_from!(LinearRgb to ProphotoRgb, via XyzD50);
+simple_from!(Named to ProphotoRgb, via XyzD50);
+simple_from!(Oklab to ProphotoRgb, via XyzD50);
+simple_from!(Oklch to ProphotoRgb, via XyzD50);
+simple_from!(Srgb to ProphotoRgb, via XyzD50);
+simple_from!(XyzD65 to ProphotoRgb, via XyzD50);
+
+simple_from!(ProphotoRgb to A98Rgb, via XyzD50);
+simple_from!(ProphotoRgb to Hex, via XyzD50);
+simple_from!(ProphotoRgb to Hsv, via XyzD50);
+simple_from!(ProphotoRgb to Hsl, via XyzD50);
+simple_from!(ProphotoRgb to Hwb, via XyzD50);
+simple_from!(ProphotoRgb to Lab, via XyzD50);
+simple_from!(ProphotoRgb to Lch, via XyzD50);
+simple_from!(ProphotoRgb to LinearRgb, via XyzD50);
+simple_from!(ProphotoRgb to Oklab, via XyzD50);
+simple_from!(ProphotoRgb to Oklch, via XyzD50);
+simple_from!(ProphotoRgb to Srgb, via XyzD50);
+simple_from!(ProphotoRgb to XyzD65, via XyzD50);
+simple_from!(ProphotoRgb to Rec2020, via XyzD50);
+
+// Rec2020 converts through XyzD65
+simple_from!(A98Rgb to Rec2020, via XyzD65);
+simple_from!(Hex to Rec2020, via XyzD65);
+simple_from!(Hsv to Rec2020, via XyzD65);
+simple_from!(Hsl to Rec2020, via XyzD65);
+simple_from!(Hwb to Rec2020, via XyzD65);
+simple_from!(Lab to Rec2020, via XyzD65);
+simple_from!(Lch to Rec2020, via XyzD65);
+simple_from!(LinearRgb to Rec2020, via XyzD65);
+simple_from!(Named to Rec2020, via XyzD65);
+simple_from!(Oklab to Rec2020, via XyzD65);
+simple_from!(Oklch to Rec2020, via XyzD65);
+simple_from!(Srgb to Rec2020, via XyzD65);
+simple_from!(XyzD50 to Rec2020, via XyzD65);
+
+simple_from!(Rec2020 to A98Rgb, via XyzD65);
+simple_from!(Rec2020 to Hex, via XyzD65);
+simple_from!(Rec2020 to Hsv, via XyzD65);
+simple_from!(Rec2020 to Hsl, via XyzD65);
+simple_from!(Rec2020 to Hwb, via XyzD65);
+simple_from!(Rec2020 to Lab, via XyzD65);
+simple_from!(Rec2020 to Lch, via XyzD65);
+simple_from!(Rec2020 to LinearRgb, via XyzD65);
+simple_from!(Rec2020 to Oklab, via XyzD65);
+simple_from!(Rec2020 to Oklch, via XyzD65);
+simple_from!(Rec2020 to Srgb, via XyzD65);
+simple_from!(Rec2020 to XyzD50, via XyzD65);
+simple_from!(Rec2020 to ProphotoRgb, via XyzD65);
+
 simple_from!(Hsv to Hex, via Srgb);
 simple_from!(Hsl to Hex, via Srgb);
 simple_from!(Hwb to Hex, via Srgb);
@@ -76,37 +164,37 @@ simple_from!(Hsv to Oklch, via Srgb);
 simple_from!(Hsv to XyzD50, via Srgb);
 simple_from!(Hsv to XyzD65, via Srgb);
 
-simple_from!(Hwb to Hsl, via Hsv);
-simple_from!(Lab to Hsl, via Srgb);
-simple_from!(Lch to Hsl, via Srgb);
+simple_from!(Hwb to Hsl, via LinearRgb);
+simple_from!(Lab to Hsl, via LinearRgb);
+simple_from!(Lch to Hsl, via LinearRgb);
 simple_from!(Named to Hsl, via Srgb);
-simple_from!(Oklab to Hsl, via Srgb);
-simple_from!(Oklch to Hsl, via Srgb);
-simple_from!(XyzD50 to Hsl, via Srgb);
-simple_from!(XyzD65 to Hsl, via Srgb);
+simple_from!(Oklab to Hsl, via LinearRgb);
+simple_from!(Oklch to Hsl, via LinearRgb);
+simple_from!(XyzD50 to Hsl, via LinearRgb);
+simple_from!(XyzD65 to Hsl, via LinearRgb);
 
-simple_from!(Hsl to Hwb, via Srgb);
-simple_from!(Hsl to Lab, via Srgb);
-simple_from!(Hsl to Lch, via Srgb);
-simple_from!(Hsl to Oklab, via Srgb);
-simple_from!(Hsl to Oklch, via Srgb);
-simple_from!(Hsl to XyzD50, via Srgb);
-simple_from!(Hsl to XyzD65, via Srgb);
+simple_from!(Hsl to Hwb, via LinearRgb);
+simple_from!(Hsl to Lab, via LinearRgb);
+simple_from!(Hsl to Lch, via LinearRgb);
+simple_from!(Hsl to Oklab, via LinearRgb);
+simple_from!(Hsl to Oklch, via LinearRgb);
+simple_from!(Hsl to XyzD50, via LinearRgb);
+simple_from!(Hsl to XyzD65, via LinearRgb);
 
-simple_from!(Lab to Hwb, via Srgb);
-simple_from!(Lch to Hwb, via Srgb);
+simple_from!(Lab to Hwb, via LinearRgb);
+simple_from!(Lch to Hwb, via LinearRgb);
 simple_from!(Named to Hwb, via Srgb);
-simple_from!(Oklab to Hwb, via Srgb);
-simple_from!(Oklch to Hwb, via Srgb);
-simple_from!(XyzD50 to Hwb, via Srgb);
-simple_from!(XyzD65 to Hwb, via Srgb);
+simple_from!(Oklab to Hwb, via LinearRgb);
+simple_from!(Oklch to Hwb, via LinearRgb);
+simple_from!(XyzD50 to Hwb, via LinearRgb);
+simple_from!(XyzD65 to Hwb, via LinearRgb);
 
-simple_from!(Hwb to Lab, via Srgb);
-simple_from!(Hwb to Lch, via Srgb);
-simple_from!(Hwb to Oklab, via Srgb);
-simple_from!(Hwb to Oklch, via Srgb);
-simple_from!(Hwb to XyzD50, via Srgb);
-simple_from!(Hwb to XyzD65, via Srgb);
+simple_from!(Hwb to Lab, via LinearRgb);
+simple_from!(Hwb to Lch, via LinearRgb);
+simple_from!(Hwb to Oklab, via LinearRgb);
+simple_from!(Hwb to Oklch, via LinearRgb);
+simple_from!(Hwb to XyzD50, via LinearRgb);
+simple_from!(Hwb to XyzD65, via LinearRgb);
 
 simple_from!(Named to Lab, via Srgb);
 simple_from!(Oklab to Lab, via Srgb);
@@ -129,8 +217,6 @@ simple_from!(Lch to XyzD50, via Srgb);
 simple_from!(Lch to XyzD65, via Srgb);
 
 simple_from!(Hsv to LinearRgb, via Srgb);
-simple_from!(Hsl to LinearRgb, via Srgb);
-simple_from!(Hwb to LinearRgb, via Srgb);
 simple_from!(Lab to LinearRgb, via XyzD50);
 simple_from!(Lch to LinearRgb, via Lab);
 simple_from!(Named to LinearRgb, via Srgb);
@@ -139,8 +225,6 @@ simple_from!(Oklch to LinearRgb, via Oklab);
 simple_from!(XyzD50 to LinearRgb, via XyzD65);
 
 simple_from!(LinearRgb to Hsv, via Srgb);
-simple_from!(LinearRgb to Hsl, via Srgb);
-simple_from!(LinearRgb to Hwb, via Srgb);
 simple_from!(LinearRgb to Lab, via XyzD50);
 simple_from!(LinearRgb to Lch, via Lab);
 simple_from!(LinearRgb to Oklab, via XyzD65);
@@ -179,6 +263,7 @@ simple_from!(Hwb to Srgb, via Hsv);
 simple_from!(Srgb to Hwb, via Hsv);
 
 simple_from!(Color to A98Rgb, via XyzD65);
+simple_from!(Color to DisplayP3, via XyzD65);
 simple_from!(Color to Hsv, via XyzD65);
 simple_from!(Color to Hex, via XyzD65);
 simple_from!(Color to Hsl, via XyzD65);
@@ -188,6 +273,8 @@ simple_from!(Color to Lch, via XyzD65);
 simple_from!(Color to LinearRgb, via XyzD65);
 simple_from!(Color to Oklab, via XyzD65);
 simple_from!(Color to Oklch, via XyzD65);
+simple_from!(Color to ProphotoRgb, via XyzD65);
+simple_from!(Color to Rec2020, via XyzD65);
 simple_from!(Color to Srgb, via XyzD65);
 simple_from!(Color to XyzD50, via XyzD65);
 
@@ -207,6 +294,7 @@ macro_rules! impl_named_try_from_via_srgb {
 
 impl_named_try_from_via_srgb!(
 	crate::A98Rgb,
+	crate::DisplayP3,
 	crate::Hex,
 	crate::Hsv,
 	crate::Hsl,
@@ -216,6 +304,8 @@ impl_named_try_from_via_srgb!(
 	crate::LinearRgb,
 	crate::Oklab,
 	crate::Oklch,
+	crate::ProphotoRgb,
+	crate::Rec2020,
 	crate::XyzD50,
 	crate::XyzD65,
 	crate::Color,
@@ -225,6 +315,8 @@ impl_named_try_from_via_srgb!(
 simple_from!(Color to anstyle::RgbColor, via Srgb);
 #[cfg(feature = "anstyle")]
 simple_from!(A98Rgb to anstyle::RgbColor, via Srgb);
+#[cfg(feature = "anstyle")]
+simple_from!(DisplayP3 to anstyle::RgbColor, via Srgb);
 #[cfg(feature = "anstyle")]
 simple_from!(Hsv to anstyle::RgbColor, via Srgb);
 #[cfg(feature = "anstyle")]
@@ -246,6 +338,10 @@ simple_from!(Oklab to anstyle::RgbColor, via Srgb);
 #[cfg(feature = "anstyle")]
 simple_from!(Oklch to anstyle::RgbColor, via Srgb);
 #[cfg(feature = "anstyle")]
+simple_from!(ProphotoRgb to anstyle::RgbColor, via Srgb);
+#[cfg(feature = "anstyle")]
+simple_from!(Rec2020 to anstyle::RgbColor, via Srgb);
+#[cfg(feature = "anstyle")]
 simple_from!(XyzD50 to anstyle::RgbColor, via Srgb);
 #[cfg(feature = "anstyle")]
 simple_from!(XyzD65 to anstyle::RgbColor, via Srgb);
@@ -254,6 +350,8 @@ simple_from!(XyzD65 to anstyle::RgbColor, via Srgb);
 simple_from!(Color to anstyle::Color, via anstyle::RgbColor);
 #[cfg(feature = "anstyle")]
 simple_from!(A98Rgb to anstyle::Color, via anstyle::RgbColor);
+#[cfg(feature = "anstyle")]
+simple_from!(DisplayP3 to anstyle::Color, via anstyle::RgbColor);
 #[cfg(feature = "anstyle")]
 simple_from!(Hsv to anstyle::Color, via anstyle::RgbColor);
 #[cfg(feature = "anstyle")]
@@ -275,6 +373,10 @@ simple_from!(Oklab to anstyle::Color, via anstyle::RgbColor);
 #[cfg(feature = "anstyle")]
 simple_from!(Oklch to anstyle::Color, via anstyle::RgbColor);
 #[cfg(feature = "anstyle")]
+simple_from!(ProphotoRgb to anstyle::Color, via anstyle::RgbColor);
+#[cfg(feature = "anstyle")]
+simple_from!(Rec2020 to anstyle::Color, via anstyle::RgbColor);
+#[cfg(feature = "anstyle")]
 simple_from!(Srgb to anstyle::Color, via anstyle::RgbColor);
 #[cfg(feature = "anstyle")]
 simple_from!(XyzD50 to anstyle::Color, via anstyle::RgbColor);
@@ -285,6 +387,8 @@ simple_from!(XyzD65 to anstyle::Color, via anstyle::RgbColor);
 simple_from!(Color to owo_colors::Rgb, via Srgb);
 #[cfg(feature = "owo-colors")]
 simple_from!(A98Rgb to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(DisplayP3 to owo_colors::Rgb, via Srgb);
 #[cfg(feature = "owo-colors")]
 simple_from!(Hsv to owo_colors::Rgb, via Srgb);
 #[cfg(feature = "owo-colors")]
@@ -305,6 +409,10 @@ simple_from!(Named to owo_colors::Rgb, via Srgb);
 simple_from!(Oklab to owo_colors::Rgb, via Srgb);
 #[cfg(feature = "owo-colors")]
 simple_from!(Oklch to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(ProphotoRgb to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Rec2020 to owo_colors::Rgb, via Srgb);
 #[cfg(feature = "owo-colors")]
 simple_from!(XyzD50 to owo_colors::Rgb, via Srgb);
 #[cfg(feature = "owo-colors")]

--- a/crates/chromashift/src/display_p3.rs
+++ b/crates/chromashift/src/display_p3.rs
@@ -1,0 +1,81 @@
+use crate::{ToAlpha, XyzD65, round_dp};
+use core::fmt;
+
+/// A colour in the Display P3 colour space.
+/// The components are:
+/// - Red - a number between 0.0 and 1.0
+/// - Green - a number between 0.0 and 1.0
+/// - Blue - a number between 0.0 and 1.0
+/// - Alpha - a number between 0.0 and 100.0
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DisplayP3 {
+	pub red: f64,
+	pub green: f64,
+	pub blue: f64,
+	pub alpha: f32,
+}
+
+impl DisplayP3 {
+	pub fn new(red: f64, green: f64, blue: f64, alpha: f32) -> Self {
+		Self { red, green, blue, alpha: alpha.clamp(0.0, 100.0) }
+	}
+}
+
+impl ToAlpha for DisplayP3 {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
+	}
+}
+
+impl fmt::Display for DisplayP3 {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let Self { red, green, blue, alpha } = self;
+		write!(f, "color(display-p3 {} {} {}", round_dp(*red, 2), round_dp(*green, 2), round_dp(*blue, 2))?;
+		if *alpha < 100.0 {
+			write!(f, " / {}", round_dp(*alpha as f64, 2))?;
+		}
+		write!(f, ")")
+	}
+}
+
+/// sRGB transfer function: linear to gamma-encoded
+fn gamma(u: f64) -> f64 {
+	let abs = u.abs();
+	if abs <= 0.0031308 { u * 12.92 } else { u.signum() * (1.055 * abs.powf(1.0 / 2.4) - 0.055) }
+}
+
+/// sRGB transfer function: gamma-encoded to linear
+fn linear(c: f64) -> f64 {
+	let abs = c.abs();
+	if abs > 0.04045 { c.signum() * ((abs + 0.055) / 1.055).powf(2.4) } else { c / 12.92 }
+}
+
+impl From<XyzD65> for DisplayP3 {
+	fn from(value: XyzD65) -> Self {
+		let XyzD65 { x, y, z, alpha } = value;
+		let x = x / 100.0;
+		let y = y / 100.0;
+		let z = z / 100.0;
+		// XYZ D65 -> Linear Display P3
+		let lr = x * 2.4934969119414263 + y * (-0.9313836179191239) + z * (-0.40271078445071684);
+		let lg = x * (-0.8294889695615747) + y * 1.7626640603183463 + z * 0.023624685841943577;
+		let lb = x * 0.03584583024378447 + y * (-0.07617238926804182) + z * 0.9568845240076872;
+		// Apply sRGB gamma
+		DisplayP3::new(gamma(lr), gamma(lg), gamma(lb), alpha)
+	}
+}
+
+impl From<DisplayP3> for XyzD65 {
+	fn from(value: DisplayP3) -> Self {
+		let DisplayP3 { red, green, blue, alpha } = value;
+		// Linearize with sRGB gamma
+		let lr = linear(red);
+		let lg = linear(green);
+		let lb = linear(blue);
+		// Linear Display P3 -> XYZ D65
+		let x = lr * 0.4865709486482162 + lg * 0.26566769316909306 + lb * 0.1982172852343625;
+		let y = lr * 0.22897456406974884 + lg * 0.6917385218365064 + lb * 0.079286914093745;
+		let z = lr * 0.0 + lg * 0.04511338185890264 + lb * 1.043944368900976;
+		XyzD65::new(x * 100.0, y * 100.0, z * 100.0, alpha)
+	}
+}

--- a/crates/chromashift/src/gamut.rs
+++ b/crates/chromashift/src/gamut.rs
@@ -1,0 +1,212 @@
+use crate::*;
+
+/// Whether a colour is within the natural bounds of its colour space, and the ability to produce a naively clamped version.
+///
+/// CSS Color 4 12.1 and 13.1 state that out-of-gamut values must be preserved through intermediate computations.
+/// Gamut mapping (reducing to displayable range) only happens at "actual-value" / display time. This trait lets
+/// callers query and clamp when appropriate.
+///
+/// Note: `clamp_to_gamut()` performs naive channel clamping. This is *not* the perceptual gamut-mapping algorithm from
+/// CSS Color 4 13.2 (which reduces Oklch chroma iteratively).
+pub trait Gamut: Sized {
+	/// Returns `true` if all colour channels are within the natural bounds of this colour space.
+	/// Alpha is not considered — it is always clamped on construction.
+	fn in_gamut(&self) -> bool;
+
+	/// Returns a copy with all colour channels clamped to the natural bounds of this colour space.
+	fn clamp_to_gamut(&self) -> Self;
+}
+
+/// Helper: checks an f64 is in [0.0, 1.0]
+fn in_unit(v: f64) -> bool {
+	(0.0..=1.0).contains(&v)
+}
+
+/// Helper: checks an f32 is in [0.0, 100.0]
+fn in_percent(v: f32) -> bool {
+	(0.0..=100.0).contains(&v)
+}
+
+macro_rules! impl_gamut_rgb_f64 {
+	($ty:ident) => {
+		impl Gamut for $ty {
+			fn in_gamut(&self) -> bool {
+				in_unit(self.red) && in_unit(self.green) && in_unit(self.blue)
+			}
+
+			fn clamp_to_gamut(&self) -> Self {
+				Self::new(self.red.clamp(0.0, 1.0), self.green.clamp(0.0, 1.0), self.blue.clamp(0.0, 1.0), self.alpha)
+			}
+		}
+	};
+}
+
+impl_gamut_rgb_f64!(LinearRgb);
+impl_gamut_rgb_f64!(A98Rgb);
+impl_gamut_rgb_f64!(DisplayP3);
+impl_gamut_rgb_f64!(ProphotoRgb);
+impl_gamut_rgb_f64!(Rec2020);
+
+impl Gamut for Srgb {
+	fn in_gamut(&self) -> bool {
+		true
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		*self
+	}
+}
+
+impl Gamut for Hex {
+	fn in_gamut(&self) -> bool {
+		true
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		*self
+	}
+}
+
+impl Gamut for Lab {
+	fn in_gamut(&self) -> bool {
+		(0.0..=100.0).contains(&self.lightness)
+			&& (-125.0..=125.0).contains(&self.a)
+			&& (-125.0..=125.0).contains(&self.b)
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		Self::new(
+			self.lightness.clamp(0.0, 100.0),
+			self.a.clamp(-125.0, 125.0),
+			self.b.clamp(-125.0, 125.0),
+			self.alpha,
+		)
+	}
+}
+
+impl Gamut for Oklab {
+	fn in_gamut(&self) -> bool {
+		(0.0..=1.0).contains(&self.lightness) && (-0.4..=0.4).contains(&self.a) && (-0.4..=0.4).contains(&self.b)
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		Self::new(self.lightness.clamp(0.0, 1.0), self.a.clamp(-0.4, 0.4), self.b.clamp(-0.4, 0.4), self.alpha)
+	}
+}
+
+impl Gamut for Lch {
+	fn in_gamut(&self) -> bool {
+		(0.0..=100.0).contains(&self.lightness) && (0.0..=150.0).contains(&self.chroma)
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		Self::new(self.lightness.clamp(0.0, 100.0), self.chroma.clamp(0.0, 150.0), self.hue, self.alpha)
+	}
+}
+
+impl Gamut for Oklch {
+	fn in_gamut(&self) -> bool {
+		(0.0..=1.0).contains(&self.lightness) && (0.0..=0.4).contains(&self.chroma)
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		Self::new(self.lightness.clamp(0.0, 1.0), self.chroma.clamp(0.0, 0.4), self.hue, self.alpha)
+	}
+}
+
+impl Gamut for Hsl {
+	fn in_gamut(&self) -> bool {
+		in_percent(self.saturation) && in_percent(self.lightness)
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		Self::new(self.hue, self.saturation.clamp(0.0, 100.0), self.lightness.clamp(0.0, 100.0), self.alpha)
+	}
+}
+
+impl Gamut for Hwb {
+	fn in_gamut(&self) -> bool {
+		in_percent(self.whiteness) && in_percent(self.blackness)
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		Self::new(self.hue, self.whiteness.clamp(0.0, 100.0), self.blackness.clamp(0.0, 100.0), self.alpha)
+	}
+}
+
+// Hsv already clamps in its constructor, so it's always in gamut.
+impl Gamut for Hsv {
+	fn in_gamut(&self) -> bool {
+		true
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		*self
+	}
+}
+
+impl Gamut for XyzD50 {
+	fn in_gamut(&self) -> bool {
+		self.x >= 0.0 && self.y >= 0.0 && self.z >= 0.0 && self.y <= 100.0
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		Self::new(self.x.max(0.0), self.y.clamp(0.0, 100.0), self.z.max(0.0), self.alpha)
+	}
+}
+
+impl Gamut for XyzD65 {
+	fn in_gamut(&self) -> bool {
+		self.x >= 0.0 && self.y >= 0.0 && self.z >= 0.0 && self.y <= 100.0
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		Self::new(self.x.max(0.0), self.y.clamp(0.0, 100.0), self.z.max(0.0), self.alpha)
+	}
+}
+
+impl Gamut for Color {
+	fn in_gamut(&self) -> bool {
+		match self {
+			Color::A98Rgb(c) => c.in_gamut(),
+			Color::DisplayP3(c) => c.in_gamut(),
+			Color::Hex(c) => c.in_gamut(),
+			Color::Hsv(c) => c.in_gamut(),
+			Color::Hsl(c) => c.in_gamut(),
+			Color::Hwb(c) => c.in_gamut(),
+			Color::Lab(c) => c.in_gamut(),
+			Color::Lch(c) => c.in_gamut(),
+			Color::LinearRgb(c) => c.in_gamut(),
+			Color::Named(_) => true,
+			Color::Oklab(c) => c.in_gamut(),
+			Color::Oklch(c) => c.in_gamut(),
+			Color::ProphotoRgb(c) => c.in_gamut(),
+			Color::Rec2020(c) => c.in_gamut(),
+			Color::Srgb(c) => c.in_gamut(),
+			Color::XyzD50(c) => c.in_gamut(),
+			Color::XyzD65(c) => c.in_gamut(),
+		}
+	}
+
+	fn clamp_to_gamut(&self) -> Self {
+		match self {
+			Color::A98Rgb(c) => Color::A98Rgb(c.clamp_to_gamut()),
+			Color::DisplayP3(c) => Color::DisplayP3(c.clamp_to_gamut()),
+			Color::Hex(c) => Color::Hex(c.clamp_to_gamut()),
+			Color::Hsv(c) => Color::Hsv(c.clamp_to_gamut()),
+			Color::Hsl(c) => Color::Hsl(c.clamp_to_gamut()),
+			Color::Hwb(c) => Color::Hwb(c.clamp_to_gamut()),
+			Color::Lab(c) => Color::Lab(c.clamp_to_gamut()),
+			Color::Lch(c) => Color::Lch(c.clamp_to_gamut()),
+			Color::LinearRgb(c) => Color::LinearRgb(c.clamp_to_gamut()),
+			Color::Named(n) => Color::Named(*n),
+			Color::Oklab(c) => Color::Oklab(c.clamp_to_gamut()),
+			Color::Oklch(c) => Color::Oklch(c.clamp_to_gamut()),
+			Color::ProphotoRgb(c) => Color::ProphotoRgb(c.clamp_to_gamut()),
+			Color::Rec2020(c) => Color::Rec2020(c.clamp_to_gamut()),
+			Color::Srgb(c) => Color::Srgb(c.clamp_to_gamut()),
+			Color::XyzD50(c) => Color::XyzD50(c.clamp_to_gamut()),
+			Color::XyzD65(c) => Color::XyzD65(c.clamp_to_gamut()),
+		}
+	}
+}

--- a/crates/chromashift/src/hsl.rs
+++ b/crates/chromashift/src/hsl.rs
@@ -1,4 +1,4 @@
-use crate::{Srgb, ToAlpha, round_dp};
+use crate::{LinearRgb, Srgb, ToAlpha, round_dp};
 use core::fmt;
 
 /// An colour represented as Hue, Saturation, and Lightness expressed in the sRGB colour space.
@@ -17,12 +17,7 @@ pub struct Hsl {
 
 impl Hsl {
 	pub fn new(hue: f32, saturation: f32, lightness: f32, alpha: f32) -> Self {
-		Self {
-			hue: hue.rem_euclid(360.0),
-			saturation: saturation.clamp(0.0, 100.0),
-			lightness: lightness.clamp(0.0, 100.0),
-			alpha: alpha.clamp(0.0, 100.0),
-		}
+		Self { hue: hue.rem_euclid(360.0), saturation, lightness, alpha: alpha.clamp(0.0, 100.0) }
 	}
 }
 
@@ -49,56 +44,98 @@ impl fmt::Display for Hsl {
 	}
 }
 
+/// sRGB gamma-encode: linear to gamma (handles negative/OOG values via signum)
+fn gamma(u: f64) -> f64 {
+	let abs = u.abs();
+	if abs <= 0.0031308 { u * 12.92 } else { u.signum() * (1.055 * abs.powf(1.0 / 2.4) - 0.055) }
+}
+
+/// sRGB linearize: gamma to linear (handles negative/OOG values via signum)
+fn linear(c: f64) -> f64 {
+	let abs = c.abs();
+	if abs > 0.04045 { c.signum() * ((abs + 0.055) / 1.055).powf(2.4) } else { c / 12.92 }
+}
+
+/// Convert float sRGB (r,g,b in 0..1 range, but may be OOG) to HSL.
+/// This is the core algorithm that preserves out-of-gamut values.
+fn srgb_float_to_hsl(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
+	let max = r.max(g).max(b);
+	let min = r.min(g).min(b);
+	let delta = max - min;
+	let lightness = (max + min) / 2.0;
+	let saturation = if delta == 0.0 { 0.0 } else { delta / (1.0 - (2.0 * lightness - 1.0).abs()) };
+	let hue = if delta == 0.0 {
+		0.0
+	} else if max == r {
+		60.0 * (((g - b) / delta) % 6.0)
+	} else if max == g {
+		60.0 * ((b - r) / delta + 2.0)
+	} else {
+		60.0 * ((r - g) / delta + 4.0)
+	};
+	let hue = if hue < 0.0 { hue + 360.0 } else { hue };
+	(hue, saturation * 100.0, lightness * 100.0)
+}
+
+/// Convert HSL to float sRGB (r,g,b in 0..1 range, but may be OOG).
+fn hsl_to_srgb_float(hue: f64, saturation: f64, lightness: f64) -> (f64, f64, f64) {
+	let h = hue / 60.0;
+	let s = saturation / 100.0;
+	let l = lightness / 100.0;
+	let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+	let x = c * (1.0 - (h % 2.0 - 1.0).abs());
+	let m = l - c / 2.0;
+	let (r_prime, g_prime, b_prime) = if h < 1.0 {
+		(c, x, 0.0)
+	} else if h < 2.0 {
+		(x, c, 0.0)
+	} else if h < 3.0 {
+		(0.0, c, x)
+	} else if h < 4.0 {
+		(0.0, x, c)
+	} else if h < 5.0 {
+		(x, 0.0, c)
+	} else {
+		(c, 0.0, x)
+	};
+	(r_prime + m, g_prime + m, b_prime + m)
+}
+
 impl From<Srgb> for Hsl {
 	fn from(value: Srgb) -> Self {
-		let r = value.red as f32 / 255.0;
-		let g = value.green as f32 / 255.0;
-		let b = value.blue as f32 / 255.0;
-		let max = r.max(g).max(b);
-		let min = r.min(g).min(b);
-		let delta = max - min;
-		let lightness = (max + min) / 2.0;
-		let saturation = if delta == 0.0 { 0.0 } else { delta / (1.0 - (2.0 * lightness - 1.0).abs()) };
-		let hue = if delta == 0.0 {
-			0.0
-		} else if max == r {
-			60.0 * (((g - b) / delta) % 6.0)
-		} else if max == g {
-			60.0 * ((b - r) / delta + 2.0)
-		} else {
-			60.0 * ((r - g) / delta + 4.0)
-		};
-		let hue = if hue < 0.0 { hue + 360.0 } else { hue };
-		Hsl::new(hue, saturation * 100.0, lightness * 100.0, value.alpha)
+		let r = value.red as f64 / 255.0;
+		let g = value.green as f64 / 255.0;
+		let b = value.blue as f64 / 255.0;
+		let (hue, saturation, lightness) = srgb_float_to_hsl(r, g, b);
+		Hsl::new(hue as f32, saturation as f32, lightness as f32, value.alpha)
 	}
 }
 
 impl From<Hsl> for Srgb {
 	fn from(value: Hsl) -> Self {
-		let h = value.hue / 60.0;
-		let s = value.saturation / 100.0;
-		let l = value.lightness / 100.0;
-		let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
-		let x = c * (1.0 - (h % 2.0 - 1.0).abs());
-		let m = l - c / 2.0;
-		let (r_prime, g_prime, b_prime) = if h < 1.0 {
-			(c, x, 0.0)
-		} else if h < 2.0 {
-			(x, c, 0.0)
-		} else if h < 3.0 {
-			(0.0, c, x)
-		} else if h < 4.0 {
-			(0.0, x, c)
-		} else if h < 5.0 {
-			(x, 0.0, c)
-		} else {
-			(c, 0.0, x)
-		};
+		let (r, g, b) = hsl_to_srgb_float(value.hue as f64, value.saturation as f64, value.lightness as f64);
 		Srgb::new(
-			((r_prime + m) * 255.0).clamp(0.0, 255.0).round() as u8,
-			((g_prime + m) * 255.0).clamp(0.0, 255.0).round() as u8,
-			((b_prime + m) * 255.0).clamp(0.0, 255.0).round() as u8,
+			(r * 255.0).clamp(0.0, 255.0).round() as u8,
+			(g * 255.0).clamp(0.0, 255.0).round() as u8,
+			(b * 255.0).clamp(0.0, 255.0).round() as u8,
 			value.alpha,
 		)
+	}
+}
+
+impl From<LinearRgb> for Hsl {
+	fn from(value: LinearRgb) -> Self {
+		let r = gamma(value.red);
+		let g = gamma(value.green);
+		let b = gamma(value.blue);
+		let (hue, saturation, lightness) = srgb_float_to_hsl(r, g, b);
+		Hsl::new(hue as f32, saturation as f32, lightness as f32, value.alpha)
+	}
+}
+
+impl From<Hsl> for LinearRgb {
+	fn from(value: Hsl) -> Self {
+		let (r, g, b) = hsl_to_srgb_float(value.hue as f64, value.saturation as f64, value.lightness as f64);
+		LinearRgb::new(linear(r), linear(g), linear(b), value.alpha)
 	}
 }

--- a/crates/chromashift/src/hwb.rs
+++ b/crates/chromashift/src/hwb.rs
@@ -1,4 +1,4 @@
-use crate::{Hsv, ToAlpha, round_dp};
+use crate::{Hsv, LinearRgb, ToAlpha, round_dp};
 use core::fmt;
 
 /// An colour represented as Hue, Whiteness, and Blackness expressed in the sRGB colour space.
@@ -17,12 +17,7 @@ pub struct Hwb {
 
 impl Hwb {
 	pub fn new(hue: f32, whiteness: f32, blackness: f32, alpha: f32) -> Self {
-		Self {
-			hue: hue.rem_euclid(360.0),
-			whiteness: whiteness.clamp(0.0, 100.0),
-			blackness: blackness.clamp(0.0, 100.0),
-			alpha: alpha.clamp(0.0, 100.0),
-		}
+		Self { hue: hue.rem_euclid(360.0), whiteness, blackness, alpha: alpha.clamp(0.0, 100.0) }
 	}
 }
 
@@ -74,5 +69,90 @@ impl From<Hwb> for Hsv {
 			(s, v)
 		};
 		Hsv::new(hue, s * 100.0, v * 100.0, alpha)
+	}
+}
+
+/// sRGB gamma-encode: linear to gamma (handles negative/OOG values via signum)
+fn gamma(u: f64) -> f64 {
+	let abs = u.abs();
+	if abs <= 0.0031308 { u * 12.92 } else { u.signum() * (1.055 * abs.powf(1.0 / 2.4) - 0.055) }
+}
+
+/// sRGB linearize: gamma to linear (handles negative/OOG values via signum)
+fn linear(c: f64) -> f64 {
+	let abs = c.abs();
+	if abs > 0.04045 { c.signum() * ((abs + 0.055) / 1.055).powf(2.4) } else { c / 12.92 }
+}
+
+/// Convert float sRGB (r,g,b may be OOG) to HWB via HSV math.
+fn srgb_float_to_hwb(r: f64, g: f64, b: f64) -> (f64, f64, f64) {
+	let max = r.max(g).max(b);
+	let min = r.min(g).min(b);
+	let delta = max - min;
+	let v = max;
+	let saturation = if max == 0.0 { 0.0 } else { delta / max };
+	let hue = if delta == 0.0 {
+		0.0
+	} else if max == r {
+		60.0 * (((g - b) / delta) % 6.0)
+	} else if max == g {
+		60.0 * ((b - r) / delta + 2.0)
+	} else {
+		60.0 * ((r - g) / delta + 4.0)
+	};
+	let hue = if hue < 0.0 { hue + 360.0 } else { hue };
+	// HSV to HWB: w = (1-s)*v, b = 1-v
+	let whiteness = (1.0 - saturation) * v;
+	let blackness = 1.0 - v;
+	(hue, whiteness * 100.0, blackness * 100.0)
+}
+
+/// Convert HWB to float sRGB (r,g,b may be OOG).
+fn hwb_to_srgb_float(hue: f64, whiteness: f64, blackness: f64) -> (f64, f64, f64) {
+	let w = whiteness / 100.0;
+	let b = blackness / 100.0;
+	let sum = w + b;
+	let (s, v) = if sum >= 1.0 {
+		(0.0, w / sum)
+	} else {
+		let v = 1.0 - b;
+		let s = if v == 0.0 { 0.0 } else { 1.0 - w / v };
+		(s, v)
+	};
+	// HSV to RGB
+	let h = hue / 60.0;
+	let c = v * s;
+	let x = c * (1.0 - (h % 2.0 - 1.0).abs());
+	let m = v - c;
+	let (r_prime, g_prime, b_prime) = if h < 1.0 {
+		(c, x, 0.0)
+	} else if h < 2.0 {
+		(x, c, 0.0)
+	} else if h < 3.0 {
+		(0.0, c, x)
+	} else if h < 4.0 {
+		(0.0, x, c)
+	} else if h < 5.0 {
+		(x, 0.0, c)
+	} else {
+		(c, 0.0, x)
+	};
+	(r_prime + m, g_prime + m, b_prime + m)
+}
+
+impl From<LinearRgb> for Hwb {
+	fn from(value: LinearRgb) -> Self {
+		let r = gamma(value.red);
+		let g = gamma(value.green);
+		let b_val = gamma(value.blue);
+		let (hue, whiteness, blackness) = srgb_float_to_hwb(r, g, b_val);
+		Hwb::new(hue as f32, whiteness as f32, blackness as f32, value.alpha)
+	}
+}
+
+impl From<Hwb> for LinearRgb {
+	fn from(value: Hwb) -> Self {
+		let (r, g, b) = hwb_to_srgb_float(value.hue as f64, value.whiteness as f64, value.blackness as f64);
+		LinearRgb::new(linear(r), linear(g), linear(b), value.alpha)
 	}
 }

--- a/crates/chromashift/src/lab.rs
+++ b/crates/chromashift/src/lab.rs
@@ -21,12 +21,7 @@ pub struct Lab {
 
 impl Lab {
 	pub fn new(lightness: f64, a: f64, b: f64, alpha: f32) -> Self {
-		Self {
-			lightness: lightness.clamp(0.0, 100.0),
-			a: a.clamp(-125.0, 125.0),
-			b: b.clamp(-125.0, 125.0),
-			alpha: alpha.clamp(0.0, 100.0),
-		}
+		Self { lightness, a, b, alpha: alpha.clamp(0.0, 100.0) }
 	}
 }
 

--- a/crates/chromashift/src/lch.rs
+++ b/crates/chromashift/src/lch.rs
@@ -17,12 +17,7 @@ pub struct Lch {
 
 impl Lch {
 	pub fn new(lightness: f64, chroma: f64, hue: f64, alpha: f32) -> Self {
-		Self {
-			lightness: lightness.clamp(0.0, 100.0),
-			chroma: chroma.clamp(0.0, 150.0),
-			hue: hue.rem_euclid(360.0),
-			alpha: alpha.clamp(0.0, 100.0),
-		}
+		Self { lightness, chroma, hue: hue.rem_euclid(360.0), alpha: alpha.clamp(0.0, 100.0) }
 	}
 }
 

--- a/crates/chromashift/src/lib.rs
+++ b/crates/chromashift/src/lib.rs
@@ -4,7 +4,9 @@ use core::fmt;
 mod a98_rgb;
 mod channels;
 mod conversion;
+mod display_p3;
 mod distance;
+mod gamut;
 mod hex;
 mod hsb;
 mod hsl;
@@ -16,6 +18,8 @@ mod mix;
 mod named;
 mod oklab;
 mod oklch;
+mod prophoto_rgb;
+mod rec2020;
 mod srgb;
 #[cfg(test)]
 mod tests;
@@ -25,7 +29,9 @@ mod xyzd65;
 
 pub use a98_rgb::A98Rgb;
 pub use channels::ToAlpha;
+pub use display_p3::DisplayP3;
 pub use distance::ColorDistance;
+pub use gamut::Gamut;
 pub use hex::Hex;
 pub use hsb::Hsv;
 pub use hsl::Hsl;
@@ -37,6 +43,8 @@ pub use mix::{ColorMix, ColorMixPolar, HueInterpolation};
 pub use named::{Named, ToNamedError};
 pub use oklab::Oklab;
 pub use oklch::Oklch;
+pub use prophoto_rgb::ProphotoRgb;
+pub use rec2020::Rec2020;
 pub use srgb::Srgb;
 pub use wcag::{WcagColorContrast, WcagLevel};
 pub use xyzd50::XyzD50;
@@ -45,6 +53,7 @@ pub use xyzd65::XyzD65;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Color {
 	A98Rgb(A98Rgb),
+	DisplayP3(DisplayP3),
 	Hsv(Hsv),
 	Hsl(Hsl),
 	Hex(Hex),
@@ -55,6 +64,8 @@ pub enum Color {
 	Named(Named),
 	Oklab(Oklab),
 	Oklch(Oklch),
+	ProphotoRgb(ProphotoRgb),
+	Rec2020(Rec2020),
 	Srgb(Srgb),
 	XyzD50(XyzD50),
 	XyzD65(XyzD65),
@@ -64,6 +75,7 @@ impl fmt::Display for Color {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			Self::A98Rgb(a) => fmt::Display::fmt(a, f),
+			Self::DisplayP3(d) => fmt::Display::fmt(d, f),
 			Self::Hex(h) => fmt::Display::fmt(h, f),
 			Self::Hsv(h) => fmt::Display::fmt(h, f),
 			Self::Hsl(h) => fmt::Display::fmt(h, f),
@@ -74,6 +86,8 @@ impl fmt::Display for Color {
 			Self::Named(n) => fmt::Display::fmt(n, f),
 			Self::Oklab(o) => fmt::Display::fmt(o, f),
 			Self::Oklch(o) => fmt::Display::fmt(o, f),
+			Self::ProphotoRgb(p) => fmt::Display::fmt(p, f),
+			Self::Rec2020(r) => fmt::Display::fmt(r, f),
 			Self::Srgb(s) => fmt::Display::fmt(s, f),
 			Self::XyzD50(x) => fmt::Display::fmt(x, f),
 			Self::XyzD65(x) => fmt::Display::fmt(x, f),
@@ -85,6 +99,7 @@ impl ToAlpha for Color {
 	fn to_alpha(&self) -> f32 {
 		match self {
 			Color::A98Rgb(a) => a.to_alpha(),
+			Color::DisplayP3(d) => d.to_alpha(),
 			Color::Hex(h) => h.to_alpha(),
 			Color::Hsv(h) => h.to_alpha(),
 			Color::Hsl(h) => h.to_alpha(),
@@ -95,6 +110,8 @@ impl ToAlpha for Color {
 			Color::Named(n) => n.to_alpha(),
 			Color::Oklab(o) => o.to_alpha(),
 			Color::Oklch(o) => o.to_alpha(),
+			Color::ProphotoRgb(p) => p.to_alpha(),
+			Color::Rec2020(r) => r.to_alpha(),
 			Color::Srgb(s) => s.to_alpha(),
 			Color::XyzD50(x) => x.to_alpha(),
 			Color::XyzD65(x) => x.to_alpha(),
@@ -106,6 +123,7 @@ impl From<Color> for XyzD65 {
 	fn from(value: Color) -> Self {
 		match value {
 			Color::A98Rgb(a) => a.into(),
+			Color::DisplayP3(d) => d.into(),
 			Color::Hex(h) => h.into(),
 			Color::Hsv(h) => h.into(),
 			Color::Hsl(h) => h.into(),
@@ -116,6 +134,8 @@ impl From<Color> for XyzD65 {
 			Color::Named(n) => n.into(),
 			Color::Oklab(o) => o.into(),
 			Color::Oklch(o) => o.into(),
+			Color::ProphotoRgb(p) => p.into(),
+			Color::Rec2020(r) => r.into(),
 			Color::Srgb(s) => s.into(),
 			Color::XyzD50(x) => x.into(),
 			Color::XyzD65(x) => x,

--- a/crates/chromashift/src/linear_rgb.rs
+++ b/crates/chromashift/src/linear_rgb.rs
@@ -17,12 +17,7 @@ pub struct LinearRgb {
 
 impl LinearRgb {
 	pub fn new(red: f64, green: f64, blue: f64, alpha: f32) -> Self {
-		Self {
-			red: red.clamp(0.0, 1.0),
-			green: green.clamp(0.0, 1.0),
-			blue: blue.clamp(0.0, 1.0),
-			alpha: alpha.clamp(0.0, 100.0),
-		}
+		Self { red, green, blue, alpha: alpha.clamp(0.0, 100.0) }
 	}
 }
 

--- a/crates/chromashift/src/mix.rs
+++ b/crates/chromashift/src/mix.rs
@@ -1,4 +1,6 @@
-use crate::{Hsl, Lab, Lch, LinearRgb, Oklab, Oklch, Srgb, XyzD50, XyzD65};
+use crate::{
+	A98Rgb, DisplayP3, Hsl, Hwb, Lab, Lch, LinearRgb, Oklab, Oklch, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
+};
 
 /// A direction to interopolate hue values between, when mixing colours.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -15,6 +17,11 @@ pub enum HueInterpolation {
 /// This trait provides a static method which will receive two colours, and can output a Self which should be the result
 /// of both colours mixed by the given percentage (the percentage pertains to how much the second colour should apply to
 /// the first).
+///
+/// Per CSS Color (4 12.3 & 5 3.5), interpolation uses premultiplied alpha:
+/// 1. Premultiply each component by its alpha
+/// 2. Linearly interpolate premultiplied values and alpha independently
+/// 3. Un-premultiply by dividing by the interpolated alpha
 pub trait ColorMix<T, U>: Sized
 where
 	T: Into<Self>,
@@ -29,12 +36,31 @@ where
 /// of both colours mixed by the given percentage (the percentage pertains to how much the second colour should apply to
 /// the first). The Hue direction should be respected. If the colour space is not Polar then consider [ColorMix]
 /// instead.
+///
+/// Per CSS Color 4 12.3, premultiplied alpha is used for non-hue components. The hue component
+/// is NOT premultiplied - it is interpolated directly using the specified hue interpolation method.
 pub trait ColorMixPolar<T, U>: Sized
 where
 	T: Into<Self>,
 	U: Into<Self>,
 {
 	fn mix_polar(first: T, second: U, percentage: f64, hue_interpolation: HueInterpolation) -> Self;
+}
+
+/// Interpolate a single component using premultiplied alpha.
+///
+/// CSS Color 4 12.3:
+///   premultiplied1 = component1 * alpha1
+///   premultiplied2 = component2 * alpha2
+///   result_premultiplied = premultiplied1 * (1 - t) + premultiplied2 * t
+///   result = result_premultiplied / result_alpha
+fn premultiply_lerp(c1: f64, a1: f64, c2: f64, a2: f64, t: f64, result_alpha: f64) -> f64 {
+	if result_alpha == 0.0 {
+		return c1 * (1.0 - t) + c2 * t;
+	}
+	let pm1 = c1 * a1;
+	let pm2 = c2 * a2;
+	(pm1 * (1.0 - t) + pm2 * t) / result_alpha
 }
 
 /// Given two hues (`h1`, `h2`), a percentage transform (`t`), and an interpolation direction, return a new Hue rotation
@@ -87,6 +113,7 @@ mod sealed {
 }
 
 impl sealed::PolarColor for Hsl {}
+impl sealed::PolarColor for Hwb {}
 impl sealed::PolarColor for Lch {}
 impl sealed::PolarColor for Oklch {}
 
@@ -109,11 +136,13 @@ where
 		let first: Self = first.into();
 		let second: Self = second.into();
 		let t = percentage / 100.0;
-		let r = first.red as f64 * (1.0 - t) + second.red as f64 * t;
-		let g = first.green as f64 * (1.0 - t) + second.green as f64 * t;
-		let b = first.blue as f64 * (1.0 - t) + second.blue as f64 * t;
-		let a = first.alpha as f64 * (1.0 - t) + second.alpha as f64 * t;
-		Srgb::new(r.round() as u8, g.round() as u8, b.round() as u8, a as f32)
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let r = premultiply_lerp(first.red as f64, a1, second.red as f64, a2, t, a);
+		let g = premultiply_lerp(first.green as f64, a1, second.green as f64, a2, t, a);
+		let b = premultiply_lerp(first.blue as f64, a1, second.blue as f64, a2, t, a);
+		Srgb::new(r.round() as u8, g.round() as u8, b.round() as u8, (a * 100.0) as f32)
 	}
 }
 
@@ -125,11 +154,13 @@ where
 		let first: Self = first.into();
 		let second: Self = second.into();
 		let t = percentage / 100.0;
-		let r = first.red * (1.0 - t) + second.red * t;
-		let g = first.green * (1.0 - t) + second.green * t;
-		let b = first.blue * (1.0 - t) + second.blue * t;
-		let a = first.alpha as f64 * (1.0 - t) + second.alpha as f64 * t;
-		LinearRgb::new(r, g, b, a as f32)
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
+		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
+		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
+		LinearRgb::new(r, g, b, (a * 100.0) as f32)
 	}
 }
 
@@ -141,11 +172,103 @@ where
 		let first: Self = first.into();
 		let second: Self = second.into();
 		let t = percentage / 100.0;
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
 		let h = interpolate_hue(first.hue as f64, second.hue as f64, t, hue_interpolation);
-		let s = first.saturation as f64 * (1.0 - t) + second.saturation as f64 * t;
-		let l = first.lightness as f64 * (1.0 - t) + second.lightness as f64 * t;
-		let a = first.alpha as f64 * (1.0 - t) + second.alpha as f64 * t;
-		Hsl::new(h as f32, s as f32, l as f32, a as f32)
+		let s = premultiply_lerp(first.saturation as f64, a1, second.saturation as f64, a2, t, a);
+		let l = premultiply_lerp(first.lightness as f64, a1, second.lightness as f64, a2, t, a);
+		Hsl::new(h as f32, s as f32, l as f32, (a * 100.0) as f32)
+	}
+}
+
+impl<T, U> ColorMixPolar<T, U> for Hwb
+where
+	Self: From<T> + From<U>,
+{
+	fn mix_polar(first: T, second: U, percentage: f64, hue_interpolation: HueInterpolation) -> Self {
+		let first: Self = first.into();
+		let second: Self = second.into();
+		let t = percentage / 100.0;
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let h = interpolate_hue(first.hue as f64, second.hue as f64, t, hue_interpolation);
+		let w = premultiply_lerp(first.whiteness as f64, a1, second.whiteness as f64, a2, t, a);
+		let b = premultiply_lerp(first.blackness as f64, a1, second.blackness as f64, a2, t, a);
+		Hwb::new(h as f32, w as f32, b as f32, (a * 100.0) as f32)
+	}
+}
+
+impl<T, U> ColorMix<T, U> for A98Rgb
+where
+	Self: From<T> + From<U>,
+{
+	fn mix(first: T, second: U, percentage: f64) -> Self {
+		let first: Self = first.into();
+		let second: Self = second.into();
+		let t = percentage / 100.0;
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
+		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
+		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
+		A98Rgb::new(r, g, b, (a * 100.0) as f32)
+	}
+}
+
+impl<T, U> ColorMix<T, U> for DisplayP3
+where
+	Self: From<T> + From<U>,
+{
+	fn mix(first: T, second: U, percentage: f64) -> Self {
+		let first: Self = first.into();
+		let second: Self = second.into();
+		let t = percentage / 100.0;
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
+		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
+		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
+		DisplayP3::new(r, g, b, (a * 100.0) as f32)
+	}
+}
+
+impl<T, U> ColorMix<T, U> for ProphotoRgb
+where
+	Self: From<T> + From<U>,
+{
+	fn mix(first: T, second: U, percentage: f64) -> Self {
+		let first: Self = first.into();
+		let second: Self = second.into();
+		let t = percentage / 100.0;
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
+		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
+		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
+		ProphotoRgb::new(r, g, b, (a * 100.0) as f32)
+	}
+}
+
+impl<T, U> ColorMix<T, U> for Rec2020
+where
+	Self: From<T> + From<U>,
+{
+	fn mix(first: T, second: U, percentage: f64) -> Self {
+		let first: Self = first.into();
+		let second: Self = second.into();
+		let t = percentage / 100.0;
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
+		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
+		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
+		Rec2020::new(r, g, b, (a * 100.0) as f32)
 	}
 }
 
@@ -157,11 +280,13 @@ where
 		let first: Self = first.into();
 		let second: Self = second.into();
 		let t = percentage / 100.0;
-		let l = first.lightness * (1.0 - t) + second.lightness * t;
-		let a = first.a * (1.0 - t) + second.a * t;
-		let b = first.b * (1.0 - t) + second.b * t;
-		let alpha = first.alpha as f64 * (1.0 - t) + second.alpha as f64 * t;
-		Lab::new(l, a, b, alpha as f32)
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let l = premultiply_lerp(first.lightness, a1, second.lightness, a2, t, a);
+		let ab_a = premultiply_lerp(first.a, a1, second.a, a2, t, a);
+		let ab_b = premultiply_lerp(first.b, a1, second.b, a2, t, a);
+		Lab::new(l, ab_a, ab_b, (a * 100.0) as f32)
 	}
 }
 
@@ -173,11 +298,13 @@ where
 		let first: Self = first.into();
 		let second: Self = second.into();
 		let t = percentage / 100.0;
-		let l = first.lightness * (1.0 - t) + second.lightness * t;
-		let c = first.chroma * (1.0 - t) + second.chroma * t;
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let l = premultiply_lerp(first.lightness, a1, second.lightness, a2, t, a);
+		let c = premultiply_lerp(first.chroma, a1, second.chroma, a2, t, a);
 		let h = interpolate_hue(first.hue, second.hue, t, hue_interpolation);
-		let a = first.alpha as f64 * (1.0 - t) + second.alpha as f64 * t;
-		Lch::new(l, c, h, a as f32)
+		Lch::new(l, c, h, (a * 100.0) as f32)
 	}
 }
 
@@ -189,11 +316,13 @@ where
 		let first: Self = first.into();
 		let second: Self = second.into();
 		let t = percentage / 100.0;
-		let l = first.lightness * (1.0 - t) + second.lightness * t;
-		let a = first.a * (1.0 - t) + second.a * t;
-		let b = first.b * (1.0 - t) + second.b * t;
-		let alpha = first.alpha as f64 * (1.0 - t) + second.alpha as f64 * t;
-		Oklab::new(l, a, b, alpha as f32)
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let l = premultiply_lerp(first.lightness, a1, second.lightness, a2, t, a);
+		let ab_a = premultiply_lerp(first.a, a1, second.a, a2, t, a);
+		let ab_b = premultiply_lerp(first.b, a1, second.b, a2, t, a);
+		Oklab::new(l, ab_a, ab_b, (a * 100.0) as f32)
 	}
 }
 
@@ -205,11 +334,13 @@ where
 		let first: Self = first.into();
 		let second: Self = second.into();
 		let t = percentage / 100.0;
-		let l = first.lightness * (1.0 - t) + second.lightness * t;
-		let c = first.chroma * (1.0 - t) + second.chroma * t;
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let l = premultiply_lerp(first.lightness, a1, second.lightness, a2, t, a);
+		let c = premultiply_lerp(first.chroma, a1, second.chroma, a2, t, a);
 		let h = interpolate_hue(first.hue, second.hue, t, hue_interpolation);
-		let a = first.alpha as f64 * (1.0 - t) + second.alpha as f64 * t;
-		Oklch::new(l, c, h, a as f32)
+		Oklch::new(l, c, h, (a * 100.0) as f32)
 	}
 }
 
@@ -221,11 +352,13 @@ where
 		let first: Self = first.into();
 		let second: Self = second.into();
 		let t = percentage / 100.0;
-		let x = first.x * (1.0 - t) + second.x * t;
-		let y = first.y * (1.0 - t) + second.y * t;
-		let z = first.z * (1.0 - t) + second.z * t;
-		let a = first.alpha as f64 * (1.0 - t) + second.alpha as f64 * t;
-		XyzD50::new(x, y, z, a as f32)
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let x = premultiply_lerp(first.x, a1, second.x, a2, t, a);
+		let y = premultiply_lerp(first.y, a1, second.y, a2, t, a);
+		let z = premultiply_lerp(first.z, a1, second.z, a2, t, a);
+		XyzD50::new(x, y, z, (a * 100.0) as f32)
 	}
 }
 
@@ -237,11 +370,13 @@ where
 		let first: Self = first.into();
 		let second: Self = second.into();
 		let t = percentage / 100.0;
-		let x = first.x * (1.0 - t) + second.x * t;
-		let y = first.y * (1.0 - t) + second.y * t;
-		let z = first.z * (1.0 - t) + second.z * t;
-		let a = first.alpha as f64 * (1.0 - t) + second.alpha as f64 * t;
-		XyzD65::new(x, y, z, a as f32)
+		let a1 = first.alpha as f64 / 100.0;
+		let a2 = second.alpha as f64 / 100.0;
+		let a = a1 * (1.0 - t) + a2 * t;
+		let x = premultiply_lerp(first.x, a1, second.x, a2, t, a);
+		let y = premultiply_lerp(first.y, a1, second.y, a2, t, a);
+		let z = premultiply_lerp(first.z, a1, second.z, a2, t, a);
+		XyzD65::new(x, y, z, (a * 100.0) as f32)
 	}
 }
 
@@ -294,9 +429,72 @@ mod tests {
 		let color2 = Srgb::new(0, 0, 255, 40.0);
 
 		let mixed = Srgb::mix(color1, color2, 50.0);
-		assert_eq!(mixed.red, 128);
+		assert_eq!(mixed.red, 170);
 		assert_eq!(mixed.green, 0);
-		assert_eq!(mixed.blue, 128);
+		assert_eq!(mixed.blue, 85);
 		assert_eq!(mixed.alpha, 60.0);
+	}
+
+	#[test]
+	fn test_hwb_mix() {
+		// Hwb is polar - default mix uses Shorter hue interpolation
+		// 0° to 240°: diff=240 > 180, so shorter wraps via 360°, midpoint is 300°
+		let red = Hwb::new(0.0, 0.0, 0.0, 100.0);
+		let blue = Hwb::new(240.0, 0.0, 0.0, 100.0);
+		let mixed = Hwb::mix(red, blue, 50.0);
+		assert_close_to!(mixed, Hwb::new(300.0, 0.0, 0.0, 100.0));
+	}
+
+	#[test]
+	fn test_hwb_mix_polar() {
+		// 0° to 240°: longer arc goes through 120°
+		let red = Hwb::new(0.0, 0.0, 0.0, 100.0);
+		let blue = Hwb::new(240.0, 0.0, 0.0, 100.0);
+		assert_close_to!(Hwb::mix_polar(red, blue, 50.0, HueInterpolation::Longer), Hwb::new(120.0, 0.0, 0.0, 100.0));
+	}
+
+	#[test]
+	fn test_a98_rgb_mix() {
+		let c1 = A98Rgb::new(1.0, 0.0, 0.0, 100.0);
+		let c2 = A98Rgb::new(0.0, 0.0, 1.0, 100.0);
+		let mixed = A98Rgb::mix(c1, c2, 50.0);
+		assert_close_to!(mixed, A98Rgb::new(0.5, 0.0, 0.5, 100.0));
+	}
+
+	/// WPT: color-mix(in lab, lab(10 20 30 / .4), lab(50 60 70 / .8)) → lab(36.666664 46.666664 56.666664 / 0.6)
+	#[test]
+	fn test_premultiplied_alpha_lab() {
+		let c1 = Lab::new(10.0, 20.0, 30.0, 40.0);
+		let c2 = Lab::new(50.0, 60.0, 70.0, 80.0);
+		let mixed = Lab::mix(c1, c2, 50.0);
+		assert_close_to!(mixed, Lab::new(36.666664, 46.666664, 56.666664, 60.0));
+	}
+
+	/// WPT: color-mix(in lab, lab(10 20 30 / .4) 25%, lab(50 60 70 / .8)) → lab(44.285713 54.285717 64.28571 / 0.7)
+	#[test]
+	fn test_premultiplied_alpha_lab_25_75() {
+		let c1 = Lab::new(10.0, 20.0, 30.0, 40.0);
+		let c2 = Lab::new(50.0, 60.0, 70.0, 80.0);
+		// 25% first, 75% second: mix_percentage = 75
+		let mixed = Lab::mix(c1, c2, 75.0);
+		assert_close_to!(mixed, Lab::new(44.285713, 54.285717, 64.28571, 70.0));
+	}
+
+	/// WPT: color-mix(in oklch, oklch(0.1 0.2 30deg / .4), oklch(0.5 0.6 70deg / .8)) → oklch(0.36666664 0.46666664 50 / 0.6)
+	#[test]
+	fn test_premultiplied_alpha_oklch() {
+		let c1 = Oklch::new(0.1, 0.2, 30.0, 40.0);
+		let c2 = Oklch::new(0.5, 0.6, 70.0, 80.0);
+		let mixed = Oklch::mix(c1, c2, 50.0);
+		assert_close_to!(mixed, Oklch::new(0.36666664, 0.46666664, 50.0, 60.0));
+	}
+
+	/// When both alphas are 100%, premultiplied interpolation == simple interpolation.
+	#[test]
+	fn test_premultiplied_alpha_opaque_same_as_simple() {
+		let c1 = Lab::new(10.0, 20.0, 30.0, 100.0);
+		let c2 = Lab::new(50.0, 60.0, 70.0, 100.0);
+		let mixed = Lab::mix(c1, c2, 50.0);
+		assert_close_to!(mixed, Lab::new(30.0, 40.0, 50.0, 100.0));
 	}
 }

--- a/crates/chromashift/src/oklab.rs
+++ b/crates/chromashift/src/oklab.rs
@@ -17,12 +17,7 @@ pub struct Oklab {
 
 impl Oklab {
 	pub fn new(lightness: f64, a: f64, b: f64, alpha: f32) -> Self {
-		Self {
-			lightness: lightness.clamp(0.0, 100.0),
-			a: a.clamp(-128.0, 127.0),
-			b: b.clamp(-128.0, 127.0),
-			alpha: alpha.clamp(0.0, 100.0),
-		}
+		Self { lightness, a, b, alpha: alpha.clamp(0.0, 100.0) }
 	}
 }
 

--- a/crates/chromashift/src/oklch.rs
+++ b/crates/chromashift/src/oklch.rs
@@ -17,12 +17,7 @@ pub struct Oklch {
 
 impl Oklch {
 	pub fn new(lightness: f64, chroma: f64, hue: f64, alpha: f32) -> Self {
-		Self {
-			lightness: lightness.clamp(0.0, 100.0),
-			chroma: chroma.clamp(0.0, 150.0),
-			hue: hue.rem_euclid(360.0),
-			alpha: alpha.clamp(0.0, 100.0),
-		}
+		Self { lightness, chroma, hue: hue.rem_euclid(360.0), alpha: alpha.clamp(0.0, 100.0) }
 	}
 }
 

--- a/crates/chromashift/src/prophoto_rgb.rs
+++ b/crates/chromashift/src/prophoto_rgb.rs
@@ -1,0 +1,82 @@
+use crate::{ToAlpha, XyzD50, round_dp};
+use core::fmt;
+
+/// A colour in the ProPhoto RGB colour space (ROMM RGB).
+/// The components are:
+/// - Red - a number between 0.0 and 1.0
+/// - Green - a number between 0.0 and 1.0
+/// - Blue - a number between 0.0 and 1.0
+/// - Alpha - a number between 0.0 and 100.0
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ProphotoRgb {
+	pub red: f64,
+	pub green: f64,
+	pub blue: f64,
+	pub alpha: f32,
+}
+
+impl ProphotoRgb {
+	pub fn new(red: f64, green: f64, blue: f64, alpha: f32) -> Self {
+		Self { red, green, blue, alpha: alpha.clamp(0.0, 100.0) }
+	}
+}
+
+impl ToAlpha for ProphotoRgb {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
+	}
+}
+
+impl fmt::Display for ProphotoRgb {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let Self { red, green, blue, alpha } = self;
+		write!(f, "color(prophoto-rgb {} {} {}", round_dp(*red, 2), round_dp(*green, 2), round_dp(*blue, 2))?;
+		if *alpha < 100.0 {
+			write!(f, " / {}", round_dp(*alpha as f64, 2))?;
+		}
+		write!(f, ")")
+	}
+}
+
+/// ProPhoto RGB transfer function: linear to gamma-encoded
+/// Uses gamma 1.8 with a linear segment.
+fn gamma(u: f64) -> f64 {
+	let abs = u.abs();
+	if abs >= 1.0 / 512.0 { u.signum() * abs.powf(1.0 / 1.8) } else { u * 16.0 }
+}
+
+/// ProPhoto RGB transfer function: gamma-encoded to linear
+fn linear(c: f64) -> f64 {
+	let abs = c.abs();
+	if abs >= 16.0 / 512.0 { c.signum() * abs.powf(1.8) } else { c / 16.0 }
+}
+
+impl From<XyzD50> for ProphotoRgb {
+	fn from(value: XyzD50) -> Self {
+		let XyzD50 { x, y, z, alpha } = value;
+		let x = x / 100.0;
+		let y = y / 100.0;
+		let z = z / 100.0;
+		// XYZ D50 -> Linear ProPhoto RGB
+		let lr = x * 1.3457868816471583 + y * (-0.25557208737979464) + z * (-0.05110186497554526);
+		let lg = x * (-0.5446307051249019) + y * 1.5082477428451468 + z * 0.02052744743642139;
+		let lb = x * 0.0 + y * 0.0 + z * 1.2119675456389452;
+		// Apply ProPhoto gamma
+		ProphotoRgb::new(gamma(lr), gamma(lg), gamma(lb), alpha)
+	}
+}
+
+impl From<ProphotoRgb> for XyzD50 {
+	fn from(value: ProphotoRgb) -> Self {
+		let ProphotoRgb { red, green, blue, alpha } = value;
+		// Linearize with ProPhoto gamma
+		let lr = linear(red);
+		let lg = linear(green);
+		let lb = linear(blue);
+		// Linear ProPhoto RGB -> XYZ D50
+		let x = lr * 0.7977666449006423 + lg * 0.13518129740053308 + lb * 0.0313477341283922;
+		let y = lr * 0.2880748288194013 + lg * 0.711835234241873 + lb * 0.00008993693872564;
+		let z = lr * 0.0 + lg * 0.0 + lb * 0.8251046025104602;
+		XyzD50::new(x * 100.0, y * 100.0, z * 100.0, alpha)
+	}
+}

--- a/crates/chromashift/src/rec2020.rs
+++ b/crates/chromashift/src/rec2020.rs
@@ -1,0 +1,84 @@
+use crate::{ToAlpha, XyzD65, round_dp};
+use core::fmt;
+
+/// A colour in the Rec. 2020 colour space.
+/// The components are:
+/// - Red - a number between 0.0 and 1.0
+/// - Green - a number between 0.0 and 1.0
+/// - Blue - a number between 0.0 and 1.0
+/// - Alpha - a number between 0.0 and 100.0
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rec2020 {
+	pub red: f64,
+	pub green: f64,
+	pub blue: f64,
+	pub alpha: f32,
+}
+
+impl Rec2020 {
+	pub fn new(red: f64, green: f64, blue: f64, alpha: f32) -> Self {
+		Self { red, green, blue, alpha: alpha.clamp(0.0, 100.0) }
+	}
+}
+
+impl ToAlpha for Rec2020 {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
+	}
+}
+
+impl fmt::Display for Rec2020 {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let Self { red, green, blue, alpha } = self;
+		write!(f, "color(rec2020 {} {} {}", round_dp(*red, 2), round_dp(*green, 2), round_dp(*blue, 2))?;
+		if *alpha < 100.0 {
+			write!(f, " / {}", round_dp(*alpha as f64, 2))?;
+		}
+		write!(f, ")")
+	}
+}
+
+const ALPHA: f64 = 1.09929682680944;
+const BETA: f64 = 0.018053968510807;
+
+/// BT.2020 transfer function: linear to gamma-encoded
+fn gamma(u: f64) -> f64 {
+	let abs = u.abs();
+	if abs >= BETA { u.signum() * (ALPHA * abs.powf(0.45) - (ALPHA - 1.0)) } else { u * 4.5 }
+}
+
+/// BT.2020 transfer function: gamma-encoded to linear
+fn linear(c: f64) -> f64 {
+	let abs = c.abs();
+	if abs >= BETA * 4.5 { c.signum() * ((abs + (ALPHA - 1.0)) / ALPHA).powf(1.0 / 0.45) } else { c / 4.5 }
+}
+
+impl From<XyzD65> for Rec2020 {
+	fn from(value: XyzD65) -> Self {
+		let XyzD65 { x, y, z, alpha } = value;
+		let x = x / 100.0;
+		let y = y / 100.0;
+		let z = z / 100.0;
+		// XYZ D65 -> Linear Rec. 2020
+		let lr = x * 1.7166511879712674 + y * (-0.35567078377639233) + z * (-0.25336628137365974);
+		let lg = x * (-0.666684351832489) + y * 1.616481236634939 + z * 0.01576854581391113;
+		let lb = x * 0.017639857445310783 + y * (-0.042770613257808524) + z * 0.9421031212354738;
+		// Apply BT.2020 gamma
+		Rec2020::new(gamma(lr), gamma(lg), gamma(lb), alpha)
+	}
+}
+
+impl From<Rec2020> for XyzD65 {
+	fn from(value: Rec2020) -> Self {
+		let Rec2020 { red, green, blue, alpha } = value;
+		// Linearize with BT.2020 gamma
+		let lr = linear(red);
+		let lg = linear(green);
+		let lb = linear(blue);
+		// Linear Rec. 2020 -> XYZ D65
+		let x = lr * 0.6369580483012914 + lg * 0.14461690358620832 + lb * 0.16888097516417205;
+		let y = lr * 0.2627002120112671 + lg * 0.6779980715188708 + lb * 0.05930171646986196;
+		let z = lr * 0.0 + lg * 0.028072693049087428 + lb * 1.0609850577107909;
+		XyzD65::new(x * 100.0, y * 100.0, z * 100.0, alpha)
+	}
+}


### PR DESCRIPTION
Chromashift had reasonable support for CSS colors, but missed some of the wide
gamut colors only available in the `color()` syntax. These are DisplayP3, ProphotoRgb, and Rec2020.

This change started by supporting these colors, but during that work, I realised
we got out-of-gamut color handling totally wrong, because CSS Color 4 & 5
specifically require out-of-gamut values are preserved, gamut mapping at
display time, and interpolated using premultiplied alphas. This means simply
clamping/quantizing channels is far too naive. In addition some spaces (HSL &
HWB) went through Srgb for conversion, which meant they were quantized, which
leads to clipping anyway.

So, this change now presents a significant rework of the color combinations,
color mixing, and color transforms for HSL/HWB, while also introducing the new
color modes. To enumerate:

- Adds DisplayP3 (wide gamut).
- Adds ProphotoRgb (wide gamut).
- Adds Rec2020 (wide gamut).
- All new wide gamut colors convert to XYZ
- ColorMix (polar) is now implemented for HWB which was missed before.
- All ColorMix/ColorMixPolar impls now use premultiplied interpolation, except
  hue channels in polar spaces which understandably do not.
- All colours which previously clamped (LinearRgb, A98Rgb, Lab, Lch, Oklab,
  Oklch, Hsl, Hwb) now no longer clamp, instead allowing out-of-gamut ranges.
- In order to maintain out-of-gamut values a bunch of transitive conversions
	have been reworked, going through LinearRgb (which allows out-of-gamut) rather
	than being quantized through Srgb and intrinsically clipped.
- Added a new `Gamut` trait which provides the `in_gamut()` and
	`clamp_to_gamut()` methods.
