### PR TITLE
chromashift: Implement css-color-4 raytrace gamut mapping

### DIFF
--- a/crates/chromashift/src/gamut.rs
+++ b/crates/chromashift/src/gamut.rs
@@ -1,20 +1,231 @@
 use crate::*;
 
-/// Whether a colour is within the natural bounds of its colour space, and the ability to produce a naively clamped version.
+/// Whether a colour is within the natural bounds of its colour space, and the ability to produce a naively clamped
+/// version or a perceptually gamut-mapped version.
 ///
-/// CSS Color 4 12.1 and 13.1 state that out-of-gamut values must be preserved through intermediate computations.
-/// Gamut mapping (reducing to displayable range) only happens at "actual-value" / display time. This trait lets
-/// callers query and clamp when appropriate.
-///
-/// Note: `clamp_to_gamut()` performs naive channel clamping. This is *not* the perceptual gamut-mapping algorithm from
-/// CSS Color 4 13.2 (which reduces Oklch chroma iteratively).
+/// CSS Color 4 12.1 and 13.1 state that out-of-gamut values must be preserved through intermediate computations. Gamut
+/// mapping (reducing to displayable range) only happens at "actual-value" / display time. This trait lets callers query
+/// and map when appropriate.
 pub trait Gamut: Sized {
 	/// Returns `true` if all colour channels are within the natural bounds of this colour space.
 	/// Alpha is not considered — it is always clamped on construction.
 	fn in_gamut(&self) -> bool;
 
-	/// Returns a copy with all colour channels clamped to the natural bounds of this colour space.
+	/// Returns a copy with all colour channels naively clamped to the natural bounds.
+	///
+	/// This is simple per-channel clipping for fast but less perceptually pleasing results.
 	fn clamp_to_gamut(&self) -> Self;
+
+	/// Perceptually maps this colour into gamut.
+	///
+	/// For RGB-based colour spaces this should use the ray trace algorithm in CSS Color 4 13.2, to casting a ray from an
+	/// achromatic anchor toward the out-of-gamut colour and finding the intersection with the gamut's RGB cube via the
+	/// slab method.
+	///
+	/// Reference: <https://facelessuser.github.io/coloraide/gamut/#ray-tracing-chroma-reduction>
+	/// CSS Color 4 spec: <https://drafts.csswg.org/css-color-4/#pseudo-raytrace>
+	fn map_to_gamut(self) -> Self;
+}
+
+/// CSS Color 4 13.2.6 ray trace gamut mapping, steps 3–14.
+///
+/// Caller has already performed steps 1–2 (in-gamut check and conversion to OkLCh).
+///
+/// <https://drafts.csswg.org/css-color-4/#pseudo-raytrace>
+fn raytrace_to_linear_rgb(oklch: Oklch) -> LinearRgb {
+	let alpha = oklch.alpha;
+
+	// 3. if the Lightness of |origin_OkLCh| is >= 100%, return white.
+	if oklch.lightness >= 1.0 {
+		return LinearRgb::new(1.0, 1.0, 1.0, alpha);
+	}
+	// 4. if the Lightness of |origin_OkLCh| is <= 0%, return black.
+	if oklch.lightness <= 0.0 {
+		return LinearRgb::new(0.0, 0.0, 0.0, alpha);
+	}
+
+	// 5. let |l_origin| be the OkLCh lightness of |origin_OkLCh|.
+	let l_origin = oklch.lightness;
+
+	// 6. let |h_origin| be the OkLCh hue of |origin_OkLCh|.
+	let h_origin = oklch.hue;
+
+	// 7. let |anchor| be an achromatic OkLCh color (l_origin, 0, h_origin),
+	//    converted to the linear-light form of |destination|.
+	let anchor_oklch = Oklch::new(l_origin, 0.0, h_origin, alpha);
+	let anchor_rgb = LinearRgb::from(Oklab::from(anchor_oklch));
+	let mut anchor = [anchor_rgb.red, anchor_rgb.green, anchor_rgb.blue];
+
+	// 8. let |origin_rgb| be |origin_OkLCh| converted to the linear-light form of |destination|.
+	let origin_rgb = LinearRgb::from(Oklab::from(oklch));
+	let mut origin_rgb = [origin_rgb.red, origin_rgb.green, origin_rgb.blue];
+
+	// 9. let |low| be 1E-6.
+	let low = 1e-6;
+
+	// 10. let |high| be 1.0 - |low|.
+	let high = 1.0 - low;
+
+	// 11. let |last| be |origin_rgb|.
+	let mut last = origin_rgb;
+
+	// 12. for (i=0; i<4; i++)
+	for i in 0..4 {
+		// 12.1. if (i > 0)
+		if i > 0 {
+			// 12.1.1. let |current_OkLCh| be |origin_rgb| converted to OkLCh.
+			let rgb = LinearRgb::new(origin_rgb[0], origin_rgb[1], origin_rgb[2], alpha);
+			let mut current_oklch = Oklch::from(Oklab::from(XyzD65::from(rgb)));
+
+			// 12.1.2. let the lightness of |current_OkLCh| be |l_origin|.
+			current_oklch.lightness = l_origin;
+
+			// 12.1.3. let the hue of |current_OkLCh| be |h_origin|.
+			current_oklch.hue = h_origin;
+
+			// 12.1.4. let |origin_rgb| be |current_OkLCh| converted to the linear-light
+			//         form of |destination|.
+			let rgb = LinearRgb::from(XyzD65::from(Oklab::from(current_oklch)));
+			origin_rgb = [rgb.red, rgb.green, rgb.blue];
+		}
+
+		// 12.2. Cast a ray from |anchor| to |origin_rgb| and let |intersection| be
+		//       the intersection of this ray with the gamut boundary.
+		let intersection = raytrace_box(&anchor, &origin_rgb);
+
+		match intersection {
+			// 12.3. if an intersection was not found, let |origin_rgb| be |last|
+			//       and exit the loop.
+			None => {
+				origin_rgb = last;
+				break;
+			}
+			Some(hit) => {
+				// 12.4. if (i > 0) AND (each component of |origin_rgb| is between
+				//       |low| and |high|) then let |anchor| be |origin_rgb|.
+				if i > 0 && origin_rgb.iter().all(|&x| low < x && x < high) {
+					anchor = origin_rgb;
+				}
+
+				// 12.5. let |origin_rgb| be |intersection|.
+				// 12.6. let |last| be |intersection|.
+				origin_rgb = hit;
+				last = hit;
+			}
+		}
+	}
+
+	// 13. let |clipped| be |origin_rgb| clipped to gamut (components in range 0 to 1),
+	//     trimming off any noise due to floating point inaccuracy.
+	// 14. return |clipped|, converted to |destination| as the gamut mapped color.
+	LinearRgb::new(origin_rgb[0].clamp(0.0, 1.0), origin_rgb[1].clamp(0.0, 1.0), origin_rgb[2].clamp(0.0, 1.0), alpha)
+}
+
+/// Implements `map_to_gamut` for a colour type that can convert to/from `Oklch` and `LinearRgb`.
+///
+/// Steps 1–2 of the spec algorithm live here; steps 3–14 are in [`raytrace_to_linear_rgb`].
+macro_rules! impl_map_to_gamut_raytrace {
+	($ty:ident, $to_oklch:expr, $from_linear:expr) => {
+		impl $ty {
+			fn raytrace_map_to_gamut(self) -> Self {
+				// 1. if |origin| is in gamut for |destination|, return it.
+				if self.in_gamut() {
+					return self;
+				}
+
+				// 2. let |origin_OkLCh| be |origin| converted to the OkLCh color space.
+				let oklch = $to_oklch(self);
+
+				// Steps 3–14.
+				$from_linear(raytrace_to_linear_rgb(oklch))
+			}
+		}
+	};
+}
+
+// Define conversions for each RGB type. Each needs a way to get to Oklch and back from LinearRgb.
+impl_map_to_gamut_raytrace!(LinearRgb, |c: LinearRgb| Oklch::from(Oklab::from(XyzD65::from(c))), |rgb: LinearRgb| rgb
+	.clamp_to_gamut());
+impl_map_to_gamut_raytrace!(DisplayP3, |c: DisplayP3| Oklch::from(Oklab::from(XyzD65::from(c))), |rgb: LinearRgb| {
+	DisplayP3::from(XyzD65::from(rgb)).clamp_to_gamut()
+});
+impl_map_to_gamut_raytrace!(
+	A98Rgb,
+	|c: A98Rgb| Oklch::from(Oklab::from(XyzD65::from(LinearRgb::from(c)))),
+	|rgb: LinearRgb| A98Rgb::from(rgb).clamp_to_gamut()
+);
+impl_map_to_gamut_raytrace!(
+	ProphotoRgb,
+	|c: ProphotoRgb| Oklch::from(Oklab::from(XyzD65::from(XyzD50::from(c)))),
+	|rgb: LinearRgb| ProphotoRgb::from(XyzD50::from(XyzD65::from(rgb))).clamp_to_gamut()
+);
+impl_map_to_gamut_raytrace!(Rec2020, |c: Rec2020| Oklch::from(Oklab::from(XyzD65::from(c))), |rgb: LinearRgb| {
+	Rec2020::from(XyzD65::from(rgb)).clamp_to_gamut()
+});
+
+/// CSS Color 4 13.2.6 "cast a ray" — ray–box intersection using the slab method.
+///
+/// Given a ray from `start` through `end`, finds where it intersects the unit cube [0,1]³.
+/// Returns `None` if no valid intersection exists (parallel miss, behind ray, or degenerate).
+///
+/// <https://drafts.csswg.org/css-color-4/#pseudo-raytrace>
+/// <https://en.wikipedia.org/wiki/Slab_method>
+fn raytrace_box(start: &[f64; 3], end: &[f64; 3]) -> Option<[f64; 3]> {
+	// 1. (bmin and bmax are [0,0,0] and [1,1,1] for unit-range RGB gamuts.)
+
+	// 2. let |tfar| be infinity.
+	let mut tfar = f64::INFINITY;
+
+	// 3. let |tnear| be -infinity.
+	let mut tnear = f64::NEG_INFINITY;
+
+	// 4. let |direction| be a 3-element array.
+	let mut direction = [0.0_f64; 3];
+
+	// 5. for (i = 0; i < 3; i++):
+	for i in 0..3 {
+		let a = start[i]; //     let |a| be |start|[i].
+		let b = end[i]; //       let |b| be |end|[i].
+		let d = b - a; //        let |d| be |b| - |a|.
+		direction[i] = d; //     let |direction|[i] be |d|.
+
+		// if abs(|d|) > 1E-12:
+		// (Corrected per https://github.com/w3c/csswg-drafts/pull/13416 — using an
+		// epsilon to prevent numerical instability when d approaches zero.)
+		if d.abs() > 1e-12 {
+			let inv_d = 1.0 / d; //          let |inv_d| be 1 / |d|.
+			let t1 = (0.0 - a) * inv_d; //   let |t1| be (|bmin|[i] - |a|) * |inv_d|.
+			let t2 = (1.0 - a) * inv_d; //   let |t2| be (|bmax|[i] - |a|) * |inv_d|.
+			tnear = tnear.max(t1.min(t2)); // let |tnear| be max(min(|t1|, |t2|), |tnear|).
+			tfar = tfar.min(t1.max(t2)); //   let |tfar| be min(max(|t1|, |t2|), |tfar|).
+		}
+		// else if (|a| < |bmin|[i] or |a| > |bmax|[i]): return INTERSECTION NOT FOUND.
+		else if !(0.0..=1.0).contains(&a) {
+			return None;
+		}
+	}
+
+	// 6. if (|tnear| > |tfar| or |tfar| < 0): return INTERSECTION NOT FOUND.
+	if tnear > tfar || tfar < 0.0 {
+		return None;
+	}
+
+	// 7. if |tnear| < 0: let |tnear| be |tfar|.
+	//    (Favoring the first intersection in the direction |start| -> |end|.)
+	if tnear < 0.0 {
+		tnear = tfar;
+	}
+
+	// 8. if |tnear| is infinite: return INTERSECTION NOT FOUND.
+	//    (Corrected per https://github.com/w3c/csswg-drafts/pull/13416 — checking
+	//    for infinite rather than an arbitrary threshold.)
+	if !tnear.is_finite() {
+		return None;
+	}
+
+	// 9. for (i = 0; i < 3; i++): let |result|[i] be |start|[i] + |direction|[i] * |tnear|.
+	// 10. return |result|.
+	Some([start[0] + direction[0] * tnear, start[1] + direction[1] * tnear, start[2] + direction[2] * tnear])
 }
 
 /// Helper: checks an f64 is in [0.0, 1.0]
@@ -37,6 +248,10 @@ macro_rules! impl_gamut_rgb_f64 {
 			fn clamp_to_gamut(&self) -> Self {
 				Self::new(self.red.clamp(0.0, 1.0), self.green.clamp(0.0, 1.0), self.blue.clamp(0.0, 1.0), self.alpha)
 			}
+
+			fn map_to_gamut(self) -> Self {
+				self.raytrace_map_to_gamut()
+			}
 		}
 	};
 }
@@ -55,6 +270,10 @@ impl Gamut for Srgb {
 	fn clamp_to_gamut(&self) -> Self {
 		*self
 	}
+
+	fn map_to_gamut(self) -> Self {
+		self.clamp_to_gamut()
+	}
 }
 
 impl Gamut for Hex {
@@ -64,6 +283,10 @@ impl Gamut for Hex {
 
 	fn clamp_to_gamut(&self) -> Self {
 		*self
+	}
+
+	fn map_to_gamut(self) -> Self {
+		self.clamp_to_gamut()
 	}
 }
 
@@ -82,6 +305,16 @@ impl Gamut for Lab {
 			self.alpha,
 		)
 	}
+
+	fn map_to_gamut(self) -> Self {
+		let rgb = LinearRgb::from(XyzD65::from(XyzD50::from(self)));
+		if rgb.in_gamut() {
+			return self;
+		}
+		let oklch = Oklch::from(Oklab::from(XyzD65::from(XyzD50::from(self))));
+		let mapped_rgb = raytrace_to_linear_rgb(oklch);
+		Lab::from(XyzD50::from(XyzD65::from(mapped_rgb))).clamp_to_gamut()
+	}
 }
 
 impl Gamut for Oklab {
@@ -91,6 +324,16 @@ impl Gamut for Oklab {
 
 	fn clamp_to_gamut(&self) -> Self {
 		Self::new(self.lightness.clamp(0.0, 1.0), self.a.clamp(-0.4, 0.4), self.b.clamp(-0.4, 0.4), self.alpha)
+	}
+
+	fn map_to_gamut(self) -> Self {
+		let rgb = LinearRgb::from(XyzD65::from(self));
+		if rgb.in_gamut() {
+			return self;
+		}
+		let oklch = Oklch::from(self);
+		let mapped_rgb = raytrace_to_linear_rgb(oklch);
+		Oklab::from(XyzD65::from(mapped_rgb)).clamp_to_gamut()
 	}
 }
 
@@ -102,6 +345,16 @@ impl Gamut for Lch {
 	fn clamp_to_gamut(&self) -> Self {
 		Self::new(self.lightness.clamp(0.0, 100.0), self.chroma.clamp(0.0, 150.0), self.hue, self.alpha)
 	}
+
+	fn map_to_gamut(self) -> Self {
+		let rgb = LinearRgb::from(XyzD65::from(XyzD50::from(Lab::from(self))));
+		if rgb.in_gamut() {
+			return self;
+		}
+		let oklch = Oklch::from(Oklab::from(XyzD65::from(XyzD50::from(Lab::from(self)))));
+		let mapped_rgb = raytrace_to_linear_rgb(oklch);
+		Lch::from(Lab::from(XyzD50::from(XyzD65::from(mapped_rgb)))).clamp_to_gamut()
+	}
 }
 
 impl Gamut for Oklch {
@@ -111,6 +364,15 @@ impl Gamut for Oklch {
 
 	fn clamp_to_gamut(&self) -> Self {
 		Self::new(self.lightness.clamp(0.0, 1.0), self.chroma.clamp(0.0, 0.4), self.hue, self.alpha)
+	}
+
+	fn map_to_gamut(self) -> Self {
+		let rgb = LinearRgb::from(XyzD65::from(Oklab::from(self)));
+		if rgb.in_gamut() {
+			return self;
+		}
+		let mapped_rgb = raytrace_to_linear_rgb(self);
+		Oklch::from(Oklab::from(XyzD65::from(mapped_rgb))).clamp_to_gamut()
 	}
 }
 
@@ -122,6 +384,16 @@ impl Gamut for Hsl {
 	fn clamp_to_gamut(&self) -> Self {
 		Self::new(self.hue, self.saturation.clamp(0.0, 100.0), self.lightness.clamp(0.0, 100.0), self.alpha)
 	}
+
+	fn map_to_gamut(self) -> Self {
+		let rgb = LinearRgb::from(self);
+		if rgb.in_gamut() {
+			return self;
+		}
+		let oklch = Oklch::from(Oklab::from(XyzD65::from(rgb)));
+		let mapped_rgb = raytrace_to_linear_rgb(oklch);
+		Hsl::from(mapped_rgb).clamp_to_gamut()
+	}
 }
 
 impl Gamut for Hwb {
@@ -131,6 +403,16 @@ impl Gamut for Hwb {
 
 	fn clamp_to_gamut(&self) -> Self {
 		Self::new(self.hue, self.whiteness.clamp(0.0, 100.0), self.blackness.clamp(0.0, 100.0), self.alpha)
+	}
+
+	fn map_to_gamut(self) -> Self {
+		let rgb = LinearRgb::from(self);
+		if rgb.in_gamut() {
+			return self;
+		}
+		let oklch = Oklch::from(Oklab::from(XyzD65::from(rgb)));
+		let mapped_rgb = raytrace_to_linear_rgb(oklch);
+		Hwb::from(mapped_rgb).clamp_to_gamut()
 	}
 }
 
@@ -143,6 +425,10 @@ impl Gamut for Hsv {
 	fn clamp_to_gamut(&self) -> Self {
 		*self
 	}
+
+	fn map_to_gamut(self) -> Self {
+		self.clamp_to_gamut()
+	}
 }
 
 impl Gamut for XyzD50 {
@@ -153,6 +439,16 @@ impl Gamut for XyzD50 {
 	fn clamp_to_gamut(&self) -> Self {
 		Self::new(self.x.max(0.0), self.y.clamp(0.0, 100.0), self.z.max(0.0), self.alpha)
 	}
+
+	fn map_to_gamut(self) -> Self {
+		let rgb = LinearRgb::from(XyzD65::from(self));
+		if rgb.in_gamut() {
+			return self;
+		}
+		let oklch = Oklch::from(Oklab::from(XyzD65::from(self)));
+		let mapped_rgb = raytrace_to_linear_rgb(oklch);
+		XyzD50::from(XyzD65::from(mapped_rgb)).clamp_to_gamut()
+	}
 }
 
 impl Gamut for XyzD65 {
@@ -162,6 +458,16 @@ impl Gamut for XyzD65 {
 
 	fn clamp_to_gamut(&self) -> Self {
 		Self::new(self.x.max(0.0), self.y.clamp(0.0, 100.0), self.z.max(0.0), self.alpha)
+	}
+
+	fn map_to_gamut(self) -> Self {
+		let rgb = LinearRgb::from(self);
+		if rgb.in_gamut() {
+			return self;
+		}
+		let oklch = Oklch::from(Oklab::from(self));
+		let mapped_rgb = raytrace_to_linear_rgb(oklch);
+		XyzD65::from(mapped_rgb).clamp_to_gamut()
 	}
 }
 
@@ -207,6 +513,28 @@ impl Gamut for Color {
 			Color::Srgb(c) => Color::Srgb(c.clamp_to_gamut()),
 			Color::XyzD50(c) => Color::XyzD50(c.clamp_to_gamut()),
 			Color::XyzD65(c) => Color::XyzD65(c.clamp_to_gamut()),
+		}
+	}
+
+	fn map_to_gamut(self) -> Self {
+		match self {
+			Color::A98Rgb(c) => Color::A98Rgb(c.map_to_gamut()),
+			Color::DisplayP3(c) => Color::DisplayP3(c.map_to_gamut()),
+			Color::Hex(c) => Color::Hex(c.map_to_gamut()),
+			Color::Hsv(c) => Color::Hsv(c.map_to_gamut()),
+			Color::Hsl(c) => Color::Hsl(c.map_to_gamut()),
+			Color::Hwb(c) => Color::Hwb(c.map_to_gamut()),
+			Color::Lab(c) => Color::Lab(c.map_to_gamut()),
+			Color::Lch(c) => Color::Lch(c.map_to_gamut()),
+			Color::LinearRgb(c) => Color::LinearRgb(c.map_to_gamut()),
+			Color::Named(n) => Color::Named(n),
+			Color::Oklab(c) => Color::Oklab(c.map_to_gamut()),
+			Color::Oklch(c) => Color::Oklch(c.map_to_gamut()),
+			Color::ProphotoRgb(c) => Color::ProphotoRgb(c.map_to_gamut()),
+			Color::Rec2020(c) => Color::Rec2020(c.map_to_gamut()),
+			Color::Srgb(c) => Color::Srgb(c.map_to_gamut()),
+			Color::XyzD50(c) => Color::XyzD50(c.map_to_gamut()),
+			Color::XyzD65(c) => Color::XyzD65(c.map_to_gamut()),
 		}
 	}
 }

--- a/crates/chromashift/src/tests.rs
+++ b/crates/chromashift/src/tests.rs
@@ -91,6 +91,26 @@ macro_rules! assert_all_conversions {
 	};
 }
 
+/// Asserts that an RGB-like type preserves values outside [0,1].
+macro_rules! assert_oog_rgb_preserved {
+	($ty:ident) => {
+		let oog = $ty::new(-0.5, 1.5, -0.3, 100.0);
+		assert_eq!(oog.red, -0.5, "{} red was clamped", stringify!($ty));
+		assert_eq!(oog.green, 1.5, "{} green was clamped", stringify!($ty));
+		assert_eq!(oog.blue, -0.3, "{} blue was clamped", stringify!($ty));
+	};
+}
+
+macro_rules! assert_map_to_gamut {
+	($input:expr, $output:expr) => {
+		assert_map_to_gamut!($input, $output, COLOR_EPSILON);
+	};
+	($input:expr, $output:expr, $tolerance:expr) => {{
+		let mapped = $input.map_to_gamut();
+		assert!(mapped.close_to($output, $tolerance), "{:?} -> {:?}. ΔE = {}", $input, mapped, mapped.delta_e($output),);
+	}};
+}
+
 #[allow(clippy::too_many_arguments)]
 fn test_combos(
 	srgb: Srgb,
@@ -221,202 +241,222 @@ fn text_hex_alpha_conversion() {
 	assert_eq!(Hex::from(Srgb::new(0, 0, 0, 100.0)), Hex::new(0x000000FF));
 }
 
-/// Out-of-gamut colors must be preserved through conversions, not clamped.
-/// CSS Color 4 §12.1, §13.1, §10.1: OOG values are retained for intermediate computations.
-/// Gamut mapping only happens at actual-value time (display time).
-mod out_of_gamut {
-	use super::*;
+#[test]
+fn rgb_types_preserve_oog_values() {
+	assert_oog_rgb_preserved!(LinearRgb);
+	assert_oog_rgb_preserved!(DisplayP3);
+	assert_oog_rgb_preserved!(A98Rgb);
+	assert_oog_rgb_preserved!(ProphotoRgb);
+	assert_oog_rgb_preserved!(Rec2020);
+}
 
-	/// Asserts that an RGB-like type preserves values outside [0,1].
-	macro_rules! assert_oog_rgb_preserved {
-		($ty:ident) => {
-			let oog = $ty::new(-0.5, 1.5, -0.3, 100.0);
-			assert_eq!(oog.red, -0.5, "{} red was clamped", stringify!($ty));
-			assert_eq!(oog.green, 1.5, "{} green was clamped", stringify!($ty));
-			assert_eq!(oog.blue, -0.3, "{} blue was clamped", stringify!($ty));
+#[test]
+fn lab_oklab_preserve_oog_values() {
+	let lab = Lab::new(110.0, 200.0, -200.0, 100.0);
+	assert_eq!(lab.lightness, 110.0);
+	assert_eq!(lab.a, 200.0);
+	assert_eq!(lab.b, -200.0);
+
+	let oklab = Oklab::new(1.5, 0.5, -0.5, 100.0);
+	assert_eq!(oklab.lightness, 1.5);
+	assert_eq!(oklab.a, 0.5);
+	assert_eq!(oklab.b, -0.5);
+}
+
+#[test]
+fn hsl_preserves_oog_values() {
+	// color(display-p3 0 1 0) in HSL is approximately hsl(127.879 301.946 25.334)
+	let oog = Hsl::new(127.0, 301.0, 25.0, 100.0);
+	assert_eq!(oog.saturation, 301.0);
+	assert_eq!(oog.lightness, 25.0);
+}
+
+/// Per CSS Color 4 §4.2, alpha is always clamped to [0,100].
+#[test]
+fn alpha_still_clamped() {
+	macro_rules! assert_alpha_clamped {
+		($color:expr, $expected:expr) => {
+			assert_eq!($color.alpha, $expected);
 		};
 	}
+	assert_alpha_clamped!(LinearRgb::new(0.0, 0.0, 0.0, 150.0), 100.0);
+	assert_alpha_clamped!(LinearRgb::new(0.0, 0.0, 0.0, -10.0), 0.0);
+	assert_alpha_clamped!(DisplayP3::new(0.0, 0.0, 0.0, 150.0), 100.0);
+	assert_alpha_clamped!(Lab::new(0.0, 0.0, 0.0, -10.0), 0.0);
+	assert_alpha_clamped!(Oklch::new(0.0, 0.0, 0.0, 200.0), 100.0);
+}
 
-	#[test]
-	fn rgb_types_preserve_oog_values() {
-		assert_oog_rgb_preserved!(LinearRgb);
-		assert_oog_rgb_preserved!(DisplayP3);
-		assert_oog_rgb_preserved!(A98Rgb);
-		assert_oog_rgb_preserved!(ProphotoRgb);
-		assert_oog_rgb_preserved!(Rec2020);
-	}
+#[test]
+fn display_p3_green_to_linear_rgb_is_oog() {
+	let p3_green = DisplayP3::new(0.0, 1.0, 0.0, 100.0);
+	let linear: LinearRgb = p3_green.into();
+	assert!(linear.red < 0.0, "Expected negative linear red, got {}", linear.red);
+	assert!(linear.blue < 0.0, "Expected negative linear blue, got {}", linear.blue);
+	assert!(linear.green > 1.0, "Expected green > 1.0, got {}", linear.green);
+}
 
-	#[test]
-	fn lab_oklab_preserve_oog_values() {
-		let lab = Lab::new(110.0, 200.0, -200.0, 100.0);
-		assert_eq!(lab.lightness, 110.0);
-		assert_eq!(lab.a, 200.0);
-		assert_eq!(lab.b, -200.0);
+#[test]
+fn display_p3_round_trips_through_xyz() {
+	let original = DisplayP3::new(0.5, 0.7, 0.3, 100.0);
+	let xyz: XyzD65 = original.into();
+	let back: DisplayP3 = xyz.into();
+	assert!(back.close_to(original, COLOR_EPSILON), "Round-trip failed: {:?} vs {:?}", original, back);
+}
 
-		let oklab = Oklab::new(1.5, 0.5, -0.5, 100.0);
-		assert_eq!(oklab.lightness, 1.5);
-		assert_eq!(oklab.a, 0.5);
-		assert_eq!(oklab.b, -0.5);
-	}
+/// WPT: color-mix-out-of-gamut.html
+/// color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0,0,0) 0%) → color(srgb -0.511814 1.01832 -0.310726)
+///
+/// Tests the full OOG chain: DisplayP3 → LinearRgb → Hsl (OOG) → LinearRgb → DisplayP3
+/// The key assertion is that the OOG sRGB float values survive the round-trip through HSL.
+#[test]
+fn wpt_display_p3_green_through_hsl() {
+	let p3_green = DisplayP3::new(0.0, 1.0, 0.0, 100.0);
+	let hsl: Hsl = p3_green.into();
+	// Mix 100%/0% — result is just the first color
+	let mixed = Hsl::mix(hsl, Hsl::new(0.0, 0.0, 0.0, 100.0), 0.0);
+	// Convert to DisplayP3 to check the round-trip
+	let back: DisplayP3 = mixed.into();
+	assert!(back.close_to(p3_green, 0.001), "Expected {:?}, got {:?}", p3_green, back);
+}
 
-	#[test]
-	fn hsl_preserves_oog_values() {
-		// color(display-p3 0 1 0) in HSL is approximately hsl(127.879 301.946 25.334)
-		let oog = Hsl::new(127.0, 301.0, 25.0, 100.0);
-		assert_eq!(oog.saturation, 301.0);
-		assert_eq!(oog.lightness, 25.0);
-	}
+#[test]
+fn in_gamut_rgb_types() {
+	// In-gamut values
+	assert!(LinearRgb::new(0.0, 0.5, 1.0, 100.0).in_gamut());
+	assert!(DisplayP3::new(0.0, 1.0, 0.0, 100.0).in_gamut());
+	assert!(A98Rgb::new(0.5, 0.5, 0.5, 100.0).in_gamut());
+	assert!(ProphotoRgb::new(0.0, 0.0, 0.0, 100.0).in_gamut());
+	assert!(Rec2020::new(1.0, 1.0, 1.0, 100.0).in_gamut());
 
-	/// Per CSS Color 4 §4.2, alpha is always clamped to [0,100].
-	#[test]
-	fn alpha_still_clamped() {
-		macro_rules! assert_alpha_clamped {
-			($color:expr, $expected:expr) => {
-				assert_eq!($color.alpha, $expected);
-			};
-		}
-		assert_alpha_clamped!(LinearRgb::new(0.0, 0.0, 0.0, 150.0), 100.0);
-		assert_alpha_clamped!(LinearRgb::new(0.0, 0.0, 0.0, -10.0), 0.0);
-		assert_alpha_clamped!(DisplayP3::new(0.0, 0.0, 0.0, 150.0), 100.0);
-		assert_alpha_clamped!(Lab::new(0.0, 0.0, 0.0, -10.0), 0.0);
-		assert_alpha_clamped!(Oklch::new(0.0, 0.0, 0.0, 200.0), 100.0);
-	}
+	// OOG values
+	assert!(!LinearRgb::new(-0.1, 0.5, 1.0, 100.0).in_gamut());
+	assert!(!DisplayP3::new(0.0, 1.1, 0.0, 100.0).in_gamut());
+	assert!(!A98Rgb::new(0.5, 0.5, -0.01, 100.0).in_gamut());
+}
 
-	#[test]
-	fn display_p3_green_to_linear_rgb_is_oog() {
-		let p3_green = DisplayP3::new(0.0, 1.0, 0.0, 100.0);
-		let linear: LinearRgb = p3_green.into();
-		assert!(linear.red < 0.0, "Expected negative linear red, got {}", linear.red);
-		assert!(linear.blue < 0.0, "Expected negative linear blue, got {}", linear.blue);
-		assert!(linear.green > 1.0, "Expected green > 1.0, got {}", linear.green);
-	}
+#[test]
+fn in_gamut_lab_oklab() {
+	assert!(Lab::new(50.0, 0.0, 0.0, 100.0).in_gamut());
+	assert!(!Lab::new(110.0, 0.0, 0.0, 100.0).in_gamut());
+	assert!(!Lab::new(50.0, 200.0, 0.0, 100.0).in_gamut());
 
-	#[test]
-	fn display_p3_round_trips_through_xyz() {
-		let original = DisplayP3::new(0.5, 0.7, 0.3, 100.0);
-		let xyz: XyzD65 = original.into();
-		let back: DisplayP3 = xyz.into();
-		assert!(back.close_to(original, COLOR_EPSILON), "Round-trip failed: {:?} vs {:?}", original, back);
-	}
+	assert!(Oklab::new(0.5, 0.0, 0.0, 100.0).in_gamut());
+	assert!(!Oklab::new(1.5, 0.0, 0.0, 100.0).in_gamut());
+	assert!(!Oklab::new(0.5, 0.5, 0.0, 100.0).in_gamut());
+}
 
-	/// WPT: color-mix-out-of-gamut.html
-	/// color-mix(in hsl, color(display-p3 0 1 0) 100%, rgb(0,0,0) 0%) → color(srgb -0.511814 1.01832 -0.310726)
-	///
-	/// Tests the full OOG chain: DisplayP3 → LinearRgb → Hsl (OOG) → LinearRgb → DisplayP3
-	/// The key assertion is that the OOG sRGB float values survive the round-trip through HSL.
-	#[test]
-	fn wpt_display_p3_green_through_hsl() {
-		let p3_green = DisplayP3::new(0.0, 1.0, 0.0, 100.0);
-		let hsl: Hsl = p3_green.into();
-		// Mix 100%/0% — result is just the first color
-		let mixed = Hsl::mix(hsl, Hsl::new(0.0, 0.0, 0.0, 100.0), 0.0);
-		// Convert to DisplayP3 to check the round-trip
-		let back: DisplayP3 = mixed.into();
-		assert!(back.close_to(p3_green, 0.001), "Expected {:?}, got {:?}", p3_green, back);
-	}
+#[test]
+fn in_gamut_lch_oklch() {
+	assert!(Lch::new(50.0, 75.0, 180.0, 100.0).in_gamut());
+	assert!(!Lch::new(-1.0, 75.0, 180.0, 100.0).in_gamut());
+	assert!(!Lch::new(50.0, 200.0, 180.0, 100.0).in_gamut());
 
-	#[test]
-	fn in_gamut_rgb_types() {
-		// In-gamut values
-		assert!(LinearRgb::new(0.0, 0.5, 1.0, 100.0).in_gamut());
-		assert!(DisplayP3::new(0.0, 1.0, 0.0, 100.0).in_gamut());
-		assert!(A98Rgb::new(0.5, 0.5, 0.5, 100.0).in_gamut());
-		assert!(ProphotoRgb::new(0.0, 0.0, 0.0, 100.0).in_gamut());
-		assert!(Rec2020::new(1.0, 1.0, 1.0, 100.0).in_gamut());
+	assert!(Oklch::new(0.5, 0.2, 180.0, 100.0).in_gamut());
+	assert!(!Oklch::new(0.5, 0.5, 180.0, 100.0).in_gamut());
+}
 
-		// OOG values
-		assert!(!LinearRgb::new(-0.1, 0.5, 1.0, 100.0).in_gamut());
-		assert!(!DisplayP3::new(0.0, 1.1, 0.0, 100.0).in_gamut());
-		assert!(!A98Rgb::new(0.5, 0.5, -0.01, 100.0).in_gamut());
-	}
+#[test]
+fn in_gamut_hsl_hwb() {
+	assert!(Hsl::new(180.0, 50.0, 50.0, 100.0).in_gamut());
+	assert!(!Hsl::new(180.0, 301.0, 50.0, 100.0).in_gamut());
 
-	#[test]
-	fn in_gamut_lab_oklab() {
-		assert!(Lab::new(50.0, 0.0, 0.0, 100.0).in_gamut());
-		assert!(!Lab::new(110.0, 0.0, 0.0, 100.0).in_gamut());
-		assert!(!Lab::new(50.0, 200.0, 0.0, 100.0).in_gamut());
+	assert!(Hwb::new(180.0, 20.0, 20.0, 100.0).in_gamut());
+	assert!(!Hwb::new(180.0, -10.0, 20.0, 100.0).in_gamut());
+}
 
-		assert!(Oklab::new(0.5, 0.0, 0.0, 100.0).in_gamut());
-		assert!(!Oklab::new(1.5, 0.0, 0.0, 100.0).in_gamut());
-		assert!(!Oklab::new(0.5, 0.5, 0.0, 100.0).in_gamut());
-	}
+#[test]
+fn in_gamut_always_in_gamut_types() {
+	// Srgb (u8), Hex (u32), and Hsv (clamps in constructor) are always in gamut
+	assert!(Srgb::new(255, 0, 128, 100.0).in_gamut());
+	assert!(Hex::new(0xFF00FFFF).in_gamut());
+	assert!(Hsv::new(180.0, 100.0, 100.0, 100.0).in_gamut());
+}
 
-	#[test]
-	fn in_gamut_lch_oklch() {
-		assert!(Lch::new(50.0, 75.0, 180.0, 100.0).in_gamut());
-		assert!(!Lch::new(-1.0, 75.0, 180.0, 100.0).in_gamut());
-		assert!(!Lch::new(50.0, 200.0, 180.0, 100.0).in_gamut());
+#[test]
+fn clamp_to_gamut_rgb_types() {
+	let oog = LinearRgb::new(-0.5, 1.5, 0.5, 100.0);
+	let clamped = oog.clamp_to_gamut();
+	assert!(clamped.in_gamut());
+	assert_eq!(clamped.red, 0.0);
+	assert_eq!(clamped.green, 1.0);
+	assert_eq!(clamped.blue, 0.5);
+	assert_eq!(clamped.alpha, 100.0);
+}
 
-		assert!(Oklch::new(0.5, 0.2, 180.0, 100.0).in_gamut());
-		assert!(!Oklch::new(0.5, 0.5, 180.0, 100.0).in_gamut());
-	}
+#[test]
+fn clamp_to_gamut_lab() {
+	let oog = Lab::new(110.0, 200.0, -200.0, 100.0);
+	let clamped = oog.clamp_to_gamut();
+	assert!(clamped.in_gamut());
+	assert_eq!(clamped.lightness, 100.0);
+	assert_eq!(clamped.a, 125.0);
+	assert_eq!(clamped.b, -125.0);
+}
 
-	#[test]
-	fn in_gamut_hsl_hwb() {
-		assert!(Hsl::new(180.0, 50.0, 50.0, 100.0).in_gamut());
-		assert!(!Hsl::new(180.0, 301.0, 50.0, 100.0).in_gamut());
+#[test]
+fn clamp_to_gamut_hsl() {
+	let oog = Hsl::new(127.0, 301.0, -10.0, 100.0);
+	let clamped = oog.clamp_to_gamut();
+	assert!(clamped.in_gamut());
+	assert_eq!(clamped.saturation, 100.0);
+	assert_eq!(clamped.lightness, 0.0);
+}
 
-		assert!(Hwb::new(180.0, 20.0, 20.0, 100.0).in_gamut());
-		assert!(!Hwb::new(180.0, -10.0, 20.0, 100.0).in_gamut());
-	}
+#[test]
+fn clamp_to_gamut_preserves_already_in_gamut() {
+	let color = DisplayP3::new(0.5, 0.7, 0.3, 80.0);
+	let clamped = color.clamp_to_gamut();
+	assert_eq!(clamped, color);
+}
 
-	#[test]
-	fn in_gamut_always_in_gamut_types() {
-		// Srgb (u8), Hex (u32), and Hsv (clamps in constructor) are always in gamut
-		assert!(Srgb::new(255, 0, 128, 100.0).in_gamut());
-		assert!(Hex::new(0xFF00FFFF).in_gamut());
-		assert!(Hsv::new(180.0, 100.0, 100.0, 100.0).in_gamut());
-	}
+/// Display P3 green is OOG when viewed as sRGB linear.
+/// clamp_to_gamut in LinearRgb should clip the negative channels.
+#[test]
+fn display_p3_green_clamped_in_linear_rgb() {
+	let p3_green = DisplayP3::new(0.0, 1.0, 0.0, 100.0);
+	let linear: LinearRgb = p3_green.into();
+	assert!(!linear.in_gamut());
+	let clamped = linear.clamp_to_gamut();
+	assert!(clamped.in_gamut());
+	assert_eq!(clamped.red, 0.0);
+	assert_eq!(clamped.blue, 0.0);
+}
 
-	#[test]
-	fn clamp_to_gamut_rgb_types() {
-		let oog = LinearRgb::new(-0.5, 1.5, 0.5, 100.0);
-		let clamped = oog.clamp_to_gamut();
-		assert!(clamped.in_gamut());
-		assert_eq!(clamped.red, 0.0);
-		assert_eq!(clamped.green, 1.0);
-		assert_eq!(clamped.blue, 0.5);
-		assert_eq!(clamped.alpha, 100.0);
-	}
+#[test]
+fn map_to_gamut_already_in_gamut() {
+	let color = DisplayP3::new(0.5, 0.3, 0.7, 100.0);
+	let mapped = color.map_to_gamut();
+	assert!(mapped.in_gamut());
+	assert!(mapped.close_to(color, COLOR_EPSILON));
+}
 
-	#[test]
-	fn clamp_to_gamut_lab() {
-		let oog = Lab::new(110.0, 200.0, -200.0, 100.0);
-		let clamped = oog.clamp_to_gamut();
-		assert!(clamped.in_gamut());
-		assert_eq!(clamped.lightness, 100.0);
-		assert_eq!(clamped.a, 125.0);
-		assert_eq!(clamped.b, -125.0);
-	}
+#[test]
+fn map_to_gamut_outside_gamut_oklch() {
+	let mapped_311 = Oklch::new(0.8, 0.436, 311.0, 100.0).map_to_gamut();
+	assert!(
+		mapped_311.close_to(Oklch::new(0.8, 0.13820, 311.0, 100.0), COLOR_EPSILON),
+		"oklch(80% 109% 311) mapped: {:?}",
+		mapped_311,
+	);
+	let mapped_87 = Oklch::new(0.8, 0.436, 87.0, 100.0).map_to_gamut();
+	assert!(
+		mapped_87.close_to(Oklch::new(0.8, 0.16362, 87.0, 100.0), COLOR_EPSILON),
+		"oklch(80% 109% 87) mapped: {:?}",
+		mapped_87,
+	);
+}
 
-	#[test]
-	fn clamp_to_gamut_hsl() {
-		let oog = Hsl::new(127.0, 301.0, -10.0, 100.0);
-		let clamped = oog.clamp_to_gamut();
-		assert!(clamped.in_gamut());
-		assert_eq!(clamped.saturation, 100.0);
-		assert_eq!(clamped.lightness, 0.0);
-	}
-
-	#[test]
-	fn clamp_to_gamut_preserves_already_in_gamut() {
-		let color = DisplayP3::new(0.5, 0.7, 0.3, 80.0);
-		let clamped = color.clamp_to_gamut();
-		assert_eq!(clamped, color);
-	}
-
-	/// Display P3 green is OOG when viewed as sRGB linear.
-	/// clamp_to_gamut in LinearRgb should clip the negative channels.
-	#[test]
-	fn display_p3_green_clamped_in_linear_rgb() {
-		let p3_green = DisplayP3::new(0.0, 1.0, 0.0, 100.0);
-		let linear: LinearRgb = p3_green.into();
-		assert!(!linear.in_gamut());
-		let clamped = linear.clamp_to_gamut();
-		assert!(clamped.in_gamut());
-		assert_eq!(clamped.red, 0.0);
-		assert_eq!(clamped.blue, 0.0);
-	}
+#[test]
+fn test_map_to_gamut_okclh_hex() {
+	assert_map_to_gamut!(Oklch::new(0.8, 0.436, 87.0, 100.0), Hex::new(0xebb500FF));
+	assert_map_to_gamut!(Oklch::new(0.8, 1.5, 113.0, 100.0), Hex::new(0xbfc800FF));
+	assert_map_to_gamut!(Oklch::new(0.95, 0.4, 150.0, 100.0), Hex::new(0xc7ffd1FF));
+	assert_map_to_gamut!(Oklch::new(0.95, 0.35, 30.0, 100.0), Hex::new(0xffe9e5FF));
+	assert_map_to_gamut!(Oklch::new(0.85, 0.4, 270.0, 100.0), Hex::new(0xbbccffFF));
+	assert_map_to_gamut!(Oklch::new(0.7, 0.45, 330.0, 100.0), Hex::new(0xff12f7FF));
+	assert_map_to_gamut!(Oklch::new(0.8, 0.38, 90.0, 100.0), Hex::new(0xe6b700FF));
+	assert_map_to_gamut!(Oklch::new(0.6, 0.42, 300.0, 100.0), Hex::new(0x9c44ffFF));
+	assert_map_to_gamut!(Oklch::new(0.75, 0.40, 180.0, 100.0), Hex::new(0x00c9b1FF));
 }
 
 #[test]


### PR DESCRIPTION
This change adds an additional function to the Gamut trait, allowing colors to
map to a gamut using one of the css-color-4 algorithms, instead of simple
clamping. I chose the Ray Trace algorithm for mapping as we can copy the
algorithm quite easily, and it seems the simplest to implement. EdgeSeeker might
be a better choice (faster due to LUTs) but requires more work and this is
honestly enough work already.
