### PR TITLE
csskit_proc_macro/css_value_definition_parser: Optimize Alternatives by distributing types to discriminants

### DIFF
--- a/crates/css_value_definition_parser/src/lib.rs
+++ b/crates/css_value_definition_parser/src/lib.rs
@@ -378,6 +378,47 @@ impl Def {
 
 	pub fn optimize(&self) -> Self {
 		match self {
+			Self::Combinator(defs, DefCombinatorStyle::Alternatives)
+				if defs.iter().any(Self::has_distributable_group) =>
+			{
+				let distributed: Vec<Def> = defs
+					.iter()
+					.flat_map(|d| match d {
+						Def::Combinator(
+							children,
+							style @ (DefCombinatorStyle::Ordered | DefCombinatorStyle::AllMustOccur),
+						) => {
+							if let Some((group_idx, alts)) = children.iter().enumerate().find_map(|(i, c)| match c {
+								Def::Group(inner, _) => {
+									if let Def::Combinator(alts, DefCombinatorStyle::Alternatives) = inner.as_ref() {
+										Some((i, alts))
+									} else {
+										None
+									}
+								}
+								Def::Combinator(alts, DefCombinatorStyle::Alternatives) => Some((i, alts)),
+								_ => None,
+							}) {
+								let prefix = &children[..group_idx];
+								let suffix = &children[group_idx + 1..];
+								alts.iter()
+									.map(|alt| {
+										let mut new_children: Vec<Def> = prefix.to_vec();
+										new_children.push(alt.clone());
+										new_children.extend_from_slice(suffix);
+										Def::Combinator(new_children, *style)
+									})
+									.collect()
+							} else {
+								vec![d.clone()]
+							}
+						}
+						_ => vec![d.clone()],
+					})
+					.collect();
+				return Self::Combinator(distributed, DefCombinatorStyle::Alternatives).optimize();
+			}
+
 			Self::Combinator(defs, DefCombinatorStyle::Alternatives) if defs.len() == 2 => {
 				let [first, second] = defs.as_slice() else { panic!("defs.len() was 2!") };
 				match (first, second) {
@@ -546,6 +587,21 @@ impl Def {
 			_ => return self.clone(),
 		}
 		.optimize()
+	}
+
+	fn has_distributable_group(def: &Def) -> bool {
+		match def {
+			Def::Combinator(children, DefCombinatorStyle::Ordered | DefCombinatorStyle::AllMustOccur) => {
+				children.iter().any(|c| match c {
+					Def::Group(inner, _) => {
+						matches!(inner.as_ref(), Def::Combinator(_, DefCombinatorStyle::Alternatives))
+					}
+					Def::Combinator(_, DefCombinatorStyle::Alternatives) => true,
+					_ => false,
+				})
+			}
+			_ => false,
+		}
 	}
 
 	/// Returns the keyword name if `self` is a keyword-optional-prefixed ordered sequence:

--- a/crates/css_value_definition_parser/src/test.rs
+++ b/crates/css_value_definition_parser/src/test.rs
@@ -539,3 +539,66 @@ fn def_builds_auto_prefixed_group_range() {
 		)
 	);
 }
+
+#[test]
+fn optimize_distributes_ordered_with_nested_alternatives() {
+	// `normal | <overflow-position>? [ <content-position> | left | right ]`
+	// distributes to: `normal | <overflow-position>? <content-position> | <overflow-position>? left | <overflow-position>? right`
+	assert_eq!(
+		to_valuedef! { normal | <overflow-position>? [ <content-position> | left | right ] },
+		Def::Combinator(
+			vec![
+				Def::Ident(DefIdent("normal".into())),
+				Def::Combinator(
+					vec![
+						Def::Optional(Box::new(Def::Type(DefType::new("OverflowPosition", DefRange::None)))),
+						Def::Type(DefType::new("ContentPosition", DefRange::None)),
+					],
+					DefCombinatorStyle::Ordered,
+				),
+				Def::Combinator(
+					vec![
+						Def::Optional(Box::new(Def::Type(DefType::new("OverflowPosition", DefRange::None)))),
+						Def::Ident(DefIdent("left".into())),
+					],
+					DefCombinatorStyle::Ordered,
+				),
+				Def::Combinator(
+					vec![
+						Def::Optional(Box::new(Def::Type(DefType::new("OverflowPosition", DefRange::None)))),
+						Def::Ident(DefIdent("right".into())),
+					],
+					DefCombinatorStyle::Ordered,
+				),
+			],
+			DefCombinatorStyle::Alternatives,
+		)
+	);
+}
+
+#[test]
+fn optimize_distributes_all_must_occur_with_nested_alternatives() {
+	// `legacy | legacy && [ left | right | center ]`
+	// distributes to: `legacy | legacy && left | legacy && right | legacy && center`
+	assert_eq!(
+		to_valuedef! { legacy | legacy && [ left | right | center ] },
+		Def::Combinator(
+			vec![
+				Def::Ident(DefIdent("legacy".into())),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("legacy".into())), Def::Ident(DefIdent("left".into()))],
+					DefCombinatorStyle::AllMustOccur,
+				),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("legacy".into())), Def::Ident(DefIdent("right".into()))],
+					DefCombinatorStyle::AllMustOccur,
+				),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("legacy".into())), Def::Ident(DefIdent("center".into()))],
+					DefCombinatorStyle::AllMustOccur,
+				),
+			],
+			DefCombinatorStyle::Alternatives,
+		)
+	);
+}

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -112,6 +112,10 @@ impl ToFieldName for Def {
 				});
 				format_ident!("{}", get_type_rename(&auto_generated_name).unwrap_or(&auto_generated_name))
 			}
+			Self::Combinator(ds, DefCombinatorStyle::AllMustOccur) => {
+				let name: String = ds.iter().map(|d| d.to_variant_name(0).to_string()).collect();
+				format_ident!("{}", name)
+			}
 			Self::Combinator(_, _) => {
 				dbg!("TODO variant name for Combinator()", self);
 				todo!("variant name")
@@ -628,6 +632,18 @@ impl GenerateDefinition for Def {
 										quote! { #attrs #ty }
 									})
 									.collect(),
+								Self::Combinator(defs, DefCombinatorStyle::AllMustOccur) => {
+									if derives_parse {
+										attrs = Some(quote! { #[parse(all_must_occur)] });
+									}
+									defs.iter()
+										.map(|d| {
+											let ty = d.to_type();
+											let a = d.type_attributes(derives_parse, derives_visitable);
+											quote! { #a #ty }
+										})
+										.collect()
+								}
 								Self::Ident(_) => d.to_types(),
 								Self::IntLiteral(_) | Self::DimensionLiteral(_, _) => {
 									let attrs = attrs.take().unwrap();

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_with_group_alternatives.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_with_group_alternatives.snap
@@ -1,0 +1,30 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(Parse)]
+enum Foo {
+    #[atom(CssAtomSet::Legacy)]
+    Legacy(::css_parse::T![Ident]),
+    #[parse(all_must_occur)]
+    LegacyLeft(
+        #[atom(CssAtomSet::Legacy)]
+        ::css_parse::T![Ident],
+        #[atom(CssAtomSet::Left)]
+        ::css_parse::T![Ident],
+    ),
+    #[parse(all_must_occur)]
+    LegacyRight(
+        #[atom(CssAtomSet::Legacy)]
+        ::css_parse::T![Ident],
+        #[atom(CssAtomSet::Right)]
+        ::css_parse::T![Ident],
+    ),
+    #[parse(all_must_occur)]
+    LegacyCenter(
+        #[atom(CssAtomSet::Legacy)]
+        ::css_parse::T![Ident],
+        #[atom(CssAtomSet::Center)]
+        ::css_parse::T![Ident],
+    ),
+}

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__mixed_ordered_and_all_must_occur_distribution.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__mixed_ordered_and_all_must_occur_distribution.snap
@@ -1,0 +1,41 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(Parse)]
+enum Foo {
+    #[atom(CssAtomSet::Normal)]
+    Normal(::css_parse::T![Ident]),
+    SelfPosition(Option<crate::OverflowPosition>, crate::SelfPosition),
+    Left(
+        Option<crate::OverflowPosition>,
+        #[atom(CssAtomSet::Left)]
+        ::css_parse::T![Ident],
+    ),
+    Right(
+        Option<crate::OverflowPosition>,
+        #[atom(CssAtomSet::Right)]
+        ::css_parse::T![Ident],
+    ),
+    #[parse(all_must_occur)]
+    LegacyLeft(
+        #[atom(CssAtomSet::Legacy)]
+        ::css_parse::T![Ident],
+        #[atom(CssAtomSet::Left)]
+        ::css_parse::T![Ident],
+    ),
+    #[parse(all_must_occur)]
+    LegacyRight(
+        #[atom(CssAtomSet::Legacy)]
+        ::css_parse::T![Ident],
+        #[atom(CssAtomSet::Right)]
+        ::css_parse::T![Ident],
+    ),
+    #[parse(all_must_occur)]
+    LegacyCenter(
+        #[atom(CssAtomSet::Legacy)]
+        ::css_parse::T![Ident],
+        #[atom(CssAtomSet::Center)]
+        ::css_parse::T![Ident],
+    ),
+}

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_with_group_alternatives.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_with_group_alternatives.snap
@@ -1,0 +1,21 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(Parse)]
+enum Foo {
+    #[atom(CssAtomSet::Normal)]
+    Normal(::css_parse::T![Ident]),
+    ContentDistribution(crate::ContentDistribution),
+    ContentPosition(Option<crate::OverflowPosition>, crate::ContentPosition),
+    Left(
+        Option<crate::OverflowPosition>,
+        #[atom(CssAtomSet::Left)]
+        ::css_parse::T![Ident],
+    ),
+    Right(
+        Option<crate::OverflowPosition>,
+        #[atom(CssAtomSet::Right)]
+        ::css_parse::T![Ident],
+    ),
+}

--- a/crates/csskit_proc_macro/src/test/test_generate.rs
+++ b/crates/csskit_proc_macro/src/test/test_generate.rs
@@ -429,3 +429,25 @@ fn auto_and_length_with_range() {
 	let data = to_deriveinput! { #[derive(Parse)] struct Foo<'a>; };
 	assert_snapshot!(syntax, data, "auto_and_length_with_range");
 }
+
+#[test]
+fn ordered_with_group_alternatives() {
+	let syntax =
+		to_valuedef! { normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ] };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "ordered_with_group_alternatives");
+}
+
+#[test]
+fn all_must_occur_with_group_alternatives() {
+	let syntax = to_valuedef! { legacy | legacy && [ left | right | center ] };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "all_must_occur_with_group_alternatives");
+}
+
+#[test]
+fn mixed_ordered_and_all_must_occur_distribution() {
+	let syntax = to_valuedef! { normal | <overflow-position>? [ <self-position> | left | right ] | legacy && [ left | right | center ] };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "mixed_ordered_and_all_must_occur_distribution");
+}


### PR DESCRIPTION
Syntaxes like `foo && [ bar | baz ]` aren't currently supported due to the
group; which would potentially be a new sub-type, which in itself is a tricky
thing to figure out how to land. However, we can re-arrange this into a syntax
of `[ foo && bar ] | [ foo && baz ]`, without sacrificing much on the Rust side
of things (arguably an enum is more ergonomic than a struct for this kind of
type, and for the most part the datatype size would be equivalent).

So this change implements an optimize routine for Combinators of alternatives;
if their members can be distributed into a group, then we do that.

This will allow us to unlock declarations like the `justify-*`/`align-*` set of
declarations.
