### PR TITLE
css_ast: Assert atoms <127 are dimensions, reorganise atoms to avoid hitting asserts

### DIFF
--- a/crates/css_ast/src/css_atom_set.rs
+++ b/crates/css_ast/src/css_atom_set.rs
@@ -84,7 +84,13 @@ pub enum CssAtomSet {
 	Vmin,
 	Vw,
 	X,
-	Y,
+
+	// n- is _not_ a dimension, but it needs to be in the lower bitset to ensure that if
+	// nth parses a Dimension that `n-` can be compared without hitting a debug_assert!
+	#[atom("n-")]
+	_NDash = 127,
+
+	// ^^^ Only dimensions go above here! ^^^
 
 	// CSS Keywords
 	A,
@@ -2127,16 +2133,16 @@ pub enum CssAtomSet {
 	Width,
 	WillChange,
 	WindowsVista,
-	With,
 	WindowsWin10,
 	WindowsWin7,
 	WindowsWin8,
 	WindowsXp,
-	Words,
+	With,
 	WordBreak,
 	WordSpaceTransform,
 	WordSpacing,
 	WordWrap,
+	Words,
 	Wrap,
 	WrapAfter,
 	WrapBefore,
@@ -2160,6 +2166,7 @@ pub enum CssAtomSet {
 	Xyz,
 	XyzD50,
 	XyzD65,
+	Y,
 	YEnd,
 	YSelfEnd,
 	YSelfStart,
@@ -2170,8 +2177,6 @@ pub enum CssAtomSet {
 	Zoom,
 	ZoomIn,
 	ZoomOut,
-	#[atom("n-")]
-	_NDash,
 	#[atom("-infinity")]
 	_NegInfinity,
 

--- a/crates/css_lexer/src/private.rs
+++ b/crates/css_lexer/src/private.rs
@@ -581,7 +581,15 @@ impl<'a> ByteCursor<'a> {
 				let (_, c2, c3) = if c == EOF && self.at_end() { (EOF, EOF, EOF) } else { self.peek3() };
 				if is_ident_start_sequence(c, c2, c3) {
 					let (unit_len, _, _, _, atom_bits, _) = self.consume_ident_sequence(atoms);
-					Token::new_dimension(is_float, has_sign, num_len as u32, unit_len, value, atom_bits as u8)
+					// Dimension token encoding packs the unit atom into 7 bits (discriminants 1-127).
+					// Unit atoms are all in the low discriminant range; non-unit keywords are placed
+					// above 127 by convention. Unknown suffixes are represented as atom 0.
+					debug_assert!(
+						atom_bits == 0 || atom_bits <= 127,
+						"atom with discriminant {atom_bits} used as dimension unit; non-unit atoms must have discriminant > 127"
+					);
+					let atom = if atom_bits <= 127 { atom_bits as u8 } else { 0 };
+					Token::new_dimension(is_float, has_sign, num_len as u32, unit_len, value, atom)
 				} else {
 					Token::new_number(is_float, has_sign, num_len as u32, value)
 				}


### PR DESCRIPTION
I noticed the Y atom was next to X, probably due to me finding a place to put
it, but that means Y is treated like a valid dimension atom, which is not true.
I fixed that by re-ordering the atoms. That got me thinking about how we can add
protections for this, so I added a debug_assert that dimension atoms should be
0-127 (just in case we end up checking a non-dimension as a dimension). This
then lead to me to realise there's one special case, N- which is _not_ a
dimension but due to weird rules around AnPlusB parsing we sometimes use it as
one... so that becomes the natural cutoff point for dimensions!

Now all CSS keywords themselves are 128+, and all CSS dimensions are 126-, with
`n-` sitting at the 127 point. Huzzah!
