### PR TITLE
css_parse: Add BumpBox type and blanket trait impls for Box types

### DIFF
--- a/crates/css_parse/src/bump_box.rs
+++ b/crates/css_parse/src/bump_box.rs
@@ -1,0 +1,117 @@
+use crate::{CursorSink, SemanticEq, ToCursors};
+use bumpalo::Bump;
+use css_lexer::{Span, ToSpan};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::{Deref, DerefMut};
+
+/// An arena-allocated box that retains a reference to its [`Bump`] allocator, enabling [`Clone`] support.
+///
+/// Unlike [`bumpalo::boxed::Box`], which only stores a mutable reference to the allocated value (and thus cannot
+/// implement [`Clone`] without the allocator), `BumpBox` stores both the allocator reference and the value pointer.
+/// This allows it to allocate a new copy during [`Clone::clone`].
+///
+/// This type is intended for recursive AST nodes (e.g. `color-mix()` containing nested `<color>` values) where
+/// indirection is required to break the cycle, but the allocation should still live in the parsing arena.
+pub struct BumpBox<'a, T> {
+	bump: &'a Bump,
+	ptr: &'a mut T,
+}
+
+impl<'a, T> BumpBox<'a, T> {
+	/// Allocates a new value in the given bump allocator.
+	#[inline]
+	pub fn new_in(bump: &'a Bump, value: T) -> Self {
+		Self { bump, ptr: bump.alloc(value) }
+	}
+}
+
+impl<T> Deref for BumpBox<'_, T> {
+	type Target = T;
+
+	#[inline]
+	fn deref(&self) -> &T {
+		self.ptr
+	}
+}
+
+impl<T> DerefMut for BumpBox<'_, T> {
+	#[inline]
+	fn deref_mut(&mut self) -> &mut T {
+		self.ptr
+	}
+}
+
+impl<T: Clone> Clone for BumpBox<'_, T> {
+	fn clone(&self) -> Self {
+		let cloned = self.ptr.clone();
+		Self { bump: self.bump, ptr: self.bump.alloc(cloned) }
+	}
+}
+
+impl<T: fmt::Debug> fmt::Debug for BumpBox<'_, T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt::Debug::fmt(&**self, f)
+	}
+}
+
+impl<T: PartialEq> PartialEq for BumpBox<'_, T> {
+	fn eq(&self, other: &Self) -> bool {
+		(**self).eq(&**other)
+	}
+}
+
+impl<T: Eq> Eq for BumpBox<'_, T> {}
+
+impl<T: PartialOrd> PartialOrd for BumpBox<'_, T> {
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		(**self).partial_cmp(&**other)
+	}
+}
+
+impl<T: Ord> Ord for BumpBox<'_, T> {
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+		(**self).cmp(&**other)
+	}
+}
+
+impl<T: Hash> Hash for BumpBox<'_, T> {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		(**self).hash(state)
+	}
+}
+
+impl<T: ToCursors> ToCursors for BumpBox<'_, T> {
+	fn to_cursors(&self, s: &mut impl CursorSink) {
+		(**self).to_cursors(s);
+	}
+}
+
+impl<T: SemanticEq> SemanticEq for BumpBox<'_, T> {
+	fn semantic_eq(&self, other: &Self) -> bool {
+		(**self).semantic_eq(other)
+	}
+}
+
+impl<T: ToSpan> ToSpan for BumpBox<'_, T> {
+	fn to_span(&self) -> Span {
+		(**self).to_span()
+	}
+}
+
+impl<M: crate::NodeMetadata, T: crate::NodeWithMetadata<M>> crate::NodeWithMetadata<M> for BumpBox<'_, T> {
+	fn self_metadata(&self) -> M {
+		(**self).self_metadata()
+	}
+
+	fn metadata(&self) -> M {
+		(**self).metadata()
+	}
+}
+
+#[cfg(feature = "serde")]
+impl<T: serde::Serialize> serde::Serialize for BumpBox<'_, T> {
+	fn serialize<S: serde::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+		(**self).serialize(serializer)
+	}
+}

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -282,6 +282,7 @@ pub use css_lexer::{
 	SourceOffset, Span, ToSpan, Token, Whitespace,
 };
 
+mod bump_box;
 mod comparison;
 mod cursor_compact_write_sink;
 #[cfg(feature = "egg")]
@@ -309,6 +310,7 @@ mod traits;
 
 pub type Result<T> = std::result::Result<T, diagnostics::Diagnostic>;
 
+pub use bump_box::*;
 pub use comparison::*;
 pub use cursor_compact_write_sink::*;
 #[cfg(feature = "egg")]


### PR DESCRIPTION
Currently we cannot use bumpal's `Box` for a couple of reasons: chiefly that it
doesn't support `Clone` which means if we tried to use it we'd have a cascading
set of derive(Clone)s to remove all the way up to Stylesheet.

This change introduces `BumpBox<'a, T>`, an arena-allocated box that retains the
allocator reference, enabling Clone by re-allocating in the same arena. Unlike
bumpalo Box (which only stores &'a mut T), BumpBox stores both &'a Bump and
&'a mut T, making it compatible with derive(Clone).