### PR TITLE
css_value_definition_parser: Improve optimisations for Alternatives with optionals

### DIFF
--- a/crates/css_value_definition_parser/src/lib.rs
+++ b/crates/css_value_definition_parser/src/lib.rs
@@ -394,19 +394,32 @@ impl Def {
 									}) {
 									let prefix = &children[..group_idx];
 									let suffix = &children[group_idx + 1..];
-									alts.iter()
+									let mut result: Vec<Def> = alts
+										.iter()
 										.map(|alt| {
 											let mut new_children: Vec<Def> = prefix.to_vec();
-											let distributed_alt = if wrap_optional {
-												Def::Optional(Box::new(alt.clone()))
-											} else {
-												alt.clone()
-											};
-											new_children.push(distributed_alt);
+											new_children.push(alt.clone());
 											new_children.extend_from_slice(suffix);
 											Def::Combinator(new_children, *style)
 										})
-										.collect()
+										.collect();
+									if wrap_optional {
+										let mut absent: Vec<Def> = prefix.to_vec();
+										absent.extend_from_slice(suffix);
+										match absent.len() {
+											0 => {}
+											1 => {
+												let single = absent.into_iter().next().unwrap();
+												if let Some((alts, _)) = Self::extract_alternatives(&single) {
+													result.extend(alts.iter().cloned());
+												} else {
+													result.push(single);
+												}
+											}
+											_ => result.push(Def::Combinator(absent, *style)),
+										}
+									}
+									result
 								} else {
 									vec![d.clone()]
 								}
@@ -561,7 +574,44 @@ impl Def {
 				}
 			}
 			Self::Combinator(defs, style) => {
-				return Self::Combinator(defs.iter().map(|d| d.optimize()).collect(), *style);
+				// First optimize all children.
+				let optimized: Vec<Def> = defs.iter().map(|d| d.optimize()).collect();
+				if !matches!(style, DefCombinatorStyle::Alternatives)
+					&& let Some((group_idx, alts, wrap_optional)) = optimized
+						.iter()
+						.enumerate()
+						.find_map(|(i, c)| Self::extract_distributable(c, *style).map(|(alts, wrap)| (i, alts, wrap)))
+				{
+					let prefix = &optimized[..group_idx];
+					let suffix = &optimized[group_idx + 1..];
+					let mut distributed: Vec<Def> = alts
+						.iter()
+						.map(|alt| {
+							let mut new_children: Vec<Def> = prefix.to_vec();
+							new_children.push(alt.clone());
+							new_children.extend_from_slice(suffix);
+							Def::Combinator(new_children, *style)
+						})
+						.collect();
+					if wrap_optional {
+						let mut absent: Vec<Def> = prefix.to_vec();
+						absent.extend_from_slice(suffix);
+						match absent.len() {
+							0 => {}
+							1 => {
+								let single = absent.into_iter().next().unwrap();
+								if let Some((alts, _)) = Self::extract_alternatives(&single) {
+									distributed.extend(alts.iter().cloned());
+								} else {
+									distributed.push(single);
+								}
+							}
+							_ => distributed.push(Def::Combinator(absent, *style)),
+						}
+					}
+					return Self::Combinator(distributed, DefCombinatorStyle::Alternatives).optimize();
+				}
+				return Self::Combinator(optimized, *style);
 			}
 			// Optimize multiplier styles to avoid unnecessarily allocating.
 			// A Multiplier with a fixed range can be normalised to an Ordered combinator of the same value.
@@ -610,6 +660,16 @@ impl Def {
 			}
 			_ => None,
 		}
+	}
+
+	/// Extracts alternatives that need distribution for the given combinator style.
+	/// For top-level Ordered structs, all-keyword alternatives are handled by codegen's
+	/// `is_all_keywords()` → `keyword_ident` path and don't need distribution.
+	/// For AllMustOccur and other styles, all alternatives need distribution.
+	fn extract_distributable(def: &Def, style: DefCombinatorStyle) -> Option<(&[Def], bool)> {
+		Self::extract_alternatives(def).filter(|(alts, _)| {
+			!matches!(style, DefCombinatorStyle::Ordered) || !alts.iter().all(|d| matches!(d, Def::Ident(_)))
+		})
 	}
 
 	fn has_distributable_group(def: &Def) -> bool {

--- a/crates/css_value_definition_parser/src/test.rs
+++ b/crates/css_value_definition_parser/src/test.rs
@@ -607,55 +607,74 @@ fn optimize_distributes_all_must_occur_with_nested_alternatives() {
 fn optimize_distributes_optional_alternatives() {
 	// `none | [ x | y | both ] [ mandatory | proximity ]?`
 	// First pass distributes [x|y|both] across the Ordered children.
-	// Second pass distributes the Optional [mandatory|proximity]? into each Ordered.
-	// Result: none | x mandatory? | x proximity? | y mandatory? | y proximity? | both mandatory? | both proximity?
+	// Second pass distributes the Optional [mandatory|proximity]? into "present" + "absent" variants.
+	// Result: none | x mandatory | x proximity | x | y mandatory | y proximity | y | both mandatory | both proximity | both
 	assert_eq!(
 		to_valuedef! { none | [ x | y | both ] [ mandatory | proximity ]? },
 		Def::Combinator(
 			vec![
 				Def::Ident(DefIdent("none".into())),
 				Def::Combinator(
-					vec![
-						Def::Ident(DefIdent("x".into())),
-						Def::Optional(Box::new(Def::Ident(DefIdent("mandatory".into())))),
-					],
+					vec![Def::Ident(DefIdent("x".into())), Def::Ident(DefIdent("mandatory".into()))],
 					DefCombinatorStyle::Ordered,
 				),
 				Def::Combinator(
-					vec![
-						Def::Ident(DefIdent("x".into())),
-						Def::Optional(Box::new(Def::Ident(DefIdent("proximity".into())))),
-					],
+					vec![Def::Ident(DefIdent("x".into())), Def::Ident(DefIdent("proximity".into()))],
+					DefCombinatorStyle::Ordered,
+				),
+				Def::Ident(DefIdent("x".into())),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("y".into())), Def::Ident(DefIdent("mandatory".into()))],
 					DefCombinatorStyle::Ordered,
 				),
 				Def::Combinator(
-					vec![
-						Def::Ident(DefIdent("y".into())),
-						Def::Optional(Box::new(Def::Ident(DefIdent("mandatory".into())))),
-					],
+					vec![Def::Ident(DefIdent("y".into())), Def::Ident(DefIdent("proximity".into()))],
+					DefCombinatorStyle::Ordered,
+				),
+				Def::Ident(DefIdent("y".into())),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("both".into())), Def::Ident(DefIdent("mandatory".into()))],
 					DefCombinatorStyle::Ordered,
 				),
 				Def::Combinator(
-					vec![
-						Def::Ident(DefIdent("y".into())),
-						Def::Optional(Box::new(Def::Ident(DefIdent("proximity".into())))),
-					],
+					vec![Def::Ident(DefIdent("both".into())), Def::Ident(DefIdent("proximity".into()))],
 					DefCombinatorStyle::Ordered,
+				),
+				Def::Ident(DefIdent("both".into())),
+			],
+			DefCombinatorStyle::Alternatives,
+		)
+	);
+}
+
+#[test]
+fn optimize_distributes_top_level_all_must_occur() {
+	// `[ over | under ] && [ right | left ]?`
+	// Lifts AllMustOccur into Alternatives, distributing both groups:
+	// First pass distributes [over|under], then [right|left]? distributes with "absent" variant.
+	// Result: over && right | over && left | over | under && right | under && left | under
+	assert_eq!(
+		to_valuedef! { [ over | under ] && [ right | left ]? },
+		Def::Combinator(
+			vec![
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("over".into())), Def::Ident(DefIdent("right".into()))],
+					DefCombinatorStyle::AllMustOccur,
 				),
 				Def::Combinator(
-					vec![
-						Def::Ident(DefIdent("both".into())),
-						Def::Optional(Box::new(Def::Ident(DefIdent("mandatory".into())))),
-					],
-					DefCombinatorStyle::Ordered,
+					vec![Def::Ident(DefIdent("over".into())), Def::Ident(DefIdent("left".into()))],
+					DefCombinatorStyle::AllMustOccur,
+				),
+				Def::Ident(DefIdent("over".into())),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("under".into())), Def::Ident(DefIdent("right".into()))],
+					DefCombinatorStyle::AllMustOccur,
 				),
 				Def::Combinator(
-					vec![
-						Def::Ident(DefIdent("both".into())),
-						Def::Optional(Box::new(Def::Ident(DefIdent("proximity".into())))),
-					],
-					DefCombinatorStyle::Ordered,
+					vec![Def::Ident(DefIdent("under".into())), Def::Ident(DefIdent("left".into()))],
+					DefCombinatorStyle::AllMustOccur,
 				),
+				Def::Ident(DefIdent("under".into())),
 			],
 			DefCombinatorStyle::Alternatives,
 		)

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -151,17 +151,30 @@ fn generate_keyword_parsing(
 	match parse_mode {
 		FieldParseMode::Sequential => {
 			let condition = atom.equals_atom(format_ident!("c"));
-			let ty = ty.unpack_option();
-			where_collector.add(&ty);
-			quote! {
-				let #var = {
-					let c = p.peek_n(1);
-					if #condition {
-						p.parse::<#ty>()?
-					} else {
-						return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
-					}
-				};
+			let inner_ty = ty.unpack_option();
+			where_collector.add(&inner_ty);
+			if ty.is_option() {
+				quote! {
+					let #var = {
+						let c = p.peek_n(1);
+						if #condition {
+							Some(p.parse::<#inner_ty>()?)
+						} else {
+							None
+						}
+					};
+				}
+			} else {
+				quote! {
+					let #var = {
+						let c = p.peek_n(1);
+						if #condition {
+							p.parse::<#inner_ty>()?
+						} else {
+							return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
+						}
+					};
+				}
 			}
 		}
 		FieldParseMode::AllMustOccur | FieldParseMode::OneMustOccur => {

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -96,9 +96,25 @@ impl ToFieldName for Def {
 			Self::IntLiteral(v) => format_ident!("Literal{}", v.to_string()),
 			Self::DimensionLiteral(int, dim) => format_ident!("Literal{int}{dim}"),
 			Self::Combinator(ds, DefCombinatorStyle::Ordered) => {
-				let (optional, others): (Vec<&Def>, Vec<&Def>) = ds.iter().partition(|d| matches!(d, Def::Optional(_)));
-				let logical_first = others.first().or(optional.first());
-				logical_first.expect("At least one Def is required").to_variant_name(0)
+				let non_optional: Vec<String> = ds
+					.iter()
+					.filter(|d| !matches!(d, Def::Optional(_)))
+					.map(|d| d.to_variant_name(0).to_string())
+					.collect();
+				let distinct_count = {
+					let mut uniq = non_optional.clone();
+					uniq.dedup();
+					uniq.len()
+				};
+				if distinct_count > 1 {
+					let name: String = ds.iter().map(|d| d.to_variant_name(0).to_string()).collect();
+					format_ident!("{}", name)
+				} else {
+					let (optional, others): (Vec<&Def>, Vec<&Def>) =
+						ds.iter().partition(|d| matches!(d, Def::Optional(_)));
+					let logical_first = others.first().or(optional.first());
+					logical_first.expect("At least one Def is required").to_variant_name(0)
+				}
 			}
 			Self::Combinator(ds, DefCombinatorStyle::Options) => {
 				let auto_generated_name = ds.iter().fold(String::new(), |str, d| match d {
@@ -165,18 +181,10 @@ impl ToType for Def {
 				let ty = ty.to_type();
 				vec![quote! { crate::NormalOr<#ty> }]
 			}
-			Self::Optional(v) => match v.as_ref() {
-				// When an optional ident appears as a keyword prefix (e.g. `auto?`),
-				// reference the standalone keyword type rather than bare T![Ident].
-				Self::Ident(DefIdent(name)) => {
-					let kw_type = format_ident!("{}", name.to_pascal_case());
-					vec![quote! { Option<crate::#kw_type> }]
-				}
-				_ => {
-					let ty = v.to_type();
-					vec![quote! { Option<#ty> }]
-				}
-			},
+			Self::Optional(v) => {
+				let ty = v.to_type();
+				vec![quote! { Option<#ty> }]
+			}
 			Self::Function(_, _) => {
 				let func_name = self.to_variant_name(0);
 				let generics = self.get_generics();
@@ -320,6 +328,13 @@ impl DefExt for Def {
 				let name = format_ident!("{}", str.to_pascal_case());
 				quote! { #[atom(CssAtomSet::#name)] }
 			}
+			Def::Optional(inner) => match inner.as_ref() {
+				Def::Ident(DefIdent(str)) if derives_parse => {
+					let name = format_ident!("{}", str.to_pascal_case());
+					quote! { #[atom(CssAtomSet::#name)] }
+				}
+				_ => quote! {},
+			},
 			_ => quote! {},
 		};
 		quote! { #skip #atom }


### PR DESCRIPTION
In https://github.com/csskit/csskit/pull/1018 and
https://github.com/csskit/csskit/pull/1016 we optimised Alternatives by
expanding e.g. `foo [ bar | baz ]?` to `foo | foo bar? | foo baz?`. One issue
with this is the per-branch `?`s get redundantly leaked in every variant, and
bare top-level groups like `[over|under] && [right|left]?` were never lifted at
all.

This change reworks optimisation to now ensure redundant `?`s are dropped (so
`foo | foo bar | foo baz`) and lifts top-level Ordered/AllMustOccur into
Alternatives, with all-keyword Ordered skipped since codegen already handles it
via `keyword_ident`. Codegen follows the new shape: Ordered variant names
concatenate all parts to avoid collisions on the first-ident heuristic,
`Optional(Ident)` emits `Option<T>` directly (forwarding `#[atom(...)]`) instead
of unwrapping to the keyword type, and sequential keyword parsing for `Option<T>`
returns `Some`/`None` rather than erroring on absence.
