### PR TITLE
Implement ColorFunctionColor::to_chromashift() and extract shortest_color helper

### DIFF
--- a/crates/css_ast/src/functions/color_function.rs
+++ b/crates/css_ast/src/functions/color_function.rs
@@ -117,7 +117,76 @@ pub struct ColorFunctionColor {
 #[cfg(feature = "chromashift")]
 impl crate::ToChromashift for ColorFunctionColor {
 	fn to_chromashift(&self) -> Option<chromashift::Color> {
-		todo!();
+		use chromashift::{A98Rgb, DisplayP3, LinearRgb, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65};
+
+		let ColorFunctionColorParams(space, c1, c2, c3, _, alpha) = &self.params;
+
+		let alpha = match alpha {
+			Some(NoneOr::None(_)) => 0.0,
+			Some(NoneOr::Some(NumberOrPercentage::Number(t))) => t.value() * 100.0,
+			Some(NoneOr::Some(NumberOrPercentage::Percentage(t))) => t.value(),
+			None => 100.0,
+		};
+
+		// Helper to extract a channel as f64 in 0.0-1.0 range
+		let channel_unit = |c: &NoneOr<NumberOrPercentage>| -> Option<f64> {
+			match c {
+				NoneOr::None(_) => None,
+				NoneOr::Some(NumberOrPercentage::Number(n)) => Some(n.value() as f64),
+				NoneOr::Some(NumberOrPercentage::Percentage(p)) => Some(p.value() as f64 / 100.0),
+			}
+		};
+
+		match space {
+			ColorSpace::Srgb(_) => {
+				let r = (channel_unit(c1)? * 255.0) as u8;
+				let g = (channel_unit(c2)? * 255.0) as u8;
+				let b = (channel_unit(c3)? * 255.0) as u8;
+				Some(chromashift::Color::Srgb(Srgb::new(r, g, b, alpha)))
+			}
+			ColorSpace::SrgbLinear(_) => {
+				let r = channel_unit(c1)?;
+				let g = channel_unit(c2)?;
+				let b = channel_unit(c3)?;
+				Some(chromashift::Color::LinearRgb(LinearRgb::new(r, g, b, alpha)))
+			}
+			ColorSpace::DisplayP3(_) => {
+				let r = channel_unit(c1)?;
+				let g = channel_unit(c2)?;
+				let b = channel_unit(c3)?;
+				Some(chromashift::Color::DisplayP3(DisplayP3::new(r, g, b, alpha)))
+			}
+			ColorSpace::A98Rgb(_) => {
+				let r = channel_unit(c1)?;
+				let g = channel_unit(c2)?;
+				let b = channel_unit(c3)?;
+				Some(chromashift::Color::A98Rgb(A98Rgb::new(r, g, b, alpha)))
+			}
+			ColorSpace::ProphotoRgb(_) => {
+				let r = channel_unit(c1)?;
+				let g = channel_unit(c2)?;
+				let b = channel_unit(c3)?;
+				Some(chromashift::Color::ProphotoRgb(ProphotoRgb::new(r, g, b, alpha)))
+			}
+			ColorSpace::Rec2020(_) => {
+				let r = channel_unit(c1)?;
+				let g = channel_unit(c2)?;
+				let b = channel_unit(c3)?;
+				Some(chromashift::Color::Rec2020(Rec2020::new(r, g, b, alpha)))
+			}
+			ColorSpace::Xyz(_) | ColorSpace::XyzD65(_) => {
+				let x = channel_unit(c1)? * 100.0;
+				let y = channel_unit(c2)? * 100.0;
+				let z = channel_unit(c3)? * 100.0;
+				Some(chromashift::Color::XyzD65(XyzD65::new(x, y, z, alpha)))
+			}
+			ColorSpace::XyzD50(_) => {
+				let x = channel_unit(c1)? * 100.0;
+				let y = channel_unit(c2)? * 100.0;
+				let z = channel_unit(c3)? * 100.0;
+				Some(chromashift::Color::XyzD50(XyzD50::new(x, y, z, alpha)))
+			}
+		}
 	}
 }
 

--- a/crates/csskit_transform/src/reduce_colors.rs
+++ b/crates/csskit_transform/src/reduce_colors.rs
@@ -105,4 +105,26 @@ mod tests {
 	fn no_transform_for_currentcolor() {
 		assert_no_transform!(CssMinifierFeature::ReduceColors, CssAtomSet, StyleSheet, "body { color: currentcolor; }");
 	}
+
+	#[test]
+	fn reduces_color_srgb_function() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color(srgb 1 0 0); }",
+			"a { color: red; }"
+		);
+	}
+
+	#[test]
+	fn reduces_color_display_p3() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color(display-p3 0.5 0.5 0.5); }",
+			"a { color: gray; }"
+		);
+	}
 }

--- a/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
+++ b/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
@@ -53,8 +53,9 @@ FAIL colors/0029
 -a{color:#ba00c2}
 +a{color:oklch(53.9985% .285449 326.643)}
 
-PANIC colors/0030
-  not yet implemented
+FAIL colors/0030
+-a{color:red}
++a{color:color(display-p3 1 0 0)}
 
 FAIL colors/0031
 -a{color:color-mix(in oklch,rgba(255,255,255,1),var(--foo))}


### PR DESCRIPTION
This change replaces the todo!() in ColorFunctionColor::to_chromashift() with a
full implementation that maps each ColorSpace variant to the appropriate
chromashift type.
