### PR TITLE
csskit_proc_macro: Don't factor Puncts into variant names

### DIFF
--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -98,7 +98,7 @@ impl ToFieldName for Def {
 			Self::Combinator(ds, DefCombinatorStyle::Ordered) => {
 				let non_optional: Vec<String> = ds
 					.iter()
-					.filter(|d| !matches!(d, Def::Optional(_)))
+					.filter(|d| !matches!(d, Def::Optional(_) | Def::Punct(_)))
 					.map(|d| d.to_variant_name(0).to_string())
 					.collect();
 				let distinct_count = {
@@ -107,11 +107,15 @@ impl ToFieldName for Def {
 					uniq.len()
 				};
 				if distinct_count > 1 {
-					let name: String = ds.iter().map(|d| d.to_variant_name(0).to_string()).collect();
+					let name: String = ds
+						.iter()
+						.filter(|d| !matches!(d, Def::Punct(_)))
+						.map(|d| d.to_variant_name(0).to_string())
+						.collect();
 					format_ident!("{}", name)
 				} else {
 					let (optional, others): (Vec<&Def>, Vec<&Def>) =
-						ds.iter().partition(|d| matches!(d, Def::Optional(_)));
+						ds.iter().filter(|d| !matches!(d, Def::Punct(_))).partition(|d| matches!(d, Def::Optional(_)));
 					let logical_first = others.first().or(optional.first());
 					logical_first.expect("At least one Def is required").to_variant_name(0)
 				}
@@ -129,17 +133,18 @@ impl ToFieldName for Def {
 				format_ident!("{}", get_type_rename(&auto_generated_name).unwrap_or(&auto_generated_name))
 			}
 			Self::Combinator(ds, DefCombinatorStyle::AllMustOccur) => {
-				let name: String = ds.iter().map(|d| d.to_variant_name(0).to_string()).collect();
+				let name: String = ds
+					.iter()
+					.filter(|d| !matches!(d, Def::Punct(_)))
+					.map(|d| d.to_variant_name(0).to_string())
+					.collect();
 				format_ident!("{}", name)
 			}
 			Self::Combinator(_, _) => {
 				dbg!("TODO variant name for Combinator()", self);
 				todo!("variant name")
 			}
-			Self::Punct(_) => {
-				dbg!("TODO variant name for Punct()", self);
-				todo!("variant name")
-			}
+			Self::Punct(c) => panic!("Punct('{c}') has no variant name; filter before calling to_variant_name"),
 		}
 	}
 }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_ordered_punct.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_ordered_punct.snap
@@ -1,0 +1,11 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(Parse)]
+enum Foo {
+    #[atom(CssAtomSet::None)]
+    None(::css_parse::T![Ident]),
+    Number(crate::Number, (::css_parse::T![/], crate::Number)),
+    Length(crate::Length),
+}

--- a/crates/csskit_proc_macro/src/test/test_generate.rs
+++ b/crates/csskit_proc_macro/src/test/test_generate.rs
@@ -451,3 +451,10 @@ fn mixed_ordered_and_all_must_occur_distribution() {
 	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
 	assert_snapshot!(syntax, data, "mixed_ordered_and_all_must_occur_distribution");
 }
+
+#[test]
+fn enum_with_ordered_punct() {
+	let syntax = to_valuedef! { none | <number> / <number> | <length> };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "enum_with_ordered_punct");
+}


### PR DESCRIPTION
Right now when trying to generate a variant name for a type with a Punct, we'll
get a panic due to the todo!() for `Punct`s. Puncts dont really need to be
"serialized" into a variant name though - they're usually in place to
disambiguate some syntaxes.

So this fixes them by filtering out Puncts (alongside Optionals) in the variant
name. Easy.
