### PR TITLE
css_lexer: Remove debug_assert! around atom bits

### DIFF
--- a/crates/css_lexer/src/private.rs
+++ b/crates/css_lexer/src/private.rs
@@ -580,16 +580,8 @@ impl<'a> ByteCursor<'a> {
 				let c = self.peek_char();
 				let (_, c2, c3) = if c == EOF && self.at_end() { (EOF, EOF, EOF) } else { self.peek3() };
 				if is_ident_start_sequence(c, c2, c3) {
-					let (unit_len, _, _, _, atom_bits, _) = self.consume_ident_sequence(atoms);
-					// Dimension token encoding packs the unit atom into 7 bits (discriminants 1-127).
-					// Unit atoms are all in the low discriminant range; non-unit keywords are placed
-					// above 127 by convention. Unknown suffixes are represented as atom 0.
-					debug_assert!(
-						atom_bits == 0 || atom_bits <= 127,
-						"atom with discriminant {atom_bits} used as dimension unit; non-unit atoms must have discriminant > 127"
-					);
-					let atom = if atom_bits <= 127 { atom_bits as u8 } else { 0 };
-					Token::new_dimension(is_float, has_sign, num_len as u32, unit_len, value, atom)
+					let (unit_len, _, _, _, atom, _) = self.consume_ident_sequence(atoms);
+					Token::new_dimension(is_float, has_sign, num_len as u32, unit_len, value, atom as u8)
 				} else {
 					Token::new_number(is_float, has_sign, num_len as u32, value)
 				}


### PR DESCRIPTION
In #989 we added a debug_assert! to ensure dimensions were in the lower bits,
but this isn't actually invariant, because of course arbitrary input can attempt
to use unknown dimensions (that are otherwise valid atoms). So we need to remove
this debug_assert!
