### PR TITLE
chromashift/csskit_transform/css_ast: Implement colour mixing & minification

### DIFF
--- a/crates/chromashift/src/gamut.rs
+++ b/crates/chromashift/src/gamut.rs
@@ -228,9 +228,13 @@ fn raytrace_box(start: &[f64; 3], end: &[f64; 3]) -> Option<[f64; 3]> {
 	Some([start[0] + direction[0] * tnear, start[1] + direction[1] * tnear, start[2] + direction[2] * tnear])
 }
 
-/// Helper: checks an f64 is in [0.0, 1.0]
+/// Tolerance for floating-point noise accumulated during colour-space round-trips
+/// (e.g. XYZ to LinearRgb can produce values like −2.9e-17 for a channel that should be 0).
+const GAMUT_EPSILON: f64 = 1e-6;
+
+/// Helper: checks an f64 is in [0.0, 1.0] with [`GAMUT_EPSILON`] tolerance.
 fn in_unit(v: f64) -> bool {
-	(0.0..=1.0).contains(&v)
+	(-GAMUT_EPSILON..=1.0 + GAMUT_EPSILON).contains(&v)
 }
 
 /// Helper: checks an f32 is in [0.0, 100.0]

--- a/crates/chromashift/src/lib.rs
+++ b/crates/chromashift/src/lib.rs
@@ -97,6 +97,87 @@ impl fmt::Display for Color {
 	}
 }
 
+impl Color {
+	/// Returns a copy of this colour with a new alpha value (0.0–100.0).
+	///
+	/// For `Named` colours (which are always fully opaque), setting a non-100 alpha converts to `Srgb`. For `Hex`,
+	/// the colour is round-tripped through `Srgb` to apply the new alpha.
+	pub fn with_alpha(self, alpha: f32) -> Self {
+		match self {
+			Color::A98Rgb(mut c) => {
+				c.alpha = alpha;
+				Color::A98Rgb(c)
+			}
+			Color::DisplayP3(mut c) => {
+				c.alpha = alpha;
+				Color::DisplayP3(c)
+			}
+			Color::Hsv(mut c) => {
+				c.alpha = alpha;
+				Color::Hsv(c)
+			}
+			Color::Hsl(mut c) => {
+				c.alpha = alpha;
+				Color::Hsl(c)
+			}
+			Color::Hex(h) => {
+				let mut srgb: Srgb = h.into();
+				srgb.alpha = alpha;
+				Color::Srgb(srgb)
+			}
+			Color::Hwb(mut c) => {
+				c.alpha = alpha;
+				Color::Hwb(c)
+			}
+			Color::Lab(mut c) => {
+				c.alpha = alpha;
+				Color::Lab(c)
+			}
+			Color::Lch(mut c) => {
+				c.alpha = alpha;
+				Color::Lch(c)
+			}
+			Color::LinearRgb(mut c) => {
+				c.alpha = alpha;
+				Color::LinearRgb(c)
+			}
+			Color::Named(n) => {
+				let mut srgb: Srgb = n.into();
+				srgb.alpha = alpha;
+				Color::Srgb(srgb)
+			}
+			Color::Oklab(mut c) => {
+				c.alpha = alpha;
+				Color::Oklab(c)
+			}
+			Color::Oklch(mut c) => {
+				c.alpha = alpha;
+				Color::Oklch(c)
+			}
+			Color::ProphotoRgb(mut c) => {
+				c.alpha = alpha;
+				Color::ProphotoRgb(c)
+			}
+			Color::Rec2020(mut c) => {
+				c.alpha = alpha;
+				Color::Rec2020(c)
+			}
+			Color::Srgb(mut c) => {
+				c.alpha = alpha;
+				Color::Srgb(c)
+			}
+			Color::XyzD50(mut c) => {
+				c.alpha = alpha;
+				Color::XyzD50(c)
+			}
+			Color::XyzD65(mut c) => {
+				c.alpha = alpha;
+				Color::XyzD65(c)
+			}
+		}
+	}
+}
+
 impl ToAlpha for Color {
 	fn to_alpha(&self) -> f32 {
 		match self {

--- a/crates/css_ast/src/functions/color_function.rs
+++ b/crates/css_ast/src/functions/color_function.rs
@@ -58,7 +58,7 @@ impl<'a> Parse<'a> for CommaOrSlash {
 /// <https://drafts.csswg.org/css-color/#typedef-color-function>
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(all))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum ColorFunction<'a> {
 	Color(BumpBox<'a, ColorFunctionColor>),

--- a/crates/css_ast/src/functions/color_mix_function.rs
+++ b/crates/css_ast/src/functions/color_mix_function.rs
@@ -8,16 +8,20 @@ use crate::Percentage;
 /// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(all))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct ColorMixFunction<'a> {
 	#[atom(CssAtomSet::ColorMix)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub name: T![Function],
 	pub interpolation: ColorInterpolationMethod,
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub comma: T![,],
 	pub first: ColorMixPart<'a>,
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub comma2: T![,],
 	pub second: ColorMixPart<'a>,
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: T![')'],
 }
 
@@ -181,13 +185,72 @@ impl<'a> Parse<'a> for ColorMixPart<'a> {
 }
 
 #[cfg(feature = "chromashift")]
+impl HueInterpolationDirection {
+	/// Converts this AST node to the corresponding chromashift hue interpolation direction.
+	pub fn to_hue_interpolation(&self) -> chromashift::HueInterpolation {
+		match self {
+			Self::Shorter(_) => chromashift::HueInterpolation::Shorter,
+			Self::Longer(_) => chromashift::HueInterpolation::Longer,
+			Self::Increasing(_) => chromashift::HueInterpolation::Increasing,
+			Self::Decreasing(_) => chromashift::HueInterpolation::Decreasing,
+		}
+	}
+}
+
+#[cfg(feature = "chromashift")]
+impl InterpolationColorSpace {
+	/// Mixes two colours in this interpolation colour space.
+	///
+	/// `percentage` is how much of the second colour to use (0.0 = all first, 100.0 = all second).
+	pub fn mix(&self, first: chromashift::Color, second: chromashift::Color, percentage: f64) -> chromashift::Color {
+		use chromashift::{
+			A98Rgb, ColorMix, ColorMixPolar, DisplayP3, Hsl, Hwb, Lab, Lch, LinearRgb, Oklab, Oklch, ProphotoRgb,
+			Rec2020, Srgb, XyzD50, XyzD65,
+		};
+		match self {
+			Self::Rectangular(space) => match space {
+				RectangularColorSpace::Srgb(_) => chromashift::Color::Srgb(Srgb::mix(first, second, percentage)),
+				RectangularColorSpace::SrgbLinear(_) => {
+					chromashift::Color::LinearRgb(LinearRgb::mix(first, second, percentage))
+				}
+				RectangularColorSpace::DisplayP3(_) => {
+					chromashift::Color::DisplayP3(DisplayP3::mix(first, second, percentage))
+				}
+				RectangularColorSpace::A98Rgb(_) => chromashift::Color::A98Rgb(A98Rgb::mix(first, second, percentage)),
+				RectangularColorSpace::ProphotoRgb(_) => {
+					chromashift::Color::ProphotoRgb(ProphotoRgb::mix(first, second, percentage))
+				}
+				RectangularColorSpace::Rec2020(_) => {
+					chromashift::Color::Rec2020(Rec2020::mix(first, second, percentage))
+				}
+				RectangularColorSpace::Lab(_) => chromashift::Color::Lab(Lab::mix(first, second, percentage)),
+				RectangularColorSpace::Oklab(_) => chromashift::Color::Oklab(Oklab::mix(first, second, percentage)),
+				RectangularColorSpace::XyzD50(_) => chromashift::Color::XyzD50(XyzD50::mix(first, second, percentage)),
+				RectangularColorSpace::Xyz(_) | RectangularColorSpace::XyzD65(_) => {
+					chromashift::Color::XyzD65(XyzD65::mix(first, second, percentage))
+				}
+			},
+			Self::Polar(space, hue_method) => {
+				let dir = match hue_method {
+					None => chromashift::HueInterpolation::Shorter,
+					Some(him) => him.direction.to_hue_interpolation(),
+				};
+				match space {
+					PolarColorSpace::Hsl(_) => chromashift::Color::Hsl(Hsl::mix_polar(first, second, percentage, dir)),
+					PolarColorSpace::Hwb(_) => chromashift::Color::Hwb(Hwb::mix_polar(first, second, percentage, dir)),
+					PolarColorSpace::Lch(_) => chromashift::Color::Lch(Lch::mix_polar(first, second, percentage, dir)),
+					PolarColorSpace::Oklch(_) => {
+						chromashift::Color::Oklch(Oklch::mix_polar(first, second, percentage, dir))
+					}
+				}
+			}
+		}
+	}
+}
+
+#[cfg(feature = "chromashift")]
 impl crate::ToChromashift for ColorMixFunction<'_> {
 	fn to_chromashift(&self) -> Option<chromashift::Color> {
-		use chromashift::{
-			A98Rgb, ColorMix, ColorMixPolar, DisplayP3, Hsl, HueInterpolation, Hwb, Lab, Lch, LinearRgb, Oklab, Oklch,
-			ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
-		};
-
 		let first_color = self.first.color.to_chromashift()?;
 		let second_color = self.second.color.to_chromashift()?;
 
@@ -211,77 +274,11 @@ impl crate::ToChromashift for ColorMixFunction<'_> {
 			return None;
 		}
 		let p1 = p1 / sum * 100.0;
-		let _p2 = p2 / sum * 100.0;
 
 		// The percentage for mixing is "how much of the second color"
-		// p1 is the first color's weight, so the second color's percentage is 100 - p1
 		let mix_percentage = 100.0 - p1;
 
-		let hue_direction = |method: &Option<HueInterpolationMethod>| -> HueInterpolation {
-			match method {
-				None => HueInterpolation::Shorter,
-				Some(him) => match him.direction {
-					HueInterpolationDirection::Shorter(_) => HueInterpolation::Shorter,
-					HueInterpolationDirection::Longer(_) => HueInterpolation::Longer,
-					HueInterpolationDirection::Increasing(_) => HueInterpolation::Increasing,
-					HueInterpolationDirection::Decreasing(_) => HueInterpolation::Decreasing,
-				},
-			}
-		};
-
-		let result = match &self.interpolation.color_space {
-			InterpolationColorSpace::Rectangular(space) => match space {
-				RectangularColorSpace::Srgb(_) => {
-					chromashift::Color::Srgb(Srgb::mix(first_color, second_color, mix_percentage))
-				}
-				RectangularColorSpace::SrgbLinear(_) => {
-					chromashift::Color::LinearRgb(LinearRgb::mix(first_color, second_color, mix_percentage))
-				}
-				RectangularColorSpace::DisplayP3(_) => {
-					chromashift::Color::DisplayP3(DisplayP3::mix(first_color, second_color, mix_percentage))
-				}
-				RectangularColorSpace::A98Rgb(_) => {
-					chromashift::Color::A98Rgb(A98Rgb::mix(first_color, second_color, mix_percentage))
-				}
-				RectangularColorSpace::ProphotoRgb(_) => {
-					chromashift::Color::ProphotoRgb(ProphotoRgb::mix(first_color, second_color, mix_percentage))
-				}
-				RectangularColorSpace::Rec2020(_) => {
-					chromashift::Color::Rec2020(Rec2020::mix(first_color, second_color, mix_percentage))
-				}
-				RectangularColorSpace::Lab(_) => {
-					chromashift::Color::Lab(Lab::mix(first_color, second_color, mix_percentage))
-				}
-				RectangularColorSpace::Oklab(_) => {
-					chromashift::Color::Oklab(Oklab::mix(first_color, second_color, mix_percentage))
-				}
-				RectangularColorSpace::Xyz(_) | RectangularColorSpace::XyzD65(_) => {
-					chromashift::Color::XyzD65(XyzD65::mix(first_color, second_color, mix_percentage))
-				}
-				RectangularColorSpace::XyzD50(_) => {
-					chromashift::Color::XyzD50(XyzD50::mix(first_color, second_color, mix_percentage))
-				}
-			},
-			InterpolationColorSpace::Polar(space, hue_method) => {
-				let dir = hue_direction(hue_method);
-				match space {
-					PolarColorSpace::Hsl(_) => {
-						chromashift::Color::Hsl(Hsl::mix_polar(first_color, second_color, mix_percentage, dir))
-					}
-					PolarColorSpace::Hwb(_) => {
-						chromashift::Color::Hwb(Hwb::mix_polar(first_color, second_color, mix_percentage, dir))
-					}
-					PolarColorSpace::Lch(_) => {
-						chromashift::Color::Lch(Lch::mix_polar(first_color, second_color, mix_percentage, dir))
-					}
-					PolarColorSpace::Oklch(_) => {
-						chromashift::Color::Oklch(Oklch::mix_polar(first_color, second_color, mix_percentage, dir))
-					}
-				}
-			}
-		};
-
-		Some(result)
+		Some(self.interpolation.color_space.mix(first_color, second_color, mix_percentage))
 	}
 }
 
@@ -319,6 +316,42 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(in xyz-d50,red,green)");
 		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(in xyz-d65,red,green)");
 		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(in srgb-linear,red,green)");
+	}
+
+	#[test]
+	#[cfg(feature = "visitable")]
+	fn test_visits() {
+		use crate::assert_visits;
+		// Named colors
+		assert_visits!("color-mix(in srgb, red, blue)", ColorMixFunction, ColorInterpolationMethod, Color, Color,);
+		// Function colors recurse into ColorFunction and its variant
+		assert_visits!(
+			"color-mix(in srgb, rgb(255, 0, 0), blue)",
+			ColorMixFunction,
+			ColorInterpolationMethod,
+			Color,
+			ColorFunction,
+			RgbFunction,
+			Color,
+		);
+		// Percentages are visited
+		assert_visits!(
+			"color-mix(in srgb, red 50%, blue 50%)",
+			ColorMixFunction,
+			ColorInterpolationMethod,
+			Color,
+			Percentage,
+			Color,
+			Percentage,
+		);
+		// Polar color space with hue interpolation
+		assert_visits!(
+			"color-mix(in oklch shorter hue, red, blue)",
+			ColorMixFunction,
+			ColorInterpolationMethod,
+			Color,
+			Color,
+		);
 	}
 
 	#[test]

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -135,10 +135,10 @@ mod tests {
 		use crate::assert_visits;
 		assert_visits!("#fff", Color);
 		assert_visits!("black", Color);
-		assert_visits!("rgb(255 255 255)", Color, ColorFunction);
-		assert_visits!("rgba(255,255,255,0.5)", Color, ColorFunction);
-		assert_visits!("lab(63.673% 51.577 5.811)", Color, ColorFunction);
-		assert_visits!("hwb(740deg 20% 30%/50%)", Color, ColorFunction);
+		assert_visits!("rgb(255 255 255)", Color, ColorFunction, RgbFunction);
+		assert_visits!("rgba(255,255,255,0.5)", Color, ColorFunction, RgbaFunction);
+		assert_visits!("lab(63.673% 51.577 5.811)", Color, ColorFunction, LabFunction);
+		assert_visits!("hwb(740deg 20% 30%/50%)", Color, ColorFunction, HwbFunction);
 	}
 
 	#[test]

--- a/crates/csskit_ast/src/selector/matcher/tests.rs
+++ b/crates/csskit_ast/src/selector/matcher/tests.rs
@@ -611,7 +611,7 @@ fn rule_pseudo() {
 
 #[test]
 fn function_pseudo() {
-	assert_query!("a { color: rgb(255, 0, 0); }", "*:function", 1, [NodeId::ColorFunction]);
+	assert_query!("a { color: rgb(255, 0, 0); }", "*:function", 2, [NodeId::ColorFunction, NodeId::RgbFunction]);
 	assert_query!(
 		"a { background: linear-gradient(red, blue); transform: rotate(45deg); }",
 		"*:function",

--- a/crates/csskit_transform/src/reduce_colors.rs
+++ b/crates/csskit_transform/src/reduce_colors.rs
@@ -1,9 +1,15 @@
 use crate::prelude::*;
-use chromashift::{ColorSpace, Hex, Named, Srgb};
-use css_ast::{Color, ToChromashift, Visitable};
+use chromashift::{COLOR_EPSILON, ColorDistance, ColorSpace, Hex, Named, Srgb, ToAlpha};
+use css_ast::{
+	Color, ColorFunction, ColorMixFunction, HueInterpolationDirection, InterpolationColorSpace, ToChromashift,
+	Visitable,
+};
 
 pub struct ReduceColors<'a, 'ctx, N: Visitable + NodeWithMetadata<CssMetadata>> {
 	pub transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>,
+	/// When true, the outer color-mix() is being replaced entirely, so inner
+	/// `visit_color` calls should be suppressed to avoid overlapping edits.
+	replacing_outer: bool,
 }
 
 impl<'a, 'ctx, N> Transform<'a, 'ctx, CssMetadata, N, CssMinifierFeature> for ReduceColors<'a, 'ctx, N>
@@ -15,7 +21,24 @@ where
 	}
 
 	fn new(transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>) -> Self {
-		Self { transformer }
+		Self { transformer, replacing_outer: false }
+	}
+}
+
+trait Shortest {
+	fn shortest(&self) -> Option<String>;
+}
+
+impl Shortest for chromashift::Color {
+	fn shortest(&self) -> Option<String> {
+		[
+			Some(Hex::from(*self).to_string()),
+			Named::try_from(*self).ok().map(|named| named.to_string()),
+			Some(Srgb::from(*self).to_string()),
+		]
+		.into_iter()
+		.flatten()
+		.min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)))
 	}
 }
 
@@ -24,6 +47,13 @@ where
 	N: Visitable + NodeWithMetadata<CssMetadata>,
 {
 	fn visit_color(&mut self, color: &Color) {
+		if self.replacing_outer {
+			return;
+		}
+		// color-mix() is handled by visit_color_mix_function
+		if matches!(color, Color::Function(ColorFunction::ColorMix(_))) {
+			return;
+		}
 		let Some(chroma_color) = color.to_chromashift() else {
 			return;
 		};
@@ -36,20 +66,136 @@ where
 			return;
 		}
 
-		let Some(candidate) = [
-			Some(Hex::from(Srgb::from(chroma_color)).to_string()),
-			Named::try_from(chroma_color).ok().map(|named| named.to_string()),
-			Some(Srgb::from(chroma_color).to_string()),
-		]
-		.into_iter()
-		.flatten()
-		.min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b))) else {
+		let Some(candidate) = chroma_color.shortest() else {
 			return;
 		};
 
 		if candidate.len() < len {
 			self.transformer.replace_parsed::<Color>(color.to_span(), &candidate);
 		}
+	}
+
+	fn visit_color_mix_function<'b>(&mut self, mix: &ColorMixFunction<'b>) {
+		let outer_span = mix.to_span();
+		let outer_len = outer_span.len() as usize;
+
+		let first_chroma = mix.first.color.to_chromashift();
+		let second_chroma = mix.second.color.to_chromashift();
+		let delta_e = first_chroma.and_then(|first| second_chroma.map(|second| first.delta_e(second)));
+
+		// Compute effective percentages per CSS Color 5 3.2:
+		// - If only one percentage is given, the other is 100% - given
+		// - If neither is given, both default to 50%
+		// - If both are given, they're used as-is (and may not sum to 100%)
+		let p1_explicit = mix.first.percentage.as_ref().map(|p| p.value());
+		let p2_explicit = mix.second.percentage.as_ref().map(|p| p.value());
+		let (p1, p2) = match (p1_explicit, p2_explicit) {
+			(Some(a), Some(b)) => (a, b),
+			(Some(a), None) => (a, 100.0 - a),
+			(None, Some(b)) => (100.0 - b, b),
+			(None, None) => (50.0, 50.0),
+		};
+		let sum = p1 + p2;
+
+		// The same color on both sides should just shrink to the one color,
+		// but only when alpha_mult is 1 (sum >= 100)
+		if delta_e.is_some_and(|delta| delta < COLOR_EPSILON) && sum >= 100.0 {
+			let str = first_chroma.and_then(|color| color.shortest()).unwrap_or_else(|| {
+				let span = mix.first.color.to_span();
+				self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
+			});
+			self.transformer.clear_pending_edits(outer_span);
+			self.transformer.replace_parsed::<Color>(outer_span, &str);
+			self.replacing_outer = true;
+			return;
+		}
+
+		// 100%/0% elimination — only when sum == 100 (no alpha multiplier, no normalization)
+		if sum == 100.0 && (p1 == 100.0 || p2 == 0.0) {
+			let str = first_chroma.and_then(|color| color.shortest()).unwrap_or_else(|| {
+				let span = mix.first.color.to_span();
+				self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
+			});
+			self.transformer.clear_pending_edits(outer_span);
+			self.transformer.replace_parsed::<Color>(outer_span, &str);
+			self.replacing_outer = true;
+			return;
+		}
+
+		// 0%/100% elimination — only when sum == 100
+		if sum == 100.0 && (p2 == 100.0 || p1 == 0.0) {
+			let str = second_chroma.and_then(|color| color.shortest()).unwrap_or_else(|| {
+				let span = mix.second.color.to_span();
+				self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
+			});
+			self.transformer.clear_pending_edits(outer_span);
+			self.transformer.replace_parsed::<Color>(outer_span, &str);
+			self.replacing_outer = true;
+			return;
+		}
+
+		// Try to statically mix both colors if they're both known
+		if let (Some(first), Some(second)) = (first_chroma, second_chroma)
+			&& sum > 0.0
+		{
+			// Normalize so that p1_norm + p2_norm = 100
+			let np1 = (p1 as f64) / (sum as f64) * 100.0;
+			// The percentage for mixing is "how much of the second color"
+			let percentage = 100.0 - np1;
+
+			let mixed = mix.interpolation.color_space.mix(first, second, percentage);
+
+			// Apply alpha multiplier per CSS Color 5 3.3:
+			// alpha_mult = 1 - leftover, where leftover = max(1 - sum/100, 0)
+			let alpha_mult = (sum as f64 / 100.0).min(1.0);
+			let mixed_alpha = (mixed.to_alpha() as f64 / 100.0 * alpha_mult * 100.0) as f32;
+			let mixed = mixed.with_alpha(mixed_alpha);
+
+			// Only convert to sRGB hex/named if the result is in sRGB gamut.
+			// Converting out-of-gamut colors to hex silently clamps, changing the color.
+			let candidate = if mixed.in_gamut_of(ColorSpace::Srgb) {
+				mixed.shortest()
+			} else {
+				// Out of sRGB gamut — output in the native interpolation color space
+				Some(mixed.to_string())
+			};
+
+			if let Some(candidate) = candidate
+				&& candidate.len() < outer_len
+			{
+				self.transformer.replace_parsed::<Color>(outer_span, &candidate);
+				self.replacing_outer = true;
+				return;
+			}
+		}
+
+		// Partial optimizations (only when not replacing the entire expression)
+
+		// Remove redundant 50% percentages — only when both effective percentages are 50%
+		// (i.e. the sum is 100, so no alpha multiplier effect)
+		if sum == 100.0 {
+			if p1 == 50.0
+				&& let Some(ref pct) = mix.first.percentage
+			{
+				self.transformer.delete(pct.to_span());
+			}
+			if p2 == 50.0
+				&& let Some(ref pct) = mix.second.percentage
+			{
+				self.transformer.delete(pct.to_span());
+			}
+		}
+
+		// Remove redundant "shorter hue" (shorter is the default hue interpolation direction)
+		if let InterpolationColorSpace::Polar(_, Some(ref hue_method)) = mix.interpolation.color_space
+			&& matches!(hue_method.direction, HueInterpolationDirection::Shorter(_))
+		{
+			self.transformer.delete(hue_method.to_span());
+		}
+	}
+
+	fn exit_color_mix_function<'b>(&mut self, _mix: &ColorMixFunction<'b>) {
+		self.replacing_outer = false;
 	}
 }
 
@@ -141,6 +287,173 @@ mod tests {
 			CssAtomSet,
 			StyleSheet,
 			"a { color: color(display-p3 1 0 0); }"
+		);
+	}
+	#[test]
+
+	fn color_mix_100_percent_first() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, red 100%, blue); }",
+			"a { color: red; }"
+		);
+	}
+
+	#[test]
+	fn color_mix_0_percent_first() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, red 0%, blue); }",
+			"a { color: #00f; }"
+		);
+	}
+
+	#[test]
+	fn color_mix_same_color_both_sides() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, red, red); }",
+			"a { color: red; }"
+		);
+	}
+
+	#[test]
+	fn color_mix_removes_redundant_50_50() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, currentcolor 50%, red 50%); }",
+			"a { color: color-mix(in srgb, currentcolor, red); }"
+		);
+	}
+
+	#[test]
+	fn color_mix_removes_single_redundant_50() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, currentcolor 50%, red); }",
+			"a { color: color-mix(in srgb, currentcolor, red); }"
+		);
+	}
+
+	#[test]
+	fn color_mix_removes_shorter_hue() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in oklch shorter hue, currentcolor, red); }",
+			"a { color: color-mix(in oklch, currentcolor, red); }"
+		);
+	}
+
+	#[test]
+	fn color_mix_keeps_longer_hue() {
+		assert_no_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in oklch longer hue,currentcolor,red); }"
+		);
+	}
+
+	#[test]
+	fn color_mix_no_transform_when_already_compact() {
+		assert_no_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in oklch longer hue,currentcolor,red); }"
+		);
+	}
+
+	#[test]
+	fn color_mix_minifies_inner_colors() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in oklch, rgba(255, 255, 255, 1), currentcolor); }",
+			"a { color: color-mix(in oklch, #fff, currentcolor); }"
+		);
+	}
+
+	#[test]
+	fn color_mix_minifies_inner_rgb_to_named() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, hsl(0, 100%, 50%), currentcolor); }",
+			"a { color: color-mix(in srgb, red, currentcolor); }"
+		);
+	}
+
+	#[test]
+	fn color_mix_mixes_static_colors() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, red, blue); }",
+			"a { color: purple; }"
+		);
+	}
+
+	#[test]
+	fn color_mix_normalizes_percentages_over_100() {
+		// 80% + 40% = 120%, normalizes to 66.67%/33.33%, giving rgb(170, 0, 85) = #a05
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, red 80%, blue 40%); }",
+			"a { color: #a05; }"
+		);
+	}
+
+	#[test]
+	fn color_mix_alpha_multiplier_under_100() {
+		// 30% + 30% = 60%, alpha_mult = 0.6, result is semi-transparent purple
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, red 30%, blue 30%); }",
+			"a { color: #80008099; }"
+		);
+	}
+
+	#[test]
+	fn color_mix_no_100_shortcircuit_when_both_explicit() {
+		// red 100% + blue 50% sums to 150%, must normalize to 67/33 — not short-circuit to red
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, red 100%, blue 50%); }",
+			"a { color: #a05; }"
+		);
+	}
+
+	#[test]
+	fn color_mix_oklch_out_of_gamut_uses_native_space() {
+		// oklch mix of lime+blue is out of sRGB gamut — resolved to oklch(), not hex
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in oklch, lime, blue); }",
+			"a { color: oklch(0.66 0.304 203.27); }"
 		);
 	}
 }

--- a/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
+++ b/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
@@ -38,7 +38,7 @@ FAIL colors/0021
 +a{color:green}
 
 FAIL colors/0024
--a{color:color-mix(in srgb,rgb(none 0 0)50%,rgb(200 0 0)50%)}
+-a{color:color-mix(in srgb,rgb(none 0 0),#c80000)}
 +a{color:#c80000}
 
 FAIL colors/0027
@@ -46,7 +46,7 @@ FAIL colors/0027
 +a{color:oklab(.5 -.1 .1)}
 
 FAIL colors/0029
--a{color:color-mix(in oklch,red 50%,blue 50%)}
+-a{color:oklch(.54 .2854 326.64)}
 +a{color:oklch(54% .285 326.6)}
 
 FAIL colors/0031
@@ -69,24 +69,8 @@ FAIL colors/0035
 -a{color:color(display-p3 1.2 -.3 .5)}
 +a{color:color(display-p3 1.2-.3 .5)}
 
-FAIL colors/0038
--a{color:color-mix(in srgb,currentcolor 50%,red 50%)}
-+a{color:color-mix(in srgb,currentcolor,red)}
-
-FAIL colors/0039
--a{color:color-mix(in oklch shorter hue,currentcolor,red)}
-+a{color:color-mix(in oklch,currentcolor,red)}
-
-FAIL colors/0040
--a{color:color-mix(in oklch,rgba(255,255,255,1),currentcolor)}
-+a{color:color-mix(in oklch,#fff,currentcolor)}
-
-FAIL colors/0042
--a{color:purple}
-+a{color:#80008099}
-
 FAIL colors/0044
--a{color:color-mix(in oklch,lime,blue)}
+-a{color:oklch(.66 .304 203.27)}
 +a{color:oklch(.659 .304 203.3)}
 
 FAIL colors/0045


### PR DESCRIPTION
This change implements proper colour mixing, which allows us to transform
literal color-mix functions down to their compacted forms.
