### PR TITLE
css_value_definition_parser: Avoid distributing repeated multipliers

### DIFF
--- a/crates/css_value_definition_parser/src/lib.rs
+++ b/crates/css_value_definition_parser/src/lib.rs
@@ -576,7 +576,15 @@ impl Def {
 			Self::Combinator(defs, style) => {
 				// First optimize all children.
 				let optimized: Vec<Def> = defs.iter().map(|d| d.optimize()).collect();
+				let is_repeated_multiplier = {
+					let extractable: Vec<_> = optimized.iter().filter_map(Self::extract_alternatives).collect();
+					extractable.len() == optimized.len() && {
+						let first = extractable[0].0;
+						extractable.iter().all(|(alts, _)| *alts == first)
+					}
+				};
 				if !matches!(style, DefCombinatorStyle::Alternatives)
+					&& !is_repeated_multiplier
 					&& let Some((group_idx, alts, wrap_optional)) = optimized
 						.iter()
 						.enumerate()
@@ -675,7 +683,17 @@ impl Def {
 	fn has_distributable_group(def: &Def) -> bool {
 		match def {
 			Def::Combinator(children, DefCombinatorStyle::Ordered | DefCombinatorStyle::AllMustOccur) => {
-				children.iter().any(|c| Self::extract_alternatives(c).is_some())
+				let extractable: Vec<_> = children.iter().filter_map(Self::extract_alternatives).collect();
+				if extractable.is_empty() {
+					return false;
+				}
+				if extractable.len() == children.len() {
+					let first_alts = extractable[0].0;
+					if extractable.iter().all(|(alts, _)| *alts == first_alts) {
+						return false;
+					}
+				}
+				true
 			}
 			_ => false,
 		}

--- a/crates/css_value_definition_parser/src/test.rs
+++ b/crates/css_value_definition_parser/src/test.rs
@@ -541,6 +541,23 @@ fn def_builds_auto_prefixed_group_range() {
 }
 
 #[test]
+fn optimize_skips_distribution_for_multiplier_expansion() {
+	let def = to_valuedef! { "[ <color> | <image-1D> ]{1,4}" };
+	assert!(matches!(&def, Def::Combinator(_, DefCombinatorStyle::Ordered)));
+	if let Def::Combinator(children, _) = &def {
+		assert_eq!(children.len(), 4); // T, Optional(T), Optional(T), Optional(T)
+		// First child should be an Alternatives (not distributed)
+		assert!(matches!(&children[0], Def::Combinator(_, DefCombinatorStyle::Alternatives)));
+		// Remaining should be Optional(Alternatives)
+		for child in &children[1..] {
+			assert!(
+				matches!(child, Def::Optional(inner) if matches!(inner.as_ref(), Def::Combinator(_, DefCombinatorStyle::Alternatives)))
+			);
+		}
+	}
+}
+
+#[test]
 fn optimize_distributes_ordered_with_nested_alternatives() {
 	// `normal | <overflow-position>? [ <content-position> | left | right ]`
 	// distributes to: `normal | <overflow-position>? <content-position> | <overflow-position>? left | <overflow-position>? right`


### PR DESCRIPTION
Attempt to take a multiplier and distributing into variants can cause
combinatorial explosions. We should not do this!

This change checks if something is a repeated multiplier and ensures
alternatives don't get extracted in this case.
