### PR TITLE
css_parse: flush trailing semicolons in CursorCompactWriteSink on drop

### DIFF
--- a/crates/css_parse/src/cursor_compact_write_sink.rs
+++ b/crates/css_parse/src/cursor_compact_write_sink.rs
@@ -12,7 +12,7 @@ pub struct CursorCompactWriteSink<'a, T: SourceCursorSink<'a>> {
 }
 
 const PENDING_KINDSET: KindSet = KindSet::new(&[Kind::Semicolon, Kind::Whitespace]);
-const REDUNDANT_SEMI_KINDSET: KindSet = KindSet::new(&[Kind::Semicolon, Kind::Colon, Kind::RightCurly]);
+const REDUNDANT_SEMI_KINDSET: KindSet = KindSet::new(&[Kind::Semicolon, Kind::RightCurly]);
 // Tokens where whitespace immediately before them can be removed
 const NO_WHITESPACE_BEFORE_KINDSET: KindSet =
 	KindSet::new(&[Kind::Whitespace, Kind::Colon, Kind::Delim, Kind::LeftCurly, Kind::RightCurly]);
@@ -64,6 +64,20 @@ impl<'a, T: SourceCursorSink<'a>> CursorCompactWriteSink<'a, T> {
 	}
 }
 
+impl<'a, T: SourceCursorSink<'a>> Drop for CursorCompactWriteSink<'a, T> {
+	fn drop(&mut self) {
+		// Flush any pending semicolons at the end of the stream.
+		// Trailing whitespace is genuinely redundant, but trailing semicolons may be
+		// required (e.g. `@import "foo.css";` needs the `;`).
+		if let Some(prev) = self.pending.take()
+			&& prev == Kind::Semicolon
+		{
+			self.last_token = Some(prev.token());
+			self.sink.append(prev.compact());
+		}
+	}
+}
+
 impl<'a, T: SourceCursorSink<'a>> CursorSink for CursorCompactWriteSink<'a, T> {
 	fn append(&mut self, c: Cursor) {
 		self.write(SourceCursor::from(c, c.str_slice(self.source_text)))
@@ -91,10 +105,12 @@ mod test {
 			let source_text = $before;
 			let bump = Bump::default();
 			let mut sink = String::new();
-			let mut stream = CursorCompactWriteSink::new(source_text, &mut sink);
-			let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
-			parser.parse_entirely::<$struct>().output.unwrap().to_cursors(&mut stream);
+			{
+				let mut stream = CursorCompactWriteSink::new(source_text, &mut sink);
+				let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
+				let mut parser = Parser::new(&bump, source_text, lexer);
+				parser.parse_entirely::<$struct>().output.unwrap().to_cursors(&mut stream);
+			}
 			assert_eq!(sink, $after.trim());
 		};
 	}
@@ -185,5 +201,16 @@ mod test {
 	fn test_does_not_change_numbers_without_optimization() {
 		assert_format!("width: 123px", "width:123px");
 		assert_format!("width: .5px", "width:.5px");
+	}
+
+	#[test]
+	fn test_preserves_trailing_semicolons() {
+		assert_format!("foo;", "foo;");
+	}
+
+	#[test]
+	fn test_drops_trailing_whitespace() {
+		assert_format!("foo  ", "foo");
+		assert_format!("foo; ", "foo;");
 	}
 }

--- a/crates/csskit/src/commands/build.rs
+++ b/crates/csskit/src/commands/build.rs
@@ -28,11 +28,11 @@ impl Build {
 			let mut source_string = String::new();
 			source.read_to_string(&mut source_string)?;
 			let source_text = source_string.as_str();
-			let mut stream = CursorCompactWriteSink::new(source_text, &mut str);
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 			let mut parser = Parser::new(&bump, source_text, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
 			if result.output.is_some() {
+				let mut stream = CursorCompactWriteSink::new(source_text, &mut str);
 				result.to_cursors(&mut stream);
 			} else {
 				for compact_err in result.errors {

--- a/crates/csskit/src/commands/min.rs
+++ b/crates/csskit/src/commands/min.rs
@@ -53,16 +53,23 @@ impl Min {
 					let mut highlighter = TokenHighlighter::new();
 					stylesheet.accept(&mut highlighter);
 					let ansi = AnsiHighlightCursorStream::new(&mut str, &highlighter, DefaultAnsiTheme);
-					let mut stream =
-						CursorOverlaySink::new(source_text, &overlays, CursorCompactWriteSink::new(source_text, ansi));
-					result.to_cursors(&mut stream);
+					{
+						let mut stream = CursorOverlaySink::new(
+							source_text,
+							&overlays,
+							CursorCompactWriteSink::new(source_text, ansi),
+						);
+						result.to_cursors(&mut stream);
+					}
 				} else {
-					let mut stream = CursorOverlaySink::new(
-						source_text,
-						&overlays,
-						CursorCompactWriteSink::new(source_text, &mut str),
-					);
-					result.to_cursors(&mut stream);
+					{
+						let mut stream = CursorOverlaySink::new(
+							source_text,
+							&overlays,
+							CursorCompactWriteSink::new(source_text, &mut str),
+						);
+						result.to_cursors(&mut stream);
+					}
 				};
 				if *check {
 					if str != source_text {

--- a/crates/csskit_transform/src/css_minifier.rs
+++ b/crates/csskit_transform/src/css_minifier.rs
@@ -40,11 +40,15 @@ mod tests {
 			transformer.transform(node);
 			let overlays = transformer.overlays();
 			let changed = transformer.has_changed();
-			let mut overlay_stream =
-				CursorOverlaySink::new(source_text, &*overlays, CursorCompactWriteSink::new(source_text, &mut output));
-			result.output.to_cursors(&mut overlay_stream);
-			drop(overlay_stream);
-			(output.clone(), changed)
+			{
+				let mut overlay_stream = CursorOverlaySink::new(
+					source_text,
+					&*overlays,
+					CursorCompactWriteSink::new(source_text, &mut output),
+				);
+				result.output.to_cursors(&mut overlay_stream);
+			}
+			(output, changed)
 		} else {
 			panic!("Could not transform output");
 		}

--- a/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
+++ b/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
@@ -216,23 +216,23 @@ FAIL gradients/0005
 +a{background:radial-gradient(red,#00f)}
 
 FAIL import/0001
--@import url("foo.css")
+-@import url("foo.css");
 +@import"foo.css";
 
 FAIL import/0002
--@import url("foo.css")screen
+-@import url("foo.css")screen;
 +@import"foo.css"screen;
 
 FAIL import/0003
--@import url(foo.css)
+-@import url(foo.css);
 +@import"foo.css";
 
 FAIL import/0004
--@import url("foo.css")layer
+-@import url("foo.css")layer;
 +@import"foo.css"layer;
 
 FAIL import/0005
--@import url("foo.css")layer(base)supports(foo:bar)
+-@import url("foo.css")layer(base)supports(foo:bar);
 +@import"foo.css"layer(base)supports(foo:bar);
 
 FAIL keyframes/0001
@@ -946,7 +946,7 @@ FAIL values/0057
 +a{--brand-color: rgb(0 0 0)}
 
 FAIL values/0058
--a{--foo:color:var(--foo,red)}
+-a{--foo:;color:var(--foo,red)}
 +a{--foo: ;color:var(--foo,red)}
 
 FAIL values/0062

--- a/crates/csskit_wasm/src/lib.rs
+++ b/crates/csskit_wasm/src/lib.rs
@@ -78,12 +78,14 @@ pub fn minify(source_text: String) -> Result<String, serde_wasm_bindgen::Error> 
 			Transformer::new_in(&allocator, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, &source_text);
 		transformer.transform(stylesheet);
 		let overlays = transformer.overlays();
-		let mut stream = CursorOverlaySink::new(
-			&source_text,
-			&overlays,
-			CursorCompactWriteSink::new(&source_text, &mut output_string),
-		);
-		result.to_cursors(&mut stream);
+		{
+			let mut stream = CursorOverlaySink::new(
+				&source_text,
+				&overlays,
+				CursorCompactWriteSink::new(&source_text, &mut output_string),
+			);
+			result.to_cursors(&mut stream);
+		}
 	}
 	Ok(output_string)
 }


### PR DESCRIPTION
Add a Drop impl that flushes pending semicolons at end-of-stream.
Previously, a trailing semicolon (e.g. `@import "foo.css";`) would be
swallowed because it was still in the pending slot when the sink was
dropped. Trailing whitespace remains discarded.

Also fix the redundant-semicolon KindSet: Colon was incorrectly listed
as a position where semicolons are redundant.

The Drop impl requires callers to scope the sink so it drops before the
output buffer is read — consumer updates follow in a separate commit.