### PR TITLE
chromashift: Increase precision of display-p3 to sRGB conversion

### DIFF
--- a/crates/chromashift/src/conversion.rs
+++ b/crates/chromashift/src/conversion.rs
@@ -36,33 +36,33 @@ simple_from!(A98Rgb to Srgb, via LinearRgb);
 simple_from!(A98Rgb to XyzD50, via LinearRgb);
 simple_from!(A98Rgb to XyzD65, via LinearRgb);
 
-// DisplayP3 converts through XyzD65
-simple_from!(A98Rgb to DisplayP3, via XyzD65);
-simple_from!(Hex to DisplayP3, via XyzD65);
-simple_from!(Hsv to DisplayP3, via XyzD65);
-simple_from!(Hsl to DisplayP3, via XyzD65);
-simple_from!(Hwb to DisplayP3, via XyzD65);
-simple_from!(Lab to DisplayP3, via XyzD65);
-simple_from!(Lch to DisplayP3, via XyzD65);
-simple_from!(LinearRgb to DisplayP3, via XyzD65);
-simple_from!(Named to DisplayP3, via XyzD65);
-simple_from!(Oklab to DisplayP3, via XyzD65);
-simple_from!(Oklch to DisplayP3, via XyzD65);
-simple_from!(Srgb to DisplayP3, via XyzD65);
+// DisplayP3 converts through LinearRgb
+simple_from!(A98Rgb to DisplayP3, via LinearRgb);
+simple_from!(Hex to DisplayP3, via LinearRgb);
+simple_from!(Hsv to DisplayP3, via LinearRgb);
+simple_from!(Hsl to DisplayP3, via LinearRgb);
+simple_from!(Hwb to DisplayP3, via LinearRgb);
+simple_from!(Lab to DisplayP3, via LinearRgb);
+simple_from!(Lch to DisplayP3, via LinearRgb);
+// LinearRgb to DisplayP3 is implemented directly
+simple_from!(Named to DisplayP3, via LinearRgb);
+simple_from!(Oklab to DisplayP3, via LinearRgb);
+simple_from!(Oklch to DisplayP3, via LinearRgb);
+simple_from!(Srgb to DisplayP3, via LinearRgb);
 simple_from!(XyzD50 to DisplayP3, via XyzD65);
 
-simple_from!(DisplayP3 to A98Rgb, via XyzD65);
-simple_from!(DisplayP3 to Hex, via XyzD65);
-simple_from!(DisplayP3 to Hsv, via XyzD65);
-simple_from!(DisplayP3 to Hsl, via XyzD65);
-simple_from!(DisplayP3 to Hwb, via XyzD65);
-simple_from!(DisplayP3 to Lab, via XyzD65);
-simple_from!(DisplayP3 to Lch, via XyzD65);
-simple_from!(DisplayP3 to LinearRgb, via XyzD65);
-simple_from!(DisplayP3 to Oklab, via XyzD65);
-simple_from!(DisplayP3 to Oklch, via XyzD65);
-simple_from!(DisplayP3 to Srgb, via XyzD65);
-simple_from!(DisplayP3 to XyzD50, via XyzD65);
+simple_from!(DisplayP3 to A98Rgb, via LinearRgb);
+simple_from!(DisplayP3 to Hex, via LinearRgb);
+simple_from!(DisplayP3 to Hsv, via LinearRgb);
+simple_from!(DisplayP3 to Hsl, via LinearRgb);
+simple_from!(DisplayP3 to Hwb, via LinearRgb);
+simple_from!(DisplayP3 to Lab, via LinearRgb);
+simple_from!(DisplayP3 to Lch, via LinearRgb);
+// DisplayP3 to LinearRgb is implemented directly
+simple_from!(DisplayP3 to Oklab, via LinearRgb);
+simple_from!(DisplayP3 to Oklch, via LinearRgb);
+simple_from!(DisplayP3 to Srgb, via LinearRgb);
+simple_from!(DisplayP3 to XyzD50, via LinearRgb);
 simple_from!(DisplayP3 to ProphotoRgb, via XyzD65);
 simple_from!(DisplayP3 to Rec2020, via XyzD65);
 
@@ -275,7 +275,23 @@ simple_from!(Color to Oklab, via XyzD65);
 simple_from!(Color to Oklch, via XyzD65);
 simple_from!(Color to ProphotoRgb, via XyzD65);
 simple_from!(Color to Rec2020, via XyzD65);
-simple_from!(Color to Srgb, via XyzD65);
+
+// Color to Srgb: route DisplayP3 through LinearRgb
+impl From<Color> for Srgb {
+	fn from(value: Color) -> Self {
+		match value {
+			Color::DisplayP3(d) => {
+				let linear: LinearRgb = d.into();
+				linear.into()
+			}
+			other => {
+				let xyz: XyzD65 = other.into();
+				xyz.into()
+			}
+		}
+	}
+}
+
 simple_from!(Color to XyzD50, via XyzD65);
 
 macro_rules! impl_named_try_from_via_srgb {

--- a/crates/chromashift/src/display_p3.rs
+++ b/crates/chromashift/src/display_p3.rs
@@ -1,4 +1,4 @@
-use crate::{ToAlpha, XyzD65, round_dp};
+use crate::{LinearRgb, ToAlpha, XyzD65, round_dp};
 use core::fmt;
 
 /// A colour in the Display P3 colour space.
@@ -56,10 +56,10 @@ impl From<XyzD65> for DisplayP3 {
 		let x = x / 100.0;
 		let y = y / 100.0;
 		let z = z / 100.0;
-		// XYZ D65 -> Linear Display P3
-		let lr = x * 2.4934969119414263 + y * (-0.9313836179191239) + z * (-0.40271078445071684);
-		let lg = x * (-0.8294889695615747) + y * 1.7626640603183463 + z * 0.023624685841943577;
-		let lb = x * 0.03584583024378447 + y * (-0.07617238926804182) + z * 0.9568845240076872;
+		// XYZ D65 -> Linear Display P3 (see XYZ_to_lin_P3 in CSS Color 4)
+		let lr = x * (446124.0 / 178915.0) + y * (-333277.0 / 357830.0) + z * (-72051.0 / 178915.0);
+		let lg = x * (-14852.0 / 17905.0) + y * (63121.0 / 35810.0) + z * (423.0 / 17905.0);
+		let lb = x * (11844.0 / 330415.0) + y * (-50337.0 / 660830.0) + z * (316169.0 / 330415.0);
 		// Apply sRGB gamma
 		DisplayP3::new(gamma(lr), gamma(lg), gamma(lb), alpha)
 	}
@@ -72,10 +72,38 @@ impl From<DisplayP3> for XyzD65 {
 		let lr = linear(red);
 		let lg = linear(green);
 		let lb = linear(blue);
-		// Linear Display P3 -> XYZ D65
-		let x = lr * 0.4865709486482162 + lg * 0.26566769316909306 + lb * 0.1982172852343625;
-		let y = lr * 0.22897456406974884 + lg * 0.6917385218365064 + lb * 0.079286914093745;
-		let z = lr * 0.0 + lg * 0.04511338185890264 + lb * 1.043944368900976;
+		// Linear Display P3 -> XYZ D65 (see lin_d3_to_XYZ in CSS Color 4)
+		let x = lr * (608311.0 / 1250200.0) + lg * (189793.0 / 714400.0) + lb * (198249.0 / 1000160.0);
+		let y = lr * (35783.0 / 156275.0) + lg * (247089.0 / 357200.0) + lb * (198249.0 / 2500400.0);
+		let z = lg * (32229.0 / 714400.0) + lb * (5220557.0 / 5000800.0);
 		XyzD65::new(x * 100.0, y * 100.0, z * 100.0, alpha)
+	}
+}
+
+impl From<DisplayP3> for LinearRgb {
+	fn from(value: DisplayP3) -> Self {
+		let DisplayP3 { red, green, blue, alpha } = value;
+		// Linearize with sRGB gamma
+		let lr = linear(red);
+		let lg = linear(green);
+		let lb = linear(blue);
+		// Linear Display P3 -> Linear sRGB
+		let red = lr * (3685649.0 / 3008840.0) + lg * (-676809.0 / 3008840.0);
+		let green = lr * (-5617931.0 / 133579120.0) + lg * (139197051.0 / 133579120.0);
+		let blue = lr * (-1323971.0 / 67420360.0) + lg * (-1514763.0 / 19262960.0) + lb * (148092003.0 / 134840720.0);
+		LinearRgb::new(red, green, blue, alpha)
+	}
+}
+
+impl From<LinearRgb> for DisplayP3 {
+	fn from(value: LinearRgb) -> Self {
+		let LinearRgb { red, green, blue, alpha } = value;
+		// Linear sRGB -> Linear Display P3
+		let lr = red * (2442703.0 / 2969989.0) + green * (527286.0 / 2969989.0);
+		let lg = red * (621563.0 / 18725049.0) + green * (18103486.0 / 18725049.0);
+		let lb =
+			red * (281089.0 / 16454667.0) + green * (10721482.0 / 148092003.0) + blue * (134840720.0 / 148092003.0);
+		// Apply sRGB gamma
+		DisplayP3::new(gamma(lr), gamma(lg), gamma(lb), alpha)
 	}
 }


### PR DESCRIPTION
Given the most likely reason for using chromashift to convert display-p3 will be
converting to sRGB, using indirect conversions via XYZ can result in floating
point precision loss, which means some colors like `display-p3 0.5 0.5 0.5`
convert to #807f80 instead of #808080. This kind of precision loss is likely
visually imperceivable but it's _annoying_ and it certainly doesn't minify well.

This change adds new direct impls for DisplayP3 to LinearRgb using the provided
matrices in CSS Color 4. It also ensures any conversion (e.g. via the generic
Color type) goes through this LinearRgb conversion, thus retaining precision for
this specific operation.

Let this commit stand as yet another exhibit of why I generally despise floating
point numbers.
