### PR TITLE
css_ast: Boxup more types

### DIFF
--- a/crates/css_ast/src/functions/gradient_functions.rs
+++ b/crates/css_ast/src/functions/gradient_functions.rs
@@ -1,3 +1,5 @@
+use css_parse::BumpBox;
+
 use super::prelude::*;
 use crate::{Length, LengthPercentage};
 
@@ -15,9 +17,9 @@ pub enum Gradient<'a> {
 	#[atom(CssAtomSet::RepeatingLinearGradient)]
 	RepeatingLinearGradientFunction(RepeatingLinearGradientFunction<'a>),
 	#[atom(CssAtomSet::RadialGradient)]
-	RadialGradientFunction(RadialGradientFunction<'a>),
+	RadialGradientFunction(BumpBox<'a, RadialGradientFunction<'a>>),
 	#[atom(CssAtomSet::RepeatingRadialGradient)]
-	RepeatingRadialGradientFunction(RepeatingRadialGradientFunction<'a>),
+	RepeatingRadialGradientFunction(BumpBox<'a, RepeatingRadialGradientFunction<'a>>),
 }
 
 /// <https://drafts.csswg.org/css-images-3/#funcdef-linear-gradient>
@@ -241,7 +243,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<Gradient>(), 208);
+		assert_eq!(std::mem::size_of::<Gradient>(), 128);
 		assert_eq!(std::mem::size_of::<LinearDirection>(), 44);
 		assert_eq!(std::mem::size_of::<RadialSize>(), 32);
 		assert_eq!(std::mem::size_of::<ColorStopOrHint<'_>>(), 160);

--- a/crates/css_ast/src/functions/symbols_function.rs
+++ b/crates/css_ast/src/functions/symbols_function.rs
@@ -59,7 +59,6 @@ pub enum SymbolsType {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 #[derive(csskit_derives::NodeWithMetadata)]
-#[allow(clippy::large_enum_variant)] // TODO: Box or shrink Image
 pub enum Symbol<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	String(T![String]),
@@ -75,7 +74,7 @@ mod tests {
 	#[test]
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<SymbolsFunction>(), 72);
-		assert_eq!(std::mem::size_of::<Symbol>(), 208);
+		assert_eq!(std::mem::size_of::<Symbol>(), 128);
 		assert_eq!(std::mem::size_of::<SymbolsType>(), 16);
 	}
 

--- a/crates/css_ast/src/functions/transform_functions.rs
+++ b/crates/css_ast/src/functions/transform_functions.rs
@@ -1,15 +1,15 @@
 use super::prelude::*;
 use crate::{AngleOrZero, Length, LengthPercentage, NoneOr, NumberOrPercentage};
+use css_parse::BumpBox;
 
 // https://drafts.csswg.org/css-transforms-1/#two-d-transform-functions
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]
-#[allow(clippy::large_enum_variant)] // TODO: matrix3d should probably be boxed
-pub enum TransformFunction {
+pub enum TransformFunction<'a> {
 	Matrix(MatrixFunction),
-	Matrix3d(Matrix3dFunction),
+	Matrix3d(BumpBox<'a, Matrix3dFunction>),
 	Translate(TranslateFunction),
 	Translate3d(Translate3dFunction),
 	TranslateX(TranslatexFunction),
@@ -462,7 +462,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<TransformFunction>(), 456);
+		assert_eq!(std::mem::size_of::<TransformFunction>(), 176);
 	}
 
 	#[test]

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -445,8 +445,8 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<Property>(), 488);
-		assert_eq!(std::mem::size_of::<StyleValue>(), 416);
+		assert_eq!(std::mem::size_of::<Property>(), 368);
+		assert_eq!(std::mem::size_of::<StyleValue>(), 296);
 	}
 
 	#[test]

--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -1,6 +1,6 @@
 use super::super::prelude::*;
 use crate::{types::Ratio, units::Length};
-use css_parse::{discrete_feature, ranged_feature};
+use css_parse::{BumpBox, discrete_feature, ranged_feature};
 
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -72,13 +72,12 @@ pub enum StyleQuery<'a> {
 	Or(Vec<'a, (StyleFeature<'a>, Option<T![Ident]>)>),
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum StyleFeature<'a> {
-	Declaration(Declaration<'a, StyleValue<'a>, CssMetadata>),
+	Declaration(BumpBox<'a, Declaration<'a, StyleValue<'a>, CssMetadata>>),
 	CustomProperty(T![Ident]),
 }
 
@@ -91,7 +90,8 @@ impl<'a> Parse<'a> for StyleFeature<'a> {
 		if c == Kind::Ident && c.token().is_dashed_ident() && p.peek_n(2) != Kind::Colon {
 			return Ok(Self::CustomProperty(p.parse::<T![Ident]>()?));
 		}
-		Ok(Self::Declaration(p.parse::<Declaration<'a, StyleValue<'a>, CssMetadata>>()?))
+		let decl = p.parse::<Declaration<'a, StyleValue<'a>, CssMetadata>>()?;
+		Ok(Self::Declaration(BumpBox::new_in(p.bump(), decl)))
 	}
 }
 
@@ -372,7 +372,7 @@ mod tests {
 		assert_eq!(std::mem::size_of::<BlockSizeContainerFeature>(), 124);
 		assert_eq!(std::mem::size_of::<AspectRatioContainerFeature>(), 180);
 		assert_eq!(std::mem::size_of::<OrientationContainerFeature>(), 64);
-		assert_eq!(std::mem::size_of::<StyleQuery>(), 504);
+		assert_eq!(std::mem::size_of::<StyleQuery>(), 40);
 		assert_eq!(std::mem::size_of::<ScrollStateQuery>(), 96);
 		assert_eq!(std::mem::size_of::<ScrollStateFeature>(), 80);
 	}

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -137,7 +137,6 @@ impl<'a> FeatureConditionList<'a> for ContainerQuery<'a> {
 
 macro_rules! container_feature {
 	( $($name: ident($typ: ident))+ ) => {
-		#[allow(clippy::large_enum_variant)] // TODO: refine
 		#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
@@ -246,8 +245,8 @@ mod tests {
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<ContainerRule>(), 144);
 		assert_eq!(std::mem::size_of::<ContainerConditionList>(), 32);
-		assert_eq!(std::mem::size_of::<ContainerCondition>(), 560);
-		assert_eq!(std::mem::size_of::<ContainerQuery>(), 544);
+		assert_eq!(std::mem::size_of::<ContainerCondition>(), 216);
+		assert_eq!(std::mem::size_of::<ContainerQuery>(), 200);
 	}
 
 	#[test]

--- a/crates/css_ast/src/rules/counter_style.rs
+++ b/crates/css_ast/src/rules/counter_style.rs
@@ -231,15 +231,15 @@ mod tests {
 		assert_eq!(std::mem::size_of::<CounterStyleRule>(), 128);
 		assert_eq!(std::mem::size_of::<CounterStyleName>(), 12);
 		assert_eq!(std::mem::size_of::<CounterStyleRuleBlock>(), 96);
-		assert_eq!(std::mem::size_of::<CounterStyleRuleStyleValue>(), 416);
+		assert_eq!(std::mem::size_of::<CounterStyleRuleStyleValue>(), 256);
 		assert_eq!(std::mem::size_of::<AdditiveSymbolsStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<FallbackStyleValue>(), 12);
-		assert_eq!(std::mem::size_of::<NegativeStyleValue>(), 416);
-		assert_eq!(std::mem::size_of::<PadStyleValue>(), 224);
-		assert_eq!(std::mem::size_of::<PrefixStyleValue>(), 208);
+		assert_eq!(std::mem::size_of::<NegativeStyleValue>(), 256);
+		assert_eq!(std::mem::size_of::<PadStyleValue>(), 144);
+		assert_eq!(std::mem::size_of::<PrefixStyleValue>(), 128);
 		// assert_eq!(std::mem::size_of::<RangeStyleValue>(), 1);
 		assert_eq!(std::mem::size_of::<SpeakAsStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<SuffixStyleValue>(), 208);
+		assert_eq!(std::mem::size_of::<SuffixStyleValue>(), 128);
 		assert_eq!(std::mem::size_of::<SymbolsStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<SystemStyleValue>(), 28);
 	}

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -99,7 +99,7 @@ mod tests {
 	#[test]
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<FontFaceRule>(), 112);
-		assert_eq!(std::mem::size_of::<FontFaceRuleStyleValue>(), 416);
+		assert_eq!(std::mem::size_of::<FontFaceRuleStyleValue>(), 296);
 		assert_eq!(std::mem::size_of::<FontFaceRuleBlock>(), 96);
 	}
 

--- a/crates/css_ast/src/rules/import.rs
+++ b/crates/css_ast/src/rules/import.rs
@@ -72,7 +72,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<ImportRule>(), 744);
+		assert_eq!(std::mem::size_of::<ImportRule>(), 320);
 	}
 
 	#[test]

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
 use crate::selector::ComplexSelector;
+use css_parse::BumpBox;
 
 ///
 /// ```md
@@ -110,7 +111,6 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
 	}
 }
 
-#[allow(clippy::large_enum_variant)] // TODO: Box?
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
@@ -139,7 +139,7 @@ pub enum SupportsFeature<'a> {
 	),
 	Property(
 		#[cfg_attr(feature = "visitable", visit(skip))] T!['('],
-		Declaration<'a, StyleValue<'a>, CssMetadata>,
+		BumpBox<'a, Declaration<'a, StyleValue<'a>, CssMetadata>>,
 		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![')']>,
 	),
 }
@@ -192,7 +192,7 @@ impl<'a> Parse<'a> for SupportsFeature<'a> {
 		} else if let Some(open) = open {
 			let property = p.parse::<Declaration<'a, StyleValue<'a>, CssMetadata>>()?;
 			let close = p.parse_if_peek::<T![')']>()?;
-			Ok(Self::Property(open, property, close))
+			Ok(Self::Property(open, BumpBox::new_in(p.bump(), property), close))
 		} else {
 			Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?
 		}
@@ -207,8 +207,8 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<SupportsRule>(), 656);
-		assert_eq!(std::mem::size_of::<SupportsCondition>(), 536);
+		assert_eq!(std::mem::size_of::<SupportsRule>(), 224);
+		assert_eq!(std::mem::size_of::<SupportsCondition>(), 112);
 		assert_eq!(std::mem::size_of::<SupportsRuleBlock>(), 96);
 	}
 

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -3,7 +3,7 @@ use crate::{
 	rules,
 };
 use css_parse::{
-	Cursor, DeclarationGroup, Diagnostic, NodeMetadata, NodeWithMetadata, Parse, Parser, QualifiedRule,
+	BumpBox, Cursor, DeclarationGroup, Diagnostic, NodeMetadata, NodeWithMetadata, Parse, Parser, QualifiedRule,
 	Result as ParserResult, RuleVariants,
 };
 use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
@@ -45,7 +45,6 @@ macro_rules! apply_rules {
 			Layer(LayerRule<'a>): "layer",
 			Media(MediaRule<'a>): "media",
 			Scope(ScopeRule): "scope",
-			Supports(SupportsRule<'a>): "supports",
 		}
 	};
 }
@@ -54,7 +53,6 @@ macro_rules! nested_group_rule {
     ( $(
         $name: ident($ty: ident$(<$a: lifetime>)?): $str: pat,
     )+ ) => {
-		#[allow(clippy::large_enum_variant)] // TODO: Box?
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
 		#[derive(ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
@@ -65,6 +63,7 @@ macro_rules! nested_group_rule {
 			$(
 				$name(rules::$ty$(<$a>)?),
 			)+
+			Supports(BumpBox<'a, rules::SupportsRule<'a>>),
 			UnknownAt(UnknownAtRule<'a>),
 			Style(StyleRule<'a>),
 			Unknown(UnknownQualifiedRule<'a>),
@@ -88,6 +87,7 @@ impl<'a> RuleVariants<'a> for NestedGroupRule<'a> {
 			)+ ) => {
 				match p.to_atom::<CssAtomSet>(name) {
 					$(CssAtomSet::$name => p.parse::<rules::$ty>().map(Self::$name),)+
+					CssAtomSet::Supports => p.parse::<rules::SupportsRule>().map(|r| Self::Supports(BumpBox::new_in(p.bump(), r))),
 					_ => Err(Diagnostic::new(name.into(), Diagnostic::unexpected_at_rule))?,
 				}
 			}

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -1,8 +1,8 @@
 use crate::{CssAtomSet, CssMetadata, StyleValue, rules, stylerule::StyleRule};
 use bumpalo::collections::Vec;
 use css_parse::{
-	ComponentValues, Cursor, Diagnostic, NodeWithMetadata, Parse, Parser, QualifiedRule, Result as ParserResult,
-	RuleVariants, StyleSheet as StyleSheetTrait, T, UnknownRuleBlock,
+	BumpBox, ComponentValues, Cursor, Diagnostic, NodeWithMetadata, Parse, Parser, QualifiedRule,
+	Result as ParserResult, RuleVariants, StyleSheet as StyleSheetTrait, T, UnknownRuleBlock,
 };
 use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
 
@@ -52,7 +52,6 @@ macro_rules! apply_rules {
 			FontFace(FontFaceRule<'a>): CssAtomSet::FontFace,
 			FontFeatureValues(FontFeatureValuesRule): CssAtomSet::FontFeatureValues,
 			FontPaletteValues(FontPaletteValuesRule): CssAtomSet::FontPaletteValues,
-			Import(ImportRule<'a>): CssAtomSet::Import,
 			Keyframes(KeyframesRule<'a>): CssAtomSet::Keyframes,
 			Layer(LayerRule<'a>): CssAtomSet::Layer,
 			Media(MediaRule<'a>): CssAtomSet::Media,
@@ -61,7 +60,6 @@ macro_rules! apply_rules {
 			Property(PropertyRule<'a>): CssAtomSet::Property,
 			Scope(ScopeRule): CssAtomSet::Scope,
 			StartingStyle(StartingStyleRule<'a>): CssAtomSet::StartingStyle,
-			Supports(SupportsRule<'a>): CssAtomSet::Supports,
 
 			// Deprecated Rules
 			Document(DocumentRule<'a>): CssAtomSet::Document,
@@ -106,7 +104,6 @@ macro_rules! rule {
     ( $(
         $name: ident($ty: ident$(<$a: lifetime>)?): $str: pat,
     )+ ) => {
-		#[allow(clippy::large_enum_variant)] // TODO: Box?
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
 		#[derive(ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
@@ -117,6 +114,10 @@ macro_rules! rule {
 			$(
 				$name(rules::$ty$(<$a>)?),
 			)+
+			// Boxed variants for rarely used rules
+			Import(BumpBox<'a, rules::ImportRule<'a>>),
+			Supports(BumpBox<'a, rules::SupportsRule<'a>>),
+
 			UnknownAt(UnknownAtRule<'a>),
 			Style(StyleRule<'a>),
 			Unknown(UnknownQualifiedRule<'a>)
@@ -140,6 +141,8 @@ impl<'a> RuleVariants<'a> for Rule<'a> {
 			)+ ) => {
 				match p.to_atom::<CssAtomSet>(c) {
 					$($atoms => p.parse::<rules::$ty>().map(Self::$name),)+
+					CssAtomSet::Import => p.parse::<rules::ImportRule>().map(|r| Self::Import(BumpBox::new_in(p.bump(), r))),
+					CssAtomSet::Supports => p.parse::<rules::SupportsRule>().map(|r| Self::Supports(BumpBox::new_in(p.bump(), r))),
 					_ => Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?,
 				}
 			}
@@ -187,7 +190,7 @@ mod tests {
 	#[test]
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<StyleSheet>(), 64);
-		assert_eq!(std::mem::size_of::<Rule>(), 752);
+		assert_eq!(std::mem::size_of::<Rule>(), 208);
 	}
 
 	#[test]

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -52,7 +52,7 @@ mod tests {
 	#[test]
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<ContentList>(), 32);
-		assert_eq!(std::mem::size_of::<ContentListItem>(), 208);
+		assert_eq!(std::mem::size_of::<ContentListItem>(), 184);
 	}
 
 	#[test]

--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -24,7 +24,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<Image>(), 208);
+		assert_eq!(std::mem::size_of::<Image>(), 128);
 	}
 
 	#[test]

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -8,7 +8,7 @@ use crate::TransformFunction;
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]
-pub struct TransformList<'a>(pub Vec<'a, TransformFunction>);
+pub struct TransformList<'a>(pub Vec<'a, TransformFunction<'a>>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/values/borders/impls.rs
+++ b/crates/css_ast/src/values/borders/impls.rs
@@ -92,7 +92,7 @@ mod tests {
 		assert_eq!(std::mem::size_of::<BoxShadowSpreadStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<BoxShadowPositionStyleValue>(), 32);
 		// assert_eq!(std::mem::size_of::<BoxShadowStyleValue>(), 1);
-		assert_eq!(std::mem::size_of::<BorderImageSourceStyleValue>(), 208);
+		assert_eq!(std::mem::size_of::<BorderImageSourceStyleValue>(), 128);
 		// assert_eq!(std::mem::size_of::<BorderImageSliceStyleValue>(), 1);
 		// assert_eq!(std::mem::size_of::<BorderImageWidthStyleValue>(), 1);
 		assert_eq!(std::mem::size_of::<BorderImageOutsetStyleValue>(), 64);

--- a/crates/css_parse/src/bump_box.rs
+++ b/crates/css_parse/src/bump_box.rs
@@ -1,6 +1,6 @@
 use crate::{Cursor, CursorSink, Parse, Parser, Peek, SemanticEq, ToCursors};
 use bumpalo::Bump;
-use css_lexer::{Span, ToSpan};
+use css_lexer::{KindSet, Span, ToSpan};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
@@ -110,6 +110,8 @@ impl<M: crate::NodeMetadata, T: crate::NodeWithMetadata<M>> crate::NodeWithMetad
 }
 
 impl<'a, T: Peek<'a>> Peek<'a> for BumpBox<'a, T> {
+	const PEEK_KINDSET: KindSet = T::PEEK_KINDSET;
+
 	fn peek<I>(p: &Parser<'a, I>, c: Cursor) -> bool
 	where
 		I: Iterator<Item = Cursor> + Clone,

--- a/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
+++ b/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/csskit_source_finder/src/lib.rs
+assertion_line: 209
 expression: "matches.iter().map(|node|\nnode.input.to_token_stream().to_string()).sorted().collect::<Vec<_>>()"
 ---
 [
@@ -393,7 +394,7 @@ expression: "matches.iter().map(|node|\nnode.input.to_token_stream().to_string()
   "pub enum TimelineScopeStyleValue < \'a > { }",
   "pub enum Todo { }",
   "pub enum TransformBoxStyleValue { }",
-  "pub enum TransformFunction { }",
+  "pub enum TransformFunction < \'a > { }",
   "pub enum TransformStyleStyleValue { }",
   "pub enum TransitionBehaviorValue { }",
   "pub enum TriggerScopeStyleValue < \'a > { }",

--- a/crates/csskit_transform/src/css_minifier.rs
+++ b/crates/csskit_transform/src/css_minifier.rs
@@ -43,6 +43,7 @@ mod tests {
 			let mut overlay_stream =
 				CursorOverlaySink::new(source_text, &*overlays, CursorCompactWriteSink::new(source_text, &mut output));
 			result.output.to_cursors(&mut overlay_stream);
+			drop(overlay_stream);
 			(output.clone(), changed)
 		} else {
 			panic!("Could not transform output");


### PR DESCRIPTION
Now we have BumpBox (introduced in #888) we can boxup rarely used types to avoid
`large_enum_variant` warnings (which actually hamper performance).
