### PR TITLE
csskit_proc_macro: Geenrate Optionals subtypes for small groups

### DIFF
--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
@@ -13781,19 +13781,22 @@ StyleSheet(
                 offset: SourceOffset(9720),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(9722),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(9724),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(9726),
-                len: 4,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(9722),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(9724),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(9726),
+                  len: 4,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -13932,19 +13935,22 @@ StyleSheet(
                 offset: SourceOffset(9799),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(9801),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(9803),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(9805),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(9801),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(9803),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(9805),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -14083,19 +14089,22 @@ StyleSheet(
                 offset: SourceOffset(9883),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(9885),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(9887),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(9889),
-                len: 10,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(9885),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(9887),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(9889),
+                  len: 10,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -14234,19 +14243,22 @@ StyleSheet(
                 offset: SourceOffset(9974),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(9976),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(9978),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(9980),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(9976),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(9978),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(9980),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -14385,19 +14397,22 @@ StyleSheet(
                 offset: SourceOffset(10051),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10053),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10055),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10057),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10053),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10055),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10057),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -14536,19 +14551,22 @@ StyleSheet(
                 offset: SourceOffset(10135),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10137),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10139),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10141),
-                len: 10,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10137),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10139),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10141),
+                  len: 10,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -14677,19 +14695,22 @@ StyleSheet(
                 offset: SourceOffset(10221),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10223),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10225),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(10227),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10223),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10225),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(10227),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -14841,19 +14862,22 @@ StyleSheet(
                 offset: SourceOffset(10312),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10314),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10316),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10318),
-                len: 9,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10314),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10316),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10318),
+                  len: 9,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -14982,19 +15006,22 @@ StyleSheet(
                 offset: SourceOffset(10399),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10401),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10403),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10405),
-                len: 10,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10401),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10403),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10405),
+                  len: 10,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -15123,19 +15150,22 @@ StyleSheet(
                 offset: SourceOffset(10481),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10483),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10485),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10487),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10483),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10485),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10487),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -15264,19 +15294,22 @@ StyleSheet(
                 offset: SourceOffset(10556),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10558),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10560),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10562),
-                len: 10,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10558),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10560),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10562),
+                  len: 10,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -15405,19 +15438,22 @@ StyleSheet(
                 offset: SourceOffset(10645),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10647),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10649),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10651),
-                len: 10,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10647),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10649),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10651),
+                  len: 10,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -15546,19 +15582,22 @@ StyleSheet(
                 offset: SourceOffset(10727),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10729),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10731),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10733),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10729),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10731),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10733),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -15687,19 +15726,22 @@ StyleSheet(
                 offset: SourceOffset(10802),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10804),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10806),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10808),
-                len: 10,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10804),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10806),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10808),
+                  len: 10,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -15828,19 +15870,22 @@ StyleSheet(
                 offset: SourceOffset(10891),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10893),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10895),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10897),
-                len: 10,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10893),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10895),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10897),
+                  len: 10,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -15969,19 +16014,22 @@ StyleSheet(
                 offset: SourceOffset(10973),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10975),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10977),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10979),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10975),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10977),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10979),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -16110,19 +16158,22 @@ StyleSheet(
                 offset: SourceOffset(11049),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(11051),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(11053),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(11055),
-                len: 10,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(11051),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(11053),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(11055),
+                  len: 10,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -16251,19 +16302,22 @@ StyleSheet(
                 offset: SourceOffset(11139),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(11141),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(11143),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(11145),
-                len: 10,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(11141),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(11143),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(11145),
+                  len: 10,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -16392,19 +16446,22 @@ StyleSheet(
                 offset: SourceOffset(11223),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(11225),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(11227),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(11229),
-                len: 4,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(11225),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(11227),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(11229),
+                  len: 4,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -18741,19 +18798,22 @@ StyleSheet(
                       offset: SourceOffset(12639),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(12641),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(12643),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(12645),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(12641),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(12643),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(12645),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -18892,19 +18952,22 @@ StyleSheet(
                       offset: SourceOffset(12730),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(12732),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(12734),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(12736),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(12732),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(12734),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(12736),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -19043,19 +19106,22 @@ StyleSheet(
                       offset: SourceOffset(12826),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(12828),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(12830),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(12832),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(12828),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(12830),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(12832),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -19194,19 +19260,22 @@ StyleSheet(
                       offset: SourceOffset(12929),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(12931),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(12933),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(12935),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(12931),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(12933),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(12935),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -19345,19 +19414,22 @@ StyleSheet(
                       offset: SourceOffset(13018),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13020),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13022),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13024),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13020),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13022),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13024),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -19496,19 +19568,22 @@ StyleSheet(
                       offset: SourceOffset(13114),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13116),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13118),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13120),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13116),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13118),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13120),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -19637,19 +19712,22 @@ StyleSheet(
                       offset: SourceOffset(13212),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13214),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13216),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(13218),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13214),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13216),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(13218),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -19801,19 +19879,22 @@ StyleSheet(
                       offset: SourceOffset(13317),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13319),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13321),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13323),
-                      len: 9,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13319),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13321),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13323),
+                        len: 9,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -19942,19 +20023,22 @@ StyleSheet(
                       offset: SourceOffset(13416),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13418),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13420),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13422),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13418),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13420),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13422),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -20083,19 +20167,22 @@ StyleSheet(
                       offset: SourceOffset(13510),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13512),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13514),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13516),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13512),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13514),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13516),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -20224,19 +20311,22 @@ StyleSheet(
                       offset: SourceOffset(13597),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13599),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13601),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13603),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13599),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13601),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13603),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -20365,19 +20455,22 @@ StyleSheet(
                       offset: SourceOffset(13698),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13700),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13702),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13704),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13700),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13702),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13704),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -20506,19 +20599,22 @@ StyleSheet(
                       offset: SourceOffset(13792),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13794),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13796),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13798),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13794),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13796),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13798),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -20647,19 +20743,22 @@ StyleSheet(
                       offset: SourceOffset(13879),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13881),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13883),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13885),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13881),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13883),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13885),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -20788,19 +20887,22 @@ StyleSheet(
                       offset: SourceOffset(13980),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13982),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(13984),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(13986),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13982),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(13984),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(13986),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -20929,19 +21031,22 @@ StyleSheet(
                       offset: SourceOffset(14074),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14076),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14078),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(14080),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14076),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14078),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(14080),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -21070,19 +21175,22 @@ StyleSheet(
                       offset: SourceOffset(14162),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14164),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14166),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(14168),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14164),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14166),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(14168),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -21211,19 +21319,22 @@ StyleSheet(
                       offset: SourceOffset(14264),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14266),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14268),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(14270),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14266),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14268),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(14270),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -21352,19 +21463,22 @@ StyleSheet(
                       offset: SourceOffset(14360),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14362),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14364),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(14366),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14362),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14364),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(14366),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23767,19 +23881,22 @@ StyleSheet(
                       offset: SourceOffset(16061),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16063),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16065),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(16067),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16063),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16065),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(16067),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23918,19 +24035,22 @@ StyleSheet(
                       offset: SourceOffset(16152),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16154),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16156),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(16158),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16154),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16156),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(16158),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24069,19 +24189,22 @@ StyleSheet(
                       offset: SourceOffset(16248),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16250),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16252),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(16254),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16250),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16252),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(16254),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24220,19 +24343,22 @@ StyleSheet(
                       offset: SourceOffset(16351),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16353),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16355),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(16357),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16353),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16355),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(16357),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24371,19 +24497,22 @@ StyleSheet(
                       offset: SourceOffset(16440),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16442),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16444),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(16446),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16442),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16444),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(16446),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24522,19 +24651,22 @@ StyleSheet(
                       offset: SourceOffset(16536),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16538),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16540),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(16542),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16538),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16540),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(16542),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24663,19 +24795,22 @@ StyleSheet(
                       offset: SourceOffset(16634),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16636),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16638),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16640),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16636),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16638),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16640),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24827,19 +24962,22 @@ StyleSheet(
                       offset: SourceOffset(16739),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16741),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16743),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(16745),
-                      len: 9,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16741),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16743),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(16745),
+                        len: 9,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24968,19 +25106,22 @@ StyleSheet(
                       offset: SourceOffset(16838),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16840),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16842),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(16844),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16840),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16842),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(16844),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25109,19 +25250,22 @@ StyleSheet(
                       offset: SourceOffset(16932),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16934),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16936),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(16938),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16934),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16936),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(16938),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25250,19 +25394,22 @@ StyleSheet(
                       offset: SourceOffset(17019),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17021),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17023),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17025),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17021),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17023),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17025),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25391,19 +25538,22 @@ StyleSheet(
                       offset: SourceOffset(17120),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17122),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17124),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17126),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17122),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17124),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17126),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25532,19 +25682,22 @@ StyleSheet(
                       offset: SourceOffset(17214),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17216),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17218),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17220),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17216),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17218),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17220),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25673,19 +25826,22 @@ StyleSheet(
                       offset: SourceOffset(17301),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17303),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17305),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17307),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17303),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17305),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17307),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25814,19 +25970,22 @@ StyleSheet(
                       offset: SourceOffset(17402),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17404),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17406),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17408),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17404),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17406),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17408),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25955,19 +26114,22 @@ StyleSheet(
                       offset: SourceOffset(17496),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17498),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17500),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17502),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17498),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17500),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17502),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26096,19 +26258,22 @@ StyleSheet(
                       offset: SourceOffset(17584),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17586),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17588),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17590),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17586),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17588),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17590),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26237,19 +26402,22 @@ StyleSheet(
                       offset: SourceOffset(17686),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17688),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17690),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17692),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17688),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17690),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17692),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26378,19 +26546,22 @@ StyleSheet(
                       offset: SourceOffset(17782),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17784),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17786),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17788),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17784),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17786),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17788),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -28793,19 +28964,22 @@ StyleSheet(
                       offset: SourceOffset(19483),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19485),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19487),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(19489),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19485),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19487),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(19489),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -28944,19 +29118,22 @@ StyleSheet(
                       offset: SourceOffset(19574),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19576),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19578),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(19580),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19576),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19578),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(19580),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29095,19 +29272,22 @@ StyleSheet(
                       offset: SourceOffset(19670),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19672),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19674),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(19676),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19672),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19674),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(19676),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29246,19 +29426,22 @@ StyleSheet(
                       offset: SourceOffset(19773),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19775),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19777),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(19779),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19775),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19777),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(19779),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29397,19 +29580,22 @@ StyleSheet(
                       offset: SourceOffset(19862),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19864),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19866),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(19868),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19864),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19866),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(19868),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29548,19 +29734,22 @@ StyleSheet(
                       offset: SourceOffset(19958),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19960),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19962),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(19964),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19960),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19962),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(19964),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29689,19 +29878,22 @@ StyleSheet(
                       offset: SourceOffset(20056),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20058),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20060),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20062),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20058),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20060),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20062),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29853,19 +30045,22 @@ StyleSheet(
                       offset: SourceOffset(20161),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20163),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20165),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20167),
-                      len: 9,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20163),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20165),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20167),
+                        len: 9,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29994,19 +30189,22 @@ StyleSheet(
                       offset: SourceOffset(20260),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20262),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20264),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20266),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20262),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20264),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20266),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30135,19 +30333,22 @@ StyleSheet(
                       offset: SourceOffset(20354),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20356),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20358),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20360),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20356),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20358),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20360),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30276,19 +30477,22 @@ StyleSheet(
                       offset: SourceOffset(20441),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20443),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20445),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20447),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20443),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20445),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20447),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30417,19 +30621,22 @@ StyleSheet(
                       offset: SourceOffset(20542),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20544),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20546),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20548),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20544),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20546),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20548),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30558,19 +30765,22 @@ StyleSheet(
                       offset: SourceOffset(20636),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20638),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20640),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20642),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20638),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20640),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20642),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30699,19 +30909,22 @@ StyleSheet(
                       offset: SourceOffset(20723),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20725),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20727),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20729),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20725),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20727),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20729),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30840,19 +31053,22 @@ StyleSheet(
                       offset: SourceOffset(20824),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20826),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20828),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20830),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20826),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20828),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20830),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30981,19 +31197,22 @@ StyleSheet(
                       offset: SourceOffset(20918),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20920),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20922),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20924),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20920),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20922),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20924),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -31122,19 +31341,22 @@ StyleSheet(
                       offset: SourceOffset(21006),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21008),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21010),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(21012),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21008),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21010),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(21012),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -31263,19 +31485,22 @@ StyleSheet(
                       offset: SourceOffset(21108),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21110),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21112),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(21114),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21110),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21112),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(21114),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -31404,19 +31629,22 @@ StyleSheet(
                       offset: SourceOffset(21204),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21206),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21208),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(21210),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21206),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21208),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(21210),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33819,19 +34047,22 @@ StyleSheet(
                       offset: SourceOffset(22906),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22908),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22910),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(22912),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22908),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22910),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(22912),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33970,19 +34201,22 @@ StyleSheet(
                       offset: SourceOffset(22997),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22999),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23001),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23003),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22999),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23001),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23003),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34121,19 +34355,22 @@ StyleSheet(
                       offset: SourceOffset(23093),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23095),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23097),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23099),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23095),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23097),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23099),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34272,19 +34509,22 @@ StyleSheet(
                       offset: SourceOffset(23196),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23198),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23200),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23202),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23198),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23200),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23202),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34423,19 +34663,22 @@ StyleSheet(
                       offset: SourceOffset(23285),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23287),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23289),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23291),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23287),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23289),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23291),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34574,19 +34817,22 @@ StyleSheet(
                       offset: SourceOffset(23381),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23383),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23385),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23387),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23383),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23385),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23387),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34715,19 +34961,22 @@ StyleSheet(
                       offset: SourceOffset(23479),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23481),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23483),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23485),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23481),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23483),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23485),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34879,19 +35128,22 @@ StyleSheet(
                       offset: SourceOffset(23584),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23586),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23588),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23590),
-                      len: 9,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23586),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23588),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23590),
+                        len: 9,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -35020,19 +35272,22 @@ StyleSheet(
                       offset: SourceOffset(23683),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23685),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23687),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23689),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23685),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23687),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23689),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -35161,19 +35416,22 @@ StyleSheet(
                       offset: SourceOffset(23777),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23779),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23781),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23783),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23779),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23781),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23783),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -35302,19 +35560,22 @@ StyleSheet(
                       offset: SourceOffset(23864),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23866),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23868),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23870),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23866),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23868),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23870),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -35443,19 +35704,22 @@ StyleSheet(
                       offset: SourceOffset(23965),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23967),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23969),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(23971),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23967),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23969),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(23971),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -35584,19 +35848,22 @@ StyleSheet(
                       offset: SourceOffset(24059),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24061),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24063),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(24065),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24061),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24063),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(24065),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -35725,19 +35992,22 @@ StyleSheet(
                       offset: SourceOffset(24146),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24148),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24150),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(24152),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24148),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24150),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(24152),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -35866,19 +36136,22 @@ StyleSheet(
                       offset: SourceOffset(24247),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24249),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24251),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(24253),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24249),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24251),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(24253),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36007,19 +36280,22 @@ StyleSheet(
                       offset: SourceOffset(24341),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24343),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24345),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(24347),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24343),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24345),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(24347),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36148,19 +36424,22 @@ StyleSheet(
                       offset: SourceOffset(24429),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24431),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24433),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(24435),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24431),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24433),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(24435),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36289,19 +36568,22 @@ StyleSheet(
                       offset: SourceOffset(24531),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24533),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24535),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(24537),
-                      len: 10,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24533),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24535),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(24537),
+                        len: 10,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36430,19 +36712,22 @@ StyleSheet(
                       offset: SourceOffset(24627),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24629),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(24631),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(24633),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24629),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(24631),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(24633),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -62311,19 +62596,22 @@ StyleSheet(
                       offset: SourceOffset(45186),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45188),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45190),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(45192),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45188),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45190),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(45192),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -94240,19 +94528,22 @@ StyleSheet(
                 offset: SourceOffset(66966),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(66968),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(66970),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(66972),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(66968),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(66970),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(66972),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -98285,19 +98576,22 @@ StyleSheet(
                 offset: SourceOffset(69947),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(69949),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(69951),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(69953),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(69949),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(69951),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(69953),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -120454,19 +120748,22 @@ StyleSheet(
                 offset: SourceOffset(88498),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(88500),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(88502),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(88504),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(88500),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(88502),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(88504),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -135130,19 +135427,22 @@ StyleSheet(
                 offset: SourceOffset(100441),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(100443),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(100445),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(100447),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(100443),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(100445),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(100447),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -137736,19 +138036,22 @@ StyleSheet(
                       offset: SourceOffset(102226),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(102228),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(102230),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(102232),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(102228),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(102230),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(102232),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -138227,19 +138530,22 @@ StyleSheet(
                       offset: SourceOffset(102561),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(102563),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(102565),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(102567),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(102563),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(102565),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(102567),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -152709,11 +153015,14 @@ StyleSheet(
                 offset: SourceOffset(113190),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(113192),
-                len: 1,
-              ))), None)), None))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(113192),
+                  len: 1,
+                ))), None)),
+                flex_basis: None,
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -166725,19 +167034,22 @@ StyleSheet(
                 offset: SourceOffset(125465),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(125467),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(125469),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(125471),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(125467),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(125469),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(125471),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -180889,19 +181201,22 @@ StyleSheet(
                 offset: SourceOffset(136719),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(136721),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(136723),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(136725),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(136721),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(136723),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(136725),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -194767,19 +195082,22 @@ StyleSheet(
                 offset: SourceOffset(147659),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(147661),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(147663),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(147665),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(147661),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(147663),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(147665),
+                  len: 4,
+                ))))),
+              ))),
               important: Some(BangImportant(
                 bang: Bang(Delim(Cursor(
                   kind: "Delim",
@@ -198781,19 +199099,22 @@ StyleSheet(
                       offset: SourceOffset(151114),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(151116),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(151118),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(151120),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(151116),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(151118),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(151120),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -202803,19 +203124,22 @@ StyleSheet(
                       offset: SourceOffset(154833),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(154835),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(154837),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(154839),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(154835),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(154837),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(154839),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -206825,19 +207149,22 @@ StyleSheet(
                       offset: SourceOffset(158552),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(158554),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(158556),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(158558),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(158554),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(158556),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(158558),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -210847,19 +211174,22 @@ StyleSheet(
                       offset: SourceOffset(162272),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(162274),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(162276),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(162278),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(162274),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(162276),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(162278),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.min.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.min.snap
@@ -19100,19 +19100,22 @@ StyleSheet(
                 offset: SourceOffset(12697),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12698),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12700),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(12702),
-                len: 2,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12698),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12700),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(12702),
+                  len: 2,
+                ))))))),
+              ))),
               important: None,
               semicolon: None,
             ),
@@ -19172,19 +19175,22 @@ StyleSheet(
                 offset: SourceOffset(12726),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12727),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12729),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(12731),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12727),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12729),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(12731),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -19267,19 +19273,22 @@ StyleSheet(
                 offset: SourceOffset(12765),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12766),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12768),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(12770),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12766),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12768),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(12770),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -19362,19 +19371,22 @@ StyleSheet(
                 offset: SourceOffset(12804),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12805),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12807),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(12809),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12805),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12807),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(12809),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -19457,19 +19469,22 @@ StyleSheet(
                 offset: SourceOffset(12842),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12843),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12845),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(12847),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12843),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12845),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(12847),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -19552,19 +19567,22 @@ StyleSheet(
                 offset: SourceOffset(12887),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12888),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12890),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(12892),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12888),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12890),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(12892),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -19647,19 +19665,22 @@ StyleSheet(
                 offset: SourceOffset(12925),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12926),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12928),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(12930),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12926),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12928),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(12930),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -19742,19 +19763,22 @@ StyleSheet(
                 offset: SourceOffset(12963),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12964),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(12966),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(12968),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12964),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(12966),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(12968),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -19827,19 +19851,22 @@ StyleSheet(
                 offset: SourceOffset(13004),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13005),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13007),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13009),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13005),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13007),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13009),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -19912,19 +19939,22 @@ StyleSheet(
                 offset: SourceOffset(13036),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13037),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13039),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13041),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13037),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13039),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13041),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -19997,19 +20027,22 @@ StyleSheet(
                 offset: SourceOffset(13073),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13074),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13076),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13078),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13074),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13076),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13078),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20082,19 +20115,22 @@ StyleSheet(
                 offset: SourceOffset(13111),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13112),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13114),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13116),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13112),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13114),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13116),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20167,19 +20203,22 @@ StyleSheet(
                 offset: SourceOffset(13142),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13143),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13145),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13147),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13143),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13145),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13147),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20252,19 +20291,22 @@ StyleSheet(
                 offset: SourceOffset(13180),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13181),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13183),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13185),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13181),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13183),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13185),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20337,19 +20379,22 @@ StyleSheet(
                 offset: SourceOffset(13218),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13219),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13221),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13223),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13219),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13221),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13223),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20422,19 +20467,22 @@ StyleSheet(
                 offset: SourceOffset(13249),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13250),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13252),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13254),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13250),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13252),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13254),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20507,19 +20555,22 @@ StyleSheet(
                 offset: SourceOffset(13287),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13288),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13290),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13292),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13288),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13290),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13292),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20592,19 +20643,22 @@ StyleSheet(
                 offset: SourceOffset(13325),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13326),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13328),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13330),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13326),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13328),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13330),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20677,19 +20731,22 @@ StyleSheet(
                 offset: SourceOffset(13357),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13358),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13360),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13362),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13358),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13360),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13362),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20762,19 +20819,22 @@ StyleSheet(
                 offset: SourceOffset(13396),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13397),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13399),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13401),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13397),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13399),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13401),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -20847,19 +20907,22 @@ StyleSheet(
                 offset: SourceOffset(13435),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13436),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(13438),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(13440),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13436),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(13438),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(13440),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22480,19 +22543,22 @@ StyleSheet(
                       offset: SourceOffset(14199),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14200),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14202),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(14204),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14200),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14202),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(14204),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -22552,19 +22618,22 @@ StyleSheet(
                       offset: SourceOffset(14231),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14232),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14234),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14236),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14232),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14234),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14236),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -22647,19 +22716,22 @@ StyleSheet(
                       offset: SourceOffset(14273),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14274),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14276),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14278),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14274),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14276),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14278),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -22742,19 +22814,22 @@ StyleSheet(
                       offset: SourceOffset(14315),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14316),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14318),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14320),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14316),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14318),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14320),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -22837,19 +22912,22 @@ StyleSheet(
                       offset: SourceOffset(14356),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14357),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14359),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14361),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14357),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14359),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14361),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -22932,19 +23010,22 @@ StyleSheet(
                       offset: SourceOffset(14404),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14405),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14407),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14409),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14405),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14407),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14409),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23027,19 +23108,22 @@ StyleSheet(
                       offset: SourceOffset(14445),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14446),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14448),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14450),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14446),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14448),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14450),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23122,19 +23206,22 @@ StyleSheet(
                       offset: SourceOffset(14486),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14487),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14489),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14491),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14487),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14489),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14491),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23207,19 +23294,22 @@ StyleSheet(
                       offset: SourceOffset(14530),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14531),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14533),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14535),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14531),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14533),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14535),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23292,19 +23382,22 @@ StyleSheet(
                       offset: SourceOffset(14565),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14566),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14568),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14570),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14566),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14568),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14570),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23377,19 +23470,22 @@ StyleSheet(
                       offset: SourceOffset(14605),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14606),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14608),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14610),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14606),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14608),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14610),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23462,19 +23558,22 @@ StyleSheet(
                       offset: SourceOffset(14646),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14647),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14649),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14651),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14647),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14649),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14651),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23547,19 +23646,22 @@ StyleSheet(
                       offset: SourceOffset(14680),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14681),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14683),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14685),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14681),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14683),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14685),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23632,19 +23734,22 @@ StyleSheet(
                       offset: SourceOffset(14721),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14722),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14724),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14726),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14722),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14724),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14726),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23717,19 +23822,22 @@ StyleSheet(
                       offset: SourceOffset(14762),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14763),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14765),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14767),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14763),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14765),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14767),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23802,19 +23910,22 @@ StyleSheet(
                       offset: SourceOffset(14796),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14797),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14799),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14801),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14797),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14799),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14801),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23887,19 +23998,22 @@ StyleSheet(
                       offset: SourceOffset(14837),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14838),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14840),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14842),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14838),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14840),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14842),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -23972,19 +24086,22 @@ StyleSheet(
                       offset: SourceOffset(14878),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14879),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14881),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14883),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14879),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14881),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14883),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24057,19 +24174,22 @@ StyleSheet(
                       offset: SourceOffset(14913),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14914),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14916),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14918),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14914),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14916),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14918),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24142,19 +24262,22 @@ StyleSheet(
                       offset: SourceOffset(14955),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14956),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14958),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(14960),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14956),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14958),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(14960),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -24227,19 +24350,22 @@ StyleSheet(
                       offset: SourceOffset(14997),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(14998),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(15000),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(15002),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(14998),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(15000),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(15002),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25922,19 +26048,22 @@ StyleSheet(
                       offset: SourceOffset(15894),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(15895),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(15897),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(15899),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(15895),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(15897),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(15899),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -25994,19 +26123,22 @@ StyleSheet(
                       offset: SourceOffset(15926),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(15927),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(15929),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(15931),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(15927),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(15929),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(15931),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26089,19 +26221,22 @@ StyleSheet(
                       offset: SourceOffset(15968),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(15969),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(15971),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(15973),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(15969),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(15971),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(15973),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26184,19 +26319,22 @@ StyleSheet(
                       offset: SourceOffset(16010),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16011),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16013),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16015),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16011),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16013),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16015),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26279,19 +26417,22 @@ StyleSheet(
                       offset: SourceOffset(16051),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16052),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16054),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16056),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16052),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16054),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16056),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26374,19 +26515,22 @@ StyleSheet(
                       offset: SourceOffset(16099),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16100),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16102),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16104),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16100),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16102),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16104),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26469,19 +26613,22 @@ StyleSheet(
                       offset: SourceOffset(16140),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16141),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16143),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16145),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16141),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16143),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16145),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26564,19 +26711,22 @@ StyleSheet(
                       offset: SourceOffset(16181),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16182),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16184),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16186),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16182),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16184),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16186),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26649,19 +26799,22 @@ StyleSheet(
                       offset: SourceOffset(16225),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16226),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16228),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16230),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16226),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16228),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16230),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26734,19 +26887,22 @@ StyleSheet(
                       offset: SourceOffset(16260),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16261),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16263),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16265),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16261),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16263),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16265),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26819,19 +26975,22 @@ StyleSheet(
                       offset: SourceOffset(16300),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16301),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16303),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16305),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16301),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16303),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16305),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26904,19 +27063,22 @@ StyleSheet(
                       offset: SourceOffset(16341),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16342),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16344),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16346),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16342),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16344),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16346),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26989,19 +27151,22 @@ StyleSheet(
                       offset: SourceOffset(16375),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16376),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16378),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16380),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16376),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16378),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16380),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -27074,19 +27239,22 @@ StyleSheet(
                       offset: SourceOffset(16416),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16417),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16419),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16421),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16417),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16419),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16421),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -27159,19 +27327,22 @@ StyleSheet(
                       offset: SourceOffset(16457),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16458),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16460),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16462),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16458),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16460),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16462),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -27244,19 +27415,22 @@ StyleSheet(
                       offset: SourceOffset(16491),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16492),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16494),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16496),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16492),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16494),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16496),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -27329,19 +27503,22 @@ StyleSheet(
                       offset: SourceOffset(16532),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16533),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16535),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16537),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16533),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16535),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16537),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -27414,19 +27591,22 @@ StyleSheet(
                       offset: SourceOffset(16573),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16574),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16576),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16578),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16574),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16576),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16578),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -27499,19 +27679,22 @@ StyleSheet(
                       offset: SourceOffset(16608),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16609),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16611),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16613),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16609),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16611),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16613),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -27584,19 +27767,22 @@ StyleSheet(
                       offset: SourceOffset(16650),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16651),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16653),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16655),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16651),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16653),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16655),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -27669,19 +27855,22 @@ StyleSheet(
                       offset: SourceOffset(16692),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16693),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(16695),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(16697),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16693),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(16695),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(16697),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29364,19 +29553,22 @@ StyleSheet(
                       offset: SourceOffset(17589),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17590),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17592),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17594),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17590),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17592),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17594),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -29436,19 +29628,22 @@ StyleSheet(
                       offset: SourceOffset(17621),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17622),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17624),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17626),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17622),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17624),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17626),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29531,19 +29726,22 @@ StyleSheet(
                       offset: SourceOffset(17663),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17664),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17666),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17668),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17664),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17666),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17668),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29626,19 +29824,22 @@ StyleSheet(
                       offset: SourceOffset(17705),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17706),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17708),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17710),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17706),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17708),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17710),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29721,19 +29922,22 @@ StyleSheet(
                       offset: SourceOffset(17746),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17747),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17749),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17751),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17747),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17749),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17751),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29816,19 +30020,22 @@ StyleSheet(
                       offset: SourceOffset(17794),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17795),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17797),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17799),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17795),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17797),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17799),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29911,19 +30118,22 @@ StyleSheet(
                       offset: SourceOffset(17835),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17836),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17838),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17840),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17836),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17838),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17840),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30006,19 +30216,22 @@ StyleSheet(
                       offset: SourceOffset(17876),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17877),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17879),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17881),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17877),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17879),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17881),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30091,19 +30304,22 @@ StyleSheet(
                       offset: SourceOffset(17920),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17921),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17923),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17925),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17921),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17923),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17925),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30176,19 +30392,22 @@ StyleSheet(
                       offset: SourceOffset(17955),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17956),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17958),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17960),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17956),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17958),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17960),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30261,19 +30480,22 @@ StyleSheet(
                       offset: SourceOffset(17995),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17996),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17998),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18000),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17996),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17998),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18000),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30346,19 +30568,22 @@ StyleSheet(
                       offset: SourceOffset(18036),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18037),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18039),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18041),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18037),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18039),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18041),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30431,19 +30656,22 @@ StyleSheet(
                       offset: SourceOffset(18070),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18071),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18073),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18075),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18071),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18073),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18075),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30516,19 +30744,22 @@ StyleSheet(
                       offset: SourceOffset(18111),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18112),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18114),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18116),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18112),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18114),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18116),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30601,19 +30832,22 @@ StyleSheet(
                       offset: SourceOffset(18152),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18153),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18155),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18157),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18153),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18155),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18157),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30686,19 +30920,22 @@ StyleSheet(
                       offset: SourceOffset(18186),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18187),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18189),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18191),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18187),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18189),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18191),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30771,19 +31008,22 @@ StyleSheet(
                       offset: SourceOffset(18227),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18228),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18230),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18232),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18228),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18230),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18232),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30856,19 +31096,22 @@ StyleSheet(
                       offset: SourceOffset(18268),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18269),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18271),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18273),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18269),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18271),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18273),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30941,19 +31184,22 @@ StyleSheet(
                       offset: SourceOffset(18303),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18304),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18306),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18308),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18304),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18306),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18308),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -31026,19 +31272,22 @@ StyleSheet(
                       offset: SourceOffset(18345),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18346),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18348),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18350),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18346),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18348),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18350),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -31111,19 +31360,22 @@ StyleSheet(
                       offset: SourceOffset(18387),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18388),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18390),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18392),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18388),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18390),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18392),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32806,19 +33058,22 @@ StyleSheet(
                       offset: SourceOffset(19285),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19286),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19288),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(19290),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19286),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19288),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(19290),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -32878,19 +33133,22 @@ StyleSheet(
                       offset: SourceOffset(19317),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19318),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19320),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19322),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19318),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19320),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19322),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32973,19 +33231,22 @@ StyleSheet(
                       offset: SourceOffset(19359),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19360),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19362),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19364),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19360),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19362),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19364),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33068,19 +33329,22 @@ StyleSheet(
                       offset: SourceOffset(19401),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19402),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19404),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19406),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19402),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19404),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19406),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33163,19 +33427,22 @@ StyleSheet(
                       offset: SourceOffset(19442),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19443),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19445),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19447),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19443),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19445),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19447),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33258,19 +33525,22 @@ StyleSheet(
                       offset: SourceOffset(19490),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19491),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19493),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19495),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19491),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19493),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19495),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33353,19 +33623,22 @@ StyleSheet(
                       offset: SourceOffset(19531),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19532),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19534),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19536),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19532),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19534),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19536),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33448,19 +33721,22 @@ StyleSheet(
                       offset: SourceOffset(19572),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19573),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19575),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19577),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19573),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19575),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19577),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33533,19 +33809,22 @@ StyleSheet(
                       offset: SourceOffset(19616),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19617),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19619),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19621),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19617),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19619),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19621),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33618,19 +33897,22 @@ StyleSheet(
                       offset: SourceOffset(19651),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19652),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19654),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19656),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19652),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19654),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19656),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33703,19 +33985,22 @@ StyleSheet(
                       offset: SourceOffset(19691),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19692),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19694),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19696),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19692),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19694),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19696),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33788,19 +34073,22 @@ StyleSheet(
                       offset: SourceOffset(19732),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19733),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19735),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19737),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19733),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19735),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19737),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33873,19 +34161,22 @@ StyleSheet(
                       offset: SourceOffset(19766),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19767),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19769),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19771),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19767),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19769),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19771),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33958,19 +34249,22 @@ StyleSheet(
                       offset: SourceOffset(19807),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19808),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19810),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19812),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19808),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19810),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19812),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34043,19 +34337,22 @@ StyleSheet(
                       offset: SourceOffset(19848),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19849),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19851),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19853),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19849),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19851),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19853),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34128,19 +34425,22 @@ StyleSheet(
                       offset: SourceOffset(19882),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19883),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19885),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19887),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19883),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19885),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19887),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34213,19 +34513,22 @@ StyleSheet(
                       offset: SourceOffset(19923),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19924),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19926),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19928),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19924),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19926),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19928),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34298,19 +34601,22 @@ StyleSheet(
                       offset: SourceOffset(19964),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19965),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(19967),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(19969),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19965),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(19967),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(19969),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34383,19 +34689,22 @@ StyleSheet(
                       offset: SourceOffset(19999),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20000),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20002),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20004),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20000),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20002),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20004),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34468,19 +34777,22 @@ StyleSheet(
                       offset: SourceOffset(20041),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20042),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20044),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20046),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20042),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20044),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20046),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34553,19 +34865,22 @@ StyleSheet(
                       offset: SourceOffset(20083),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20084),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20086),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20088),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20084),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20086),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20088),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36248,19 +36563,22 @@ StyleSheet(
                       offset: SourceOffset(20982),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20983),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20985),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20987),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20983),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20985),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20987),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -36320,19 +36638,22 @@ StyleSheet(
                       offset: SourceOffset(21015),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21016),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21018),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21020),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21016),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21018),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21020),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36415,19 +36736,22 @@ StyleSheet(
                       offset: SourceOffset(21058),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21059),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21061),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21063),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21059),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21061),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21063),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36510,19 +36834,22 @@ StyleSheet(
                       offset: SourceOffset(21101),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21102),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21104),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21106),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21102),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21104),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21106),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36605,19 +36932,22 @@ StyleSheet(
                       offset: SourceOffset(21143),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21144),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21146),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21148),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21144),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21146),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21148),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36700,19 +37030,22 @@ StyleSheet(
                       offset: SourceOffset(21192),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21193),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21195),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21197),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21193),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21195),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21197),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36795,19 +37128,22 @@ StyleSheet(
                       offset: SourceOffset(21234),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21235),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21237),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21239),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21235),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21237),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21239),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36890,19 +37226,22 @@ StyleSheet(
                       offset: SourceOffset(21276),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21277),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21279),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21281),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21277),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21279),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21281),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36975,19 +37314,22 @@ StyleSheet(
                       offset: SourceOffset(21321),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21322),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21324),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21326),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21322),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21324),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21326),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37060,19 +37402,22 @@ StyleSheet(
                       offset: SourceOffset(21357),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21358),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21360),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21362),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21358),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21360),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21362),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37145,19 +37490,22 @@ StyleSheet(
                       offset: SourceOffset(21398),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21399),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21401),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21403),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21399),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21401),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21403),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37230,19 +37578,22 @@ StyleSheet(
                       offset: SourceOffset(21440),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21441),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21443),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21445),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21441),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21443),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21445),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37315,19 +37666,22 @@ StyleSheet(
                       offset: SourceOffset(21475),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21476),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21478),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21480),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21476),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21478),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21480),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37400,19 +37754,22 @@ StyleSheet(
                       offset: SourceOffset(21517),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21518),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21520),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21522),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21518),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21520),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21522),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37485,19 +37842,22 @@ StyleSheet(
                       offset: SourceOffset(21559),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21560),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21562),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21564),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21560),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21562),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21564),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37570,19 +37930,22 @@ StyleSheet(
                       offset: SourceOffset(21594),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21595),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21597),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21599),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21595),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21597),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21599),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37655,19 +38018,22 @@ StyleSheet(
                       offset: SourceOffset(21636),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21637),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21639),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21641),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21637),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21639),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21641),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37740,19 +38106,22 @@ StyleSheet(
                       offset: SourceOffset(21678),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21679),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21681),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21683),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21679),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21681),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21683),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37825,19 +38194,22 @@ StyleSheet(
                       offset: SourceOffset(21714),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21715),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21717),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21719),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21715),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21717),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21719),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37910,19 +38282,22 @@ StyleSheet(
                       offset: SourceOffset(21757),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21758),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21760),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21762),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21758),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21760),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21762),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37995,19 +38370,22 @@ StyleSheet(
                       offset: SourceOffset(21800),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21801),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21803),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21805),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21801),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21803),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21805),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -65724,19 +66102,22 @@ StyleSheet(
                 offset: SourceOffset(43648),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(43649),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(43651),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(43653),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(43649),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(43651),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(43653),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -99251,19 +99632,22 @@ StyleSheet(
                 offset: SourceOffset(70506),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(70507),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(70509),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(70511),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(70507),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(70509),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(70511),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: None,
             ),
@@ -106479,19 +106863,22 @@ StyleSheet(
                 offset: SourceOffset(76061),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(76062),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(76064),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(76066),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(76062),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(76064),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(76066),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -120481,19 +120868,22 @@ StyleSheet(
                 offset: SourceOffset(87572),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(87573),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(87575),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(87577),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(87573),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(87575),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(87577),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -123324,19 +123714,22 @@ StyleSheet(
                       offset: SourceOffset(89729),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(89730),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(89732),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(89734),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(89730),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(89732),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(89734),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -157351,19 +157744,22 @@ StyleSheet(
                 offset: SourceOffset(122586),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(122587),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(122589),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(122591),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(122587),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(122589),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(122591),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -175885,19 +176281,22 @@ StyleSheet(
                 offset: SourceOffset(137457),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(137458),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(137460),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(137462),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(137458),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(137460),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(137462),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -207513,19 +207912,22 @@ StyleSheet(
                 offset: SourceOffset(159971),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(159972),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(159974),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(159976),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(159972),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(159974),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(159976),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -219435,19 +219837,22 @@ StyleSheet(
                 offset: SourceOffset(167684),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(167685),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(167687),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(167689),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(167685),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(167687),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(167689),
+                  len: 4,
+                ))))),
+              ))),
               important: Some(BangImportant(
                 bang: Bang(Delim(Cursor(
                   kind: "Delim",
@@ -251235,19 +251640,22 @@ StyleSheet(
                       offset: SourceOffset(190789),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(190790),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(190792),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(190794),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(190790),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(190792),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(190794),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -263989,19 +264397,22 @@ StyleSheet(
                       offset: SourceOffset(198926),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(198927),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(198929),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(198931),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(198927),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(198929),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(198931),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -276743,19 +277154,22 @@ StyleSheet(
                       offset: SourceOffset(207063),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(207064),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(207066),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(207068),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(207064),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(207066),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(207068),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -289497,19 +289911,22 @@ StyleSheet(
                       offset: SourceOffset(215201),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(215202),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(215204),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(215206),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(215202),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(215204),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(215206),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -302251,19 +302668,22 @@ StyleSheet(
                       offset: SourceOffset(223359),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(223360),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(223362),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(223364),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(223360),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(223362),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(223364),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
@@ -21348,19 +21348,22 @@ StyleSheet(
                 offset: SourceOffset(15569),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15571),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15573),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(15575),
-                len: 2,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15571),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15573),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(15575),
+                  len: 2,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -21424,19 +21427,22 @@ StyleSheet(
                 offset: SourceOffset(15609),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15611),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15613),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(15615),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15611),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15613),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(15615),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -21523,19 +21529,22 @@ StyleSheet(
                 offset: SourceOffset(15663),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15665),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15667),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(15669),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15665),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15667),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(15669),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -21622,19 +21631,22 @@ StyleSheet(
                 offset: SourceOffset(15717),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15719),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15721),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(15723),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15719),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15721),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(15723),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -21721,19 +21733,22 @@ StyleSheet(
                 offset: SourceOffset(15770),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15772),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15774),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(15776),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15772),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15774),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(15776),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -21820,19 +21835,22 @@ StyleSheet(
                 offset: SourceOffset(15834),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15836),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15838),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(15840),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15836),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15838),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(15840),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -21919,19 +21937,22 @@ StyleSheet(
                 offset: SourceOffset(15887),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15889),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15891),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(15893),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15889),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15891),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(15893),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22018,19 +22039,22 @@ StyleSheet(
                 offset: SourceOffset(15940),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15942),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(15944),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(15946),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15942),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(15944),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(15946),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22107,19 +22131,22 @@ StyleSheet(
                 offset: SourceOffset(15998),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16000),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16002),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16004),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16000),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16002),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16004),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22196,19 +22223,22 @@ StyleSheet(
                 offset: SourceOffset(16043),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16045),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16047),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16049),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16045),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16047),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16049),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22285,19 +22315,22 @@ StyleSheet(
                 offset: SourceOffset(16095),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16097),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16099),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16101),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16097),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16099),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16101),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22374,19 +22407,22 @@ StyleSheet(
                 offset: SourceOffset(16148),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16150),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16152),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16154),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16150),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16152),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16154),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22463,19 +22499,22 @@ StyleSheet(
                 offset: SourceOffset(16192),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16194),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16196),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16198),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16194),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16196),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16198),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22552,19 +22591,22 @@ StyleSheet(
                 offset: SourceOffset(16245),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16247),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16249),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16251),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16247),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16249),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16251),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22641,19 +22683,22 @@ StyleSheet(
                 offset: SourceOffset(16298),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16300),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16302),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16304),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16300),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16302),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16304),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22730,19 +22775,22 @@ StyleSheet(
                 offset: SourceOffset(16342),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16344),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16346),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16348),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16344),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16346),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16348),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22819,19 +22867,22 @@ StyleSheet(
                 offset: SourceOffset(16395),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16397),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16399),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16401),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16397),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16399),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16401),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22908,19 +22959,22 @@ StyleSheet(
                 offset: SourceOffset(16448),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16450),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16452),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16454),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16450),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16452),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16454),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -22997,19 +23051,22 @@ StyleSheet(
                 offset: SourceOffset(16493),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16495),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16497),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16499),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16495),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16497),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16499),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -23086,19 +23143,22 @@ StyleSheet(
                 offset: SourceOffset(16547),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16549),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16551),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16553),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16549),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16551),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16553),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -23175,19 +23235,22 @@ StyleSheet(
                 offset: SourceOffset(16601),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16603),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(16605),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(16607),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16603),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(16605),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(16607),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -24964,19 +25027,22 @@ StyleSheet(
                       offset: SourceOffset(17625),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17627),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17629),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(17631),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17627),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17629),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(17631),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25040,19 +25106,22 @@ StyleSheet(
                       offset: SourceOffset(17673),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17675),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17677),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17679),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17675),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17677),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17679),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25139,19 +25208,22 @@ StyleSheet(
                       offset: SourceOffset(17737),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17739),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17741),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17743),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17739),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17741),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17743),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25238,19 +25310,22 @@ StyleSheet(
                       offset: SourceOffset(17801),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17803),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17805),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17807),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17803),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17805),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17807),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25337,19 +25412,22 @@ StyleSheet(
                       offset: SourceOffset(17864),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17866),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17868),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17870),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17866),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17868),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17870),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25436,19 +25514,22 @@ StyleSheet(
                       offset: SourceOffset(17938),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17940),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(17942),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(17944),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17940),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(17942),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(17944),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25535,19 +25616,22 @@ StyleSheet(
                       offset: SourceOffset(18001),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18003),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18005),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18007),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18003),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18005),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18007),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25634,19 +25718,22 @@ StyleSheet(
                       offset: SourceOffset(18064),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18066),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18068),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18070),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18066),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18068),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18070),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25723,19 +25810,22 @@ StyleSheet(
                       offset: SourceOffset(18132),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18134),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18136),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18138),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18134),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18136),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18138),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25812,19 +25902,22 @@ StyleSheet(
                       offset: SourceOffset(18187),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18189),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18191),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18193),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18189),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18191),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18193),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25901,19 +25994,22 @@ StyleSheet(
                       offset: SourceOffset(18249),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18251),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18253),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18255),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18251),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18253),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18255),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -25990,19 +26086,22 @@ StyleSheet(
                       offset: SourceOffset(18312),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18314),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18316),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18318),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18314),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18316),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18318),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26079,19 +26178,22 @@ StyleSheet(
                       offset: SourceOffset(18366),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18368),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18370),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18372),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18368),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18370),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18372),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26168,19 +26270,22 @@ StyleSheet(
                       offset: SourceOffset(18429),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18431),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18433),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18435),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18431),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18433),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18435),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26257,19 +26362,22 @@ StyleSheet(
                       offset: SourceOffset(18492),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18494),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18496),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18498),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18494),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18496),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18498),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26346,19 +26454,22 @@ StyleSheet(
                       offset: SourceOffset(18546),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18548),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18550),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18552),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18548),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18550),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18552),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26435,19 +26546,22 @@ StyleSheet(
                       offset: SourceOffset(18609),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18611),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18613),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18615),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18611),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18613),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18615),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26524,19 +26638,22 @@ StyleSheet(
                       offset: SourceOffset(18672),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18674),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18676),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18678),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18674),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18676),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18678),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26613,19 +26730,22 @@ StyleSheet(
                       offset: SourceOffset(18727),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18729),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18731),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18733),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18729),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18731),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18733),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26702,19 +26822,22 @@ StyleSheet(
                       offset: SourceOffset(18791),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18793),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18795),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18797),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18793),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18795),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18797),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -26791,19 +26914,22 @@ StyleSheet(
                       offset: SourceOffset(18855),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18857),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(18859),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(18861),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18857),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(18859),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(18861),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -28646,19 +28772,22 @@ StyleSheet(
                       offset: SourceOffset(20169),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20171),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20173),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(20175),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20171),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20173),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(20175),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -28722,19 +28851,22 @@ StyleSheet(
                       offset: SourceOffset(20217),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20219),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20221),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20223),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20219),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20221),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20223),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -28821,19 +28953,22 @@ StyleSheet(
                       offset: SourceOffset(20281),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20283),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20285),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20287),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20283),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20285),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20287),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -28920,19 +29055,22 @@ StyleSheet(
                       offset: SourceOffset(20345),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20347),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20349),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20351),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20347),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20349),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20351),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29019,19 +29157,22 @@ StyleSheet(
                       offset: SourceOffset(20408),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20410),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20412),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20414),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20410),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20412),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20414),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29118,19 +29259,22 @@ StyleSheet(
                       offset: SourceOffset(20482),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20484),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20486),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20488),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20484),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20486),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20488),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29217,19 +29361,22 @@ StyleSheet(
                       offset: SourceOffset(20545),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20547),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20549),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20551),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20547),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20549),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20551),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29316,19 +29463,22 @@ StyleSheet(
                       offset: SourceOffset(20608),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20610),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20612),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20614),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20610),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20612),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20614),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29405,19 +29555,22 @@ StyleSheet(
                       offset: SourceOffset(20676),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20678),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20680),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20682),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20678),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20680),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20682),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29494,19 +29647,22 @@ StyleSheet(
                       offset: SourceOffset(20731),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20733),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20735),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20737),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20733),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20735),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20737),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29583,19 +29739,22 @@ StyleSheet(
                       offset: SourceOffset(20793),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20795),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20797),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20799),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20795),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20797),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20799),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29672,19 +29831,22 @@ StyleSheet(
                       offset: SourceOffset(20856),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20858),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20860),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20862),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20858),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20860),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20862),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29761,19 +29923,22 @@ StyleSheet(
                       offset: SourceOffset(20910),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20912),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20914),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20916),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20912),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20914),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20916),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29850,19 +30015,22 @@ StyleSheet(
                       offset: SourceOffset(20973),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20975),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(20977),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(20979),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20975),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(20977),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(20979),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -29939,19 +30107,22 @@ StyleSheet(
                       offset: SourceOffset(21036),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21038),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21040),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21042),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21038),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21040),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21042),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30028,19 +30199,22 @@ StyleSheet(
                       offset: SourceOffset(21090),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21092),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21094),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21096),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21092),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21094),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21096),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30117,19 +30291,22 @@ StyleSheet(
                       offset: SourceOffset(21153),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21155),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21157),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21159),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21155),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21157),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21159),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30206,19 +30383,22 @@ StyleSheet(
                       offset: SourceOffset(21216),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21218),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21220),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21222),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21218),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21220),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21222),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30295,19 +30475,22 @@ StyleSheet(
                       offset: SourceOffset(21271),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21273),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21275),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21277),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21273),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21275),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21277),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30384,19 +30567,22 @@ StyleSheet(
                       offset: SourceOffset(21335),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21337),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21339),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21341),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21337),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21339),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21341),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -30473,19 +30659,22 @@ StyleSheet(
                       offset: SourceOffset(21399),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21401),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(21403),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(21405),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21401),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(21403),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(21405),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32328,19 +32517,22 @@ StyleSheet(
                       offset: SourceOffset(22713),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22715),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22717),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(22719),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22715),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22717),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(22719),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32404,19 +32596,22 @@ StyleSheet(
                       offset: SourceOffset(22761),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22763),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22765),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(22767),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22763),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22765),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(22767),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32503,19 +32698,22 @@ StyleSheet(
                       offset: SourceOffset(22825),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22827),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22829),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(22831),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22827),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22829),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(22831),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32602,19 +32800,22 @@ StyleSheet(
                       offset: SourceOffset(22889),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22891),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22893),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(22895),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22891),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22893),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(22895),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32701,19 +32902,22 @@ StyleSheet(
                       offset: SourceOffset(22952),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22954),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(22956),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(22958),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22954),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(22956),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(22958),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32800,19 +33004,22 @@ StyleSheet(
                       offset: SourceOffset(23026),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23028),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23030),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23032),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23028),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23030),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23032),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32899,19 +33106,22 @@ StyleSheet(
                       offset: SourceOffset(23089),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23091),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23093),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23095),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23091),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23093),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23095),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -32998,19 +33208,22 @@ StyleSheet(
                       offset: SourceOffset(23152),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23154),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23156),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23158),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23154),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23156),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23158),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33087,19 +33300,22 @@ StyleSheet(
                       offset: SourceOffset(23220),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23222),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23224),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23226),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23222),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23224),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23226),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33176,19 +33392,22 @@ StyleSheet(
                       offset: SourceOffset(23275),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23277),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23279),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23281),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23277),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23279),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23281),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33265,19 +33484,22 @@ StyleSheet(
                       offset: SourceOffset(23337),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23339),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23341),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23343),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23339),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23341),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23343),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33354,19 +33576,22 @@ StyleSheet(
                       offset: SourceOffset(23400),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23402),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23404),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23406),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23402),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23404),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23406),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33443,19 +33668,22 @@ StyleSheet(
                       offset: SourceOffset(23454),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23456),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23458),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23460),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23456),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23458),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23460),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33532,19 +33760,22 @@ StyleSheet(
                       offset: SourceOffset(23517),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23519),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23521),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23523),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23519),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23521),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23523),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33621,19 +33852,22 @@ StyleSheet(
                       offset: SourceOffset(23580),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23582),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23584),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23586),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23582),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23584),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23586),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33710,19 +33944,22 @@ StyleSheet(
                       offset: SourceOffset(23634),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23636),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23638),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23640),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23636),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23638),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23640),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33799,19 +34036,22 @@ StyleSheet(
                       offset: SourceOffset(23697),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23699),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23701),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23703),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23699),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23701),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23703),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33888,19 +34128,22 @@ StyleSheet(
                       offset: SourceOffset(23760),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23762),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23764),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23766),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23762),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23764),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23766),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -33977,19 +34220,22 @@ StyleSheet(
                       offset: SourceOffset(23815),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23817),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23819),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23821),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23817),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23819),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23821),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34066,19 +34312,22 @@ StyleSheet(
                       offset: SourceOffset(23879),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23881),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23883),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23885),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23881),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23883),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23885),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -34155,19 +34404,22 @@ StyleSheet(
                       offset: SourceOffset(23943),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23945),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(23947),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(23949),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23945),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(23947),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(23949),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36010,19 +36262,22 @@ StyleSheet(
                       offset: SourceOffset(25258),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25260),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25262),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(25264),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25260),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25262),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(25264),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36086,19 +36341,22 @@ StyleSheet(
                       offset: SourceOffset(25306),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25308),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25310),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25312),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25308),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25310),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25312),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36185,19 +36443,22 @@ StyleSheet(
                       offset: SourceOffset(25370),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25372),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25374),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25376),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25372),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25374),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25376),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36284,19 +36545,22 @@ StyleSheet(
                       offset: SourceOffset(25434),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25436),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25438),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25440),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25436),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25438),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25440),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36383,19 +36647,22 @@ StyleSheet(
                       offset: SourceOffset(25497),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25499),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25501),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25503),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25499),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25501),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25503),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36482,19 +36749,22 @@ StyleSheet(
                       offset: SourceOffset(25571),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25573),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25575),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25577),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25573),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25575),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25577),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36581,19 +36851,22 @@ StyleSheet(
                       offset: SourceOffset(25634),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25636),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25638),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25640),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25636),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25638),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25640),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36680,19 +36953,22 @@ StyleSheet(
                       offset: SourceOffset(25697),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25699),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25701),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25703),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25699),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25701),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25703),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36769,19 +37045,22 @@ StyleSheet(
                       offset: SourceOffset(25765),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25767),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25769),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25771),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25767),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25769),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25771),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36858,19 +37137,22 @@ StyleSheet(
                       offset: SourceOffset(25820),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25822),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25824),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25826),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25822),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25824),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25826),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -36947,19 +37229,22 @@ StyleSheet(
                       offset: SourceOffset(25882),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25884),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25886),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25888),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25884),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25886),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25888),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37036,19 +37321,22 @@ StyleSheet(
                       offset: SourceOffset(25945),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25947),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(25949),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(25951),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25947),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(25949),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(25951),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37125,19 +37413,22 @@ StyleSheet(
                       offset: SourceOffset(25999),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26001),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26003),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(26005),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26001),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26003),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(26005),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37214,19 +37505,22 @@ StyleSheet(
                       offset: SourceOffset(26062),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26064),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26066),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(26068),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26064),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26066),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(26068),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37303,19 +37597,22 @@ StyleSheet(
                       offset: SourceOffset(26125),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26127),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26129),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(26131),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26127),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26129),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(26131),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37392,19 +37689,22 @@ StyleSheet(
                       offset: SourceOffset(26179),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26181),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26183),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(26185),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26181),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26183),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(26185),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37481,19 +37781,22 @@ StyleSheet(
                       offset: SourceOffset(26242),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26244),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26246),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(26248),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26244),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26246),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(26248),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37570,19 +37873,22 @@ StyleSheet(
                       offset: SourceOffset(26305),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26307),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26309),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(26311),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26307),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26309),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(26311),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37659,19 +37965,22 @@ StyleSheet(
                       offset: SourceOffset(26360),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26362),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26364),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(26366),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26362),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26364),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(26366),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37748,19 +38057,22 @@ StyleSheet(
                       offset: SourceOffset(26424),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26426),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26428),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(26430),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26426),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26428),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(26430),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -37837,19 +38149,22 @@ StyleSheet(
                       offset: SourceOffset(26488),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26490),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(26492),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(26494),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26490),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(26492),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(26494),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -39692,19 +40007,22 @@ StyleSheet(
                       offset: SourceOffset(27804),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27806),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27808),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(27810),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27806),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27808),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(27810),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -39768,19 +40086,22 @@ StyleSheet(
                       offset: SourceOffset(27853),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27855),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27857),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(27859),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27855),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27857),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(27859),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -39867,19 +40188,22 @@ StyleSheet(
                       offset: SourceOffset(27918),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27920),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27922),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(27924),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27920),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27922),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(27924),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -39966,19 +40290,22 @@ StyleSheet(
                       offset: SourceOffset(27983),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27985),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27987),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(27989),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27985),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27987),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(27989),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40065,19 +40392,22 @@ StyleSheet(
                       offset: SourceOffset(28047),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28049),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28051),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28053),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28049),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28051),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28053),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40164,19 +40494,22 @@ StyleSheet(
                       offset: SourceOffset(28122),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28124),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28126),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28128),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28124),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28126),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28128),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40263,19 +40596,22 @@ StyleSheet(
                       offset: SourceOffset(28186),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28188),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28190),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28192),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28188),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28190),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28192),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40362,19 +40698,22 @@ StyleSheet(
                       offset: SourceOffset(28250),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28252),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28254),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28256),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28252),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28254),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28256),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40451,19 +40790,22 @@ StyleSheet(
                       offset: SourceOffset(28319),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28321),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28323),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28325),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28321),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28323),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28325),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40540,19 +40882,22 @@ StyleSheet(
                       offset: SourceOffset(28375),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28377),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28379),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28381),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28377),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28379),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28381),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40629,19 +40974,22 @@ StyleSheet(
                       offset: SourceOffset(28438),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28440),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28442),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28444),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28440),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28442),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28444),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40718,19 +41066,22 @@ StyleSheet(
                       offset: SourceOffset(28502),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28504),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28506),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28508),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28504),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28506),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28508),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40807,19 +41158,22 @@ StyleSheet(
                       offset: SourceOffset(28557),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28559),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28561),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28563),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28559),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28561),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28563),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40896,19 +41250,22 @@ StyleSheet(
                       offset: SourceOffset(28621),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28623),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28625),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28627),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28623),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28625),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28627),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -40985,19 +41342,22 @@ StyleSheet(
                       offset: SourceOffset(28685),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28687),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28689),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28691),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28687),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28689),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28691),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -41074,19 +41434,22 @@ StyleSheet(
                       offset: SourceOffset(28740),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28742),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28744),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28746),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28742),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28744),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28746),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -41163,19 +41526,22 @@ StyleSheet(
                       offset: SourceOffset(28804),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28806),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28808),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28810),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28806),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28808),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28810),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -41252,19 +41618,22 @@ StyleSheet(
                       offset: SourceOffset(28868),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28870),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28872),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28874),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28870),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28872),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28874),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -41341,19 +41710,22 @@ StyleSheet(
                       offset: SourceOffset(28924),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28926),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28928),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28930),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28926),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28928),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28930),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -41430,19 +41802,22 @@ StyleSheet(
                       offset: SourceOffset(28989),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28991),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28993),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28995),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28991),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28993),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28995),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -41519,19 +41894,22 @@ StyleSheet(
                       offset: SourceOffset(29054),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(29056),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(29058),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(29060),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(29056),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(29058),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(29060),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -71524,19 +71902,22 @@ StyleSheet(
                 offset: SourceOffset(54503),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(54505),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(54507),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(54509),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(54505),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(54507),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(54509),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -108701,19 +109082,22 @@ StyleSheet(
                 offset: SourceOffset(85248),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(85250),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(85252),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(85254),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(85250),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(85252),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(85254),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -116516,19 +116900,22 @@ StyleSheet(
                 offset: SourceOffset(91565),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91567),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91569),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(91571),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91567),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91569),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(91571),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -131934,19 +132321,22 @@ StyleSheet(
                 offset: SourceOffset(105358),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(105360),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(105362),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(105364),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(105360),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(105362),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(105364),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -135049,19 +135439,22 @@ StyleSheet(
                       offset: SourceOffset(107816),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(107818),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(107820),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(107822),
-                      len: 2,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(107818),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(107820),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(107822),
+                        len: 2,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -172457,19 +172850,22 @@ StyleSheet(
                 offset: SourceOffset(144716),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(144718),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(144720),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(144722),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(144718),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(144720),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(144722),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -192556,19 +192952,22 @@ StyleSheet(
                 offset: SourceOffset(162112),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(162114),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(162116),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(162118),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(162114),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(162116),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(162118),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -227666,19 +228065,22 @@ StyleSheet(
                 offset: SourceOffset(189102),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(189104),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(189106),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(189108),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(189104),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(189106),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(189108),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -240824,19 +241226,22 @@ StyleSheet(
                 offset: SourceOffset(198340),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(198342),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(198344),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(198346),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(198342),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(198344),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(198346),
+                  len: 4,
+                ))))),
+              ))),
               important: Some(BangImportant(
                 bang: Bang(Delim(Cursor(
                   kind: "Delim",
@@ -276181,19 +276586,22 @@ StyleSheet(
                       offset: SourceOffset(225845),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(225847),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(225849),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(225851),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(225847),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(225849),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(225851),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -289711,19 +290119,22 @@ StyleSheet(
                       offset: SourceOffset(236884),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(236886),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(236888),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(236890),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(236886),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(236888),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(236890),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -303241,19 +303652,22 @@ StyleSheet(
                       offset: SourceOffset(247923),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(247925),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(247927),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(247929),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(247925),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(247927),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(247929),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -316771,19 +317185,22 @@ StyleSheet(
                       offset: SourceOffset(258963),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(258965),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(258967),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(258969),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(258965),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(258967),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(258969),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",
@@ -330301,19 +330718,22 @@ StyleSheet(
                       offset: SourceOffset(270023),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(270025),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(270027),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(270029),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(270025),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(270027),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(270029),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: Some(BangImportant(
                       bang: Bang(Delim(Cursor(
                         kind: "Delim",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.min.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.min.snap
@@ -6706,19 +6706,22 @@ StyleSheet(
                 offset: SourceOffset(4296),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4297),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4299),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(4301),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4297),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4299),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(4301),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -6784,19 +6787,22 @@ StyleSheet(
                 offset: SourceOffset(4328),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4329),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4331),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(4333),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4329),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4331),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(4333),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -6954,19 +6960,22 @@ StyleSheet(
                 offset: SourceOffset(4416),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4417),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4419),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4421),
-                len: 1,
-              ))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4417),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4419),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4421),
+                  len: 1,
+                )))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -7032,19 +7041,22 @@ StyleSheet(
                 offset: SourceOffset(4444),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4445),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4447),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4449),
-                len: 1,
-              ))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4445),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4447),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4449),
+                  len: 1,
+                )))))),
+              ))),
               important: None,
               semicolon: None,
             ),
@@ -7133,19 +7145,22 @@ StyleSheet(
                 offset: SourceOffset(4495),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4496),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4498),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(4500),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4496),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4498),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(4500),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -7211,19 +7226,22 @@ StyleSheet(
                 offset: SourceOffset(4527),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4528),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4530),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(4532),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4528),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4530),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(4532),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: None,
             ),
@@ -9728,19 +9746,22 @@ StyleSheet(
                 offset: SourceOffset(5879),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5880),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5882),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(5884),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5880),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5882),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(5884),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -9806,19 +9827,22 @@ StyleSheet(
                 offset: SourceOffset(5911),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5912),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5914),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(5916),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5912),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5914),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(5916),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: None,
             ),
@@ -10828,19 +10852,22 @@ StyleSheet(
                       offset: SourceOffset(6389),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6390),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6392),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6394),
-                      len: 1,
-                    ))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6390),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6392),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6394),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -10906,19 +10933,22 @@ StyleSheet(
                       offset: SourceOffset(6417),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6418),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6420),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6422),
-                      len: 1,
-                    ))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6418),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6420),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6422),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -11455,19 +11485,22 @@ StyleSheet(
                       offset: SourceOffset(6708),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6709),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6711),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(6713),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6709),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6711),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(6713),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -11533,19 +11566,22 @@ StyleSheet(
                       offset: SourceOffset(6740),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6741),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6743),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(6745),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6741),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6743),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(6745),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -12634,19 +12670,22 @@ StyleSheet(
                       offset: SourceOffset(7264),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7265),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7267),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7269),
-                      len: 1,
-                    ))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7265),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7267),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7269),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -12712,19 +12751,22 @@ StyleSheet(
                       offset: SourceOffset(7292),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7293),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7295),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7297),
-                      len: 1,
-                    ))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7293),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7295),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7297),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -13261,19 +13303,22 @@ StyleSheet(
                       offset: SourceOffset(7570),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7571),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7573),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(7575),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7571),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7573),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(7575),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -13339,19 +13384,22 @@ StyleSheet(
                       offset: SourceOffset(7602),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7603),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(7605),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(7607),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7603),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(7605),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(7607),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -47160,19 +47208,22 @@ StyleSheet(
                 offset: SourceOffset(26826),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(26827),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(26829),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(26831),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(26827),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(26829),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(26831),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -47238,19 +47289,22 @@ StyleSheet(
                 offset: SourceOffset(26858),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(26859),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(26861),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(26863),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(26859),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(26861),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(26863),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: None,
             ),
@@ -48260,19 +48314,22 @@ StyleSheet(
                       offset: SourceOffset(27348),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27349),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27351),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27353),
-                      len: 1,
-                    ))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27349),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27351),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27353),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -48338,19 +48395,22 @@ StyleSheet(
                       offset: SourceOffset(27376),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27377),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27379),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27381),
-                      len: 1,
-                    ))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27377),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27379),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27381),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -48887,19 +48947,22 @@ StyleSheet(
                       offset: SourceOffset(27668),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27669),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27671),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(27673),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27669),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27671),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(27673),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -48965,19 +49028,22 @@ StyleSheet(
                       offset: SourceOffset(27700),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27701),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(27703),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(27705),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27701),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(27703),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(27705),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -50066,19 +50132,22 @@ StyleSheet(
                       offset: SourceOffset(28237),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28238),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28240),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28242),
-                      len: 1,
-                    ))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28238),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28240),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28242),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -50144,19 +50213,22 @@ StyleSheet(
                       offset: SourceOffset(28265),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28266),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28268),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28270),
-                      len: 1,
-                    ))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28266),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28268),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28270),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -50693,19 +50765,22 @@ StyleSheet(
                       offset: SourceOffset(28544),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28545),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28547),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28549),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28545),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28547),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28549),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -50771,19 +50846,22 @@ StyleSheet(
                       offset: SourceOffset(28576),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28577),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(28579),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(28581),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28577),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(28579),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(28581),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -76354,19 +76432,22 @@ StyleSheet(
                 offset: SourceOffset(44330),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44331),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44333),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(44335),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44331),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44333),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(44335),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -76432,19 +76513,22 @@ StyleSheet(
                 offset: SourceOffset(44362),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44363),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44365),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(44367),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44363),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44365),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(44367),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: None,
             ),
@@ -76521,19 +76605,22 @@ StyleSheet(
                 offset: SourceOffset(44420),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44421),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44423),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(44425),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44421),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44423),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(44425),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -76599,19 +76686,22 @@ StyleSheet(
                 offset: SourceOffset(44452),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44453),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44455),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(44457),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44453),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44455),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(44457),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: None,
             ),
@@ -76688,19 +76778,22 @@ StyleSheet(
                 offset: SourceOffset(44512),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44513),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44515),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(44517),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44513),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44515),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(44517),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -76766,19 +76859,22 @@ StyleSheet(
                 offset: SourceOffset(44544),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44545),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(44547),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(44549),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44545),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(44547),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(44549),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: None,
             ),
@@ -77702,19 +77798,22 @@ StyleSheet(
                       offset: SourceOffset(45401),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45402),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45404),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(45406),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45402),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45404),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(45406),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -77780,19 +77879,22 @@ StyleSheet(
                       offset: SourceOffset(45433),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45434),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45436),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(45438),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45434),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45436),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(45438),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -77869,19 +77971,22 @@ StyleSheet(
                       offset: SourceOffset(45498),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45499),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45501),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(45503),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45499),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45501),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(45503),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -77947,19 +78052,22 @@ StyleSheet(
                       offset: SourceOffset(45530),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45531),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45533),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(45535),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45531),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45533),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(45535),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -78036,19 +78144,22 @@ StyleSheet(
                       offset: SourceOffset(45597),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45598),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45600),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(45602),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45598),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45600),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(45602),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -78114,19 +78225,22 @@ StyleSheet(
                       offset: SourceOffset(45629),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45630),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(45632),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(45634),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45630),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(45632),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(45634),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -79058,19 +79172,22 @@ StyleSheet(
                       offset: SourceOffset(46513),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46514),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46516),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(46518),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46514),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46516),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(46518),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -79136,19 +79253,22 @@ StyleSheet(
                       offset: SourceOffset(46545),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46546),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46548),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(46550),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46546),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46548),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(46550),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -79225,19 +79345,22 @@ StyleSheet(
                       offset: SourceOffset(46609),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46610),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46612),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(46614),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46610),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46612),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(46614),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -79303,19 +79426,22 @@ StyleSheet(
                       offset: SourceOffset(46641),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46642),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46644),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(46646),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46642),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46644),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(46646),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -79392,19 +79518,22 @@ StyleSheet(
                       offset: SourceOffset(46707),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46708),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46710),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(46712),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46708),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46710),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(46712),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -79470,19 +79599,22 @@ StyleSheet(
                       offset: SourceOffset(46739),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46740),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(46742),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(46744),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46740),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(46742),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(46744),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: None,
                   ),
@@ -108042,19 +108174,22 @@ StyleSheet(
                 offset: SourceOffset(63539),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63540),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63542),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(63544),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63540),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63542),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(63544),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -108120,19 +108255,22 @@ StyleSheet(
                 offset: SourceOffset(63571),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63572),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63574),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(63576),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63572),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63574),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(63576),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -108470,19 +108608,22 @@ StyleSheet(
                 offset: SourceOffset(63830),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63831),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63833),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63835),
-                len: 1,
-              ))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63831),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63833),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63835),
+                  len: 1,
+                )))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -108548,19 +108689,22 @@ StyleSheet(
                 offset: SourceOffset(63858),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63859),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63861),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(63863),
-                len: 1,
-              ))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63859),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63861),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(63863),
+                  len: 1,
+                )))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -108833,19 +108977,22 @@ StyleSheet(
                 offset: SourceOffset(64051),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(64052),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(64054),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(64056),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(64052),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(64054),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(64056),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -108911,19 +109058,22 @@ StyleSheet(
                 offset: SourceOffset(64083),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(64084),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(64086),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(64088),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(64084),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(64086),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(64088),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: None,
             ),

--- a/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.snap
@@ -7115,19 +7115,22 @@ StyleSheet(
                 offset: SourceOffset(5555),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5557),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5559),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(5561),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5557),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5559),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(5561),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -7198,19 +7201,22 @@ StyleSheet(
                 offset: SourceOffset(5607),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5609),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5611),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(5613),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5609),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5611),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(5613),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -7377,19 +7383,22 @@ StyleSheet(
                 offset: SourceOffset(5725),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5727),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5729),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5731),
-                len: 1,
-              ))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5727),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5729),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5731),
+                  len: 1,
+                )))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -7460,19 +7469,22 @@ StyleSheet(
                 offset: SourceOffset(5777),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5779),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5781),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5783),
-                len: 1,
-              ))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5779),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5781),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5783),
+                  len: 1,
+                )))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -7570,19 +7582,22 @@ StyleSheet(
                 offset: SourceOffset(5846),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5848),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5850),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(5852),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5848),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5850),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(5852),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -7653,19 +7668,22 @@ StyleSheet(
                 offset: SourceOffset(5902),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5904),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(5906),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(5908),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5904),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(5906),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(5908),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -10229,19 +10247,22 @@ StyleSheet(
                 offset: SourceOffset(7560),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(7562),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(7564),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(7566),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(7562),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(7564),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(7566),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -10312,19 +10333,22 @@ StyleSheet(
                 offset: SourceOffset(7612),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(7614),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(7616),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(7618),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(7614),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(7616),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(7618),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -11391,19 +11415,22 @@ StyleSheet(
                       offset: SourceOffset(8247),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8249),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8251),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8253),
-                      len: 1,
-                    ))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8249),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8251),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8253),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -11474,19 +11501,22 @@ StyleSheet(
                       offset: SourceOffset(8299),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8301),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8303),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8305),
-                      len: 1,
-                    ))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8301),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8303),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8305),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -12032,19 +12062,22 @@ StyleSheet(
                       offset: SourceOffset(8652),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8654),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8656),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(8658),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8654),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8656),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(8658),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -12115,19 +12148,22 @@ StyleSheet(
                       offset: SourceOffset(8708),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8710),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8712),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(8714),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8710),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8712),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(8714),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -13277,19 +13313,22 @@ StyleSheet(
                       offset: SourceOffset(9440),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9442),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9444),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9446),
-                      len: 1,
-                    ))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9442),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9444),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9446),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -13360,19 +13399,22 @@ StyleSheet(
                       offset: SourceOffset(9492),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9494),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9496),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9498),
-                      len: 1,
-                    ))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9494),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9496),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9498),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -13918,19 +13960,22 @@ StyleSheet(
                       offset: SourceOffset(9832),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9834),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9836),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(9838),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9834),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9836),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(9838),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -14001,19 +14046,22 @@ StyleSheet(
                       offset: SourceOffset(9888),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9890),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(9892),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(9894),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9890),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(9892),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(9894),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -49840,19 +49888,22 @@ StyleSheet(
                 offset: SourceOffset(34531),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(34533),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(34535),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(34537),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(34533),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(34535),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(34537),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -49923,19 +49974,22 @@ StyleSheet(
                 offset: SourceOffset(34587),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(34589),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(34591),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(34593),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(34589),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(34591),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(34593),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -51002,19 +51056,22 @@ StyleSheet(
                       offset: SourceOffset(35277),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35279),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35281),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35283),
-                      len: 1,
-                    ))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35279),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35281),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35283),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -51085,19 +51142,22 @@ StyleSheet(
                       offset: SourceOffset(35333),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35335),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35337),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35339),
-                      len: 1,
-                    ))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35335),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35337),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35339),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -51643,19 +51703,22 @@ StyleSheet(
                       offset: SourceOffset(35695),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35697),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35699),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(35701),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35697),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35699),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(35701),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -51726,19 +51789,22 @@ StyleSheet(
                       offset: SourceOffset(35755),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35757),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(35759),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(35761),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35757),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(35759),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(35761),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -52888,19 +52954,22 @@ StyleSheet(
                       offset: SourceOffset(36559),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(36561),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(36563),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(36565),
-                      len: 1,
-                    ))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(36561),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(36563),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(36565),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -52971,19 +53040,22 @@ StyleSheet(
                       offset: SourceOffset(36615),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(36617),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(36619),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(36621),
-                      len: 1,
-                    ))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(36617),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(36619),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(36621),
+                        len: 1,
+                      )))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -53529,19 +53601,22 @@ StyleSheet(
                       offset: SourceOffset(36964),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(36966),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(36968),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(36970),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(36966),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(36968),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(36970),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -53612,19 +53687,22 @@ StyleSheet(
                       offset: SourceOffset(37024),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(37026),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(37028),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(37030),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(37026),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(37028),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(37030),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -81372,19 +81450,22 @@ StyleSheet(
                 offset: SourceOffset(57894),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(57896),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(57898),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(57900),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(57896),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(57898),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(57900),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -81455,19 +81536,22 @@ StyleSheet(
                 offset: SourceOffset(57946),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(57948),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(57950),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(57952),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(57948),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(57950),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(57952),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -81553,19 +81637,22 @@ StyleSheet(
                 offset: SourceOffset(58017),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(58019),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(58021),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(58023),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(58019),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(58021),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(58023),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -81636,19 +81723,22 @@ StyleSheet(
                 offset: SourceOffset(58069),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(58071),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(58073),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(58075),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(58071),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(58073),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(58075),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -81734,19 +81824,22 @@ StyleSheet(
                 offset: SourceOffset(58142),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(58144),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(58146),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(58148),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(58144),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(58146),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(58148),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -81817,19 +81910,22 @@ StyleSheet(
                 offset: SourceOffset(58194),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(58196),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(58198),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(58200),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(58196),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(58198),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(58200),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -82877,19 +82973,22 @@ StyleSheet(
                       offset: SourceOffset(59252),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59254),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59256),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(59258),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59254),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59256),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(59258),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -82960,19 +83059,22 @@ StyleSheet(
                       offset: SourceOffset(59308),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59310),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59312),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(59314),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59310),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59312),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(59314),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -83058,19 +83160,22 @@ StyleSheet(
                       offset: SourceOffset(59391),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59393),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59395),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(59397),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59393),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59395),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(59397),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -83141,19 +83246,22 @@ StyleSheet(
                       offset: SourceOffset(59447),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59449),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59451),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(59453),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59449),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59451),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(59453),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -83239,19 +83347,22 @@ StyleSheet(
                       offset: SourceOffset(59532),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59534),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59536),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(59538),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59534),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59536),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(59538),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -83322,19 +83433,22 @@ StyleSheet(
                       offset: SourceOffset(59588),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59590),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(59592),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(59594),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59590),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(59592),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(59594),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -84390,19 +84504,22 @@ StyleSheet(
                       offset: SourceOffset(60718),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(60720),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(60722),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(60724),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(60720),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(60722),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(60724),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -84473,19 +84590,22 @@ StyleSheet(
                       offset: SourceOffset(60774),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(60776),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(60778),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(60780),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(60776),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(60778),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(60780),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -84571,19 +84691,22 @@ StyleSheet(
                       offset: SourceOffset(60856),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(60858),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(60860),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(60862),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(60858),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(60860),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(60862),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -84654,19 +84777,22 @@ StyleSheet(
                       offset: SourceOffset(60912),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(60914),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(60916),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(60918),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(60914),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(60916),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(60918),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -84752,19 +84878,22 @@ StyleSheet(
                       offset: SourceOffset(60996),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(60998),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(61000),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(61002),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(60998),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(61000),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(61002),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -84835,19 +84964,22 @@ StyleSheet(
                       offset: SourceOffset(61052),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(61054),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(61056),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(61058),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(61054),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(61056),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(61058),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -114426,19 +114558,22 @@ StyleSheet(
                 offset: SourceOffset(81298),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81300),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81302),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(81304),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81300),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81302),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(81304),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -114509,19 +114644,22 @@ StyleSheet(
                 offset: SourceOffset(81350),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81352),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81354),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(81356),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81352),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81354),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(81356),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -114891,19 +115029,22 @@ StyleSheet(
                 offset: SourceOffset(81678),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81680),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81682),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(81684),
-                len: 3,
-              )))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81680),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81682),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(81684),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -114974,19 +115115,22 @@ StyleSheet(
                 offset: SourceOffset(81728),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81730),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81732),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(81734),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81730),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81732),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(81734),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -115283,19 +115427,22 @@ StyleSheet(
                 offset: SourceOffset(81968),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81970),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(81972),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(81974),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81970),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(81972),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(81974),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -115366,19 +115513,22 @@ StyleSheet(
                 offset: SourceOffset(82020),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(82022),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(82024),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(82026),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(82022),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(82024),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(82026),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -126300,19 +126450,22 @@ StyleSheet(
                 offset: SourceOffset(91348),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91350),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91352),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(91354),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91350),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91352),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(91354),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -126383,19 +126536,22 @@ StyleSheet(
                 offset: SourceOffset(91404),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91406),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91408),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(91410),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91406),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91408),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(91410),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -126855,19 +127011,22 @@ StyleSheet(
                 offset: SourceOffset(91730),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91732),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91734),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(91736),
-                len: 3,
-              )))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91732),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91734),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(91736),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -126938,19 +127097,22 @@ StyleSheet(
                 offset: SourceOffset(91784),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91786),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(91788),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(91790),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91786),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(91788),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(91790),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -148512,19 +148674,22 @@ StyleSheet(
                 offset: SourceOffset(105818),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(105820),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(105822),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(105824),
-                len: 4,
-              )))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(105820),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(105822),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(105824),
+                  len: 4,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -148595,19 +148760,22 @@ StyleSheet(
                 offset: SourceOffset(105878),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(105880),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(105882),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(105884),
-                len: 4,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(105880),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(105882),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(105884),
+                  len: 4,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -149060,19 +149228,22 @@ StyleSheet(
                 offset: SourceOffset(106265),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(106267),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(106269),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(106271),
-                len: 3,
-              )))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(106267),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(106269),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(106271),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -149143,19 +149314,22 @@ StyleSheet(
                 offset: SourceOffset(106323),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(106325),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(106327),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(106329),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(106325),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(106327),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(106329),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -149334,19 +149508,22 @@ StyleSheet(
                       offset: SourceOffset(106474),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(106476),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(106478),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(106480),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(106476),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(106478),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(106480),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -149417,19 +149594,22 @@ StyleSheet(
                       offset: SourceOffset(106534),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(106536),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(106538),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(106540),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(106536),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(106538),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(106540),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -149639,19 +149819,22 @@ StyleSheet(
                       offset: SourceOffset(106713),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(106715),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(106717),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(106719),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(106715),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(106717),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(106719),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -149722,19 +149905,22 @@ StyleSheet(
                       offset: SourceOffset(106773),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(106775),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(106777),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(106779),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(106775),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(106777),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(106779),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -151241,19 +151427,22 @@ StyleSheet(
                 offset: SourceOffset(108031),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(108033),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(108035),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(108037),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(108033),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(108035),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(108037),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -151324,19 +151513,22 @@ StyleSheet(
                 offset: SourceOffset(108083),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(108085),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(108087),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(108089),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(108085),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(108087),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(108089),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -151549,19 +151741,22 @@ StyleSheet(
                 offset: SourceOffset(108247),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(108249),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(108251),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(108253),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(108249),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(108251),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(108253),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -151632,19 +151827,22 @@ StyleSheet(
                 offset: SourceOffset(108299),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(108301),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(108303),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(108305),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(108301),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(108303),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(108305),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -155578,19 +155776,22 @@ StyleSheet(
                 offset: SourceOffset(111220),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(111222),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(111224),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(111226),
-                len: 3,
-              )))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(111222),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(111224),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(111226),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -155661,19 +155862,22 @@ StyleSheet(
                 offset: SourceOffset(111274),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(111276),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(111278),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(111280),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(111276),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(111278),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(111280),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -157223,19 +157427,22 @@ StyleSheet(
                       offset: SourceOffset(112518),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(112520),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(112522),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(112524),
-                      len: 3,
-                    )))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(112520),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(112522),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(112524),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -157306,19 +157513,22 @@ StyleSheet(
                       offset: SourceOffset(112576),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(112578),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(112580),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(112582),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(112578),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(112580),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(112582),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -157426,19 +157636,22 @@ StyleSheet(
                       offset: SourceOffset(112663),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(112665),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(112667),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(112669),
-                      len: 3,
-                    )))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(112665),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(112667),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(112669),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -157509,19 +157722,22 @@ StyleSheet(
                       offset: SourceOffset(112721),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(112723),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(112725),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(112727),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(112723),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(112725),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(112727),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -158271,19 +158487,22 @@ StyleSheet(
                       offset: SourceOffset(113477),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(113479),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(113481),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(113483),
-                      len: 3,
-                    )))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(113479),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(113481),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(113483),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -158354,19 +158573,22 @@ StyleSheet(
                       offset: SourceOffset(113535),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(113537),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(113539),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(113541),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(113537),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(113539),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(113541),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -158474,19 +158696,22 @@ StyleSheet(
                       offset: SourceOffset(113621),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(113623),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(113625),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(113627),
-                      len: 3,
-                    )))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(113623),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(113625),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(113627),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -158557,19 +158782,22 @@ StyleSheet(
                       offset: SourceOffset(113679),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(113681),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(113683),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(113685),
-                      len: 3,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(113681),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(113683),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(113685),
+                        len: 3,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -182360,19 +182588,22 @@ StyleSheet(
                 offset: SourceOffset(131372),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(131374),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(131376),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(131378),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(131374),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(131376),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(131378),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -182443,19 +182674,22 @@ StyleSheet(
                 offset: SourceOffset(131424),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(131426),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(131428),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(131430),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(131426),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(131428),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(131430),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -183167,19 +183401,22 @@ StyleSheet(
                 offset: SourceOffset(132079),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(132081),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(132083),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(132085),
-                len: 3,
-              )))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(132081),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(132083),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(132085),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -183250,19 +183487,22 @@ StyleSheet(
                 offset: SourceOffset(132133),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(132135),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(132137),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(132139),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(132135),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(132137),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(132139),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -220345,19 +220585,22 @@ StyleSheet(
                 offset: SourceOffset(161685),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(161687),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(161689),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(161691),
-                len: 3,
-              )))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(161687),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(161689),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(161691),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -220428,19 +220671,22 @@ StyleSheet(
                 offset: SourceOffset(161735),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(161737),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(161739),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(161741),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(161737),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(161739),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(161741),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -224846,19 +225092,22 @@ StyleSheet(
                 offset: SourceOffset(165209),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(165211),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(165213),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(165215),
-                len: 4,
-              )))))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(165211),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(165213),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(165215),
+                  len: 4,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -224929,19 +225178,22 @@ StyleSheet(
                 offset: SourceOffset(165265),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(165267),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(165269),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(165271),
-                len: 4,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(165267),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(165269),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(165271),
+                  len: 4,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -225253,19 +225505,22 @@ StyleSheet(
                       offset: SourceOffset(165543),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(165545),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(165547),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(165549),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(165545),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(165547),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(165549),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -225336,19 +225591,22 @@ StyleSheet(
                       offset: SourceOffset(165607),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(165609),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(165611),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(165613),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(165609),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(165611),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(165613),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -225474,19 +225732,22 @@ StyleSheet(
                       offset: SourceOffset(165730),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(165732),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(165734),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(165736),
-                      len: 4,
-                    )))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(165732),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(165734),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(165736),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -225557,19 +225818,22 @@ StyleSheet(
                       offset: SourceOffset(165794),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(165796),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(165798),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(165800),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(165796),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(165798),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(165800),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -225960,19 +226224,22 @@ StyleSheet(
                       offset: SourceOffset(166168),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(166170),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(166172),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(166174),
-                      len: 4,
-                    )))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(166170),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(166172),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(166174),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -226043,19 +226310,22 @@ StyleSheet(
                       offset: SourceOffset(166232),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(166234),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(166236),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(166238),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(166234),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(166236),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(166238),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -226446,19 +226716,22 @@ StyleSheet(
                       offset: SourceOffset(166601),
                       len: 1,
                     )),
-                    value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(166603),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(166605),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(166607),
-                      len: 4,
-                    )))))))))),
+                    value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(166603),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(166605),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(166607),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -226529,19 +226802,22 @@ StyleSheet(
                       offset: SourceOffset(166665),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(166667),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(166669),
-                      len: 1,
-                    )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                      kind: "Dimension",
-                      offset: SourceOffset(166671),
-                      len: 4,
-                    )))))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(166667),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(166669),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                        kind: "Dimension",
+                        offset: SourceOffset(166671),
+                        len: 4,
+                      ))))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -226658,19 +226934,22 @@ StyleSheet(
                 offset: SourceOffset(166761),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(166763),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(166765),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(166767),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(166763),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(166765),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(166767),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -226741,19 +227020,22 @@ StyleSheet(
                 offset: SourceOffset(166813),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(166815),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(166817),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(166819),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(166815),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(166817),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(166819),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -226892,19 +227174,22 @@ StyleSheet(
                 offset: SourceOffset(166929),
                 len: 1,
               )),
-              value: WebkitFlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(166931),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(166933),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(166935),
-                len: 4,
-              )))))))),
+              value: WebkitFlexStyleValue(r#Some(WebkitFlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(166931),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(166933),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(166935),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -226975,19 +227260,22 @@ StyleSheet(
                 offset: SourceOffset(166981),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(166983),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(166985),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(166987),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(166983),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(166985),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(166987),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
@@ -6653,19 +6653,22 @@ StyleSheet(
                 offset: SourceOffset(4692),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4694),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4696),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(4698),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4694),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4696),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(4698),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -6911,19 +6914,22 @@ StyleSheet(
                 offset: SourceOffset(4848),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4850),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(4852),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(4854),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4850),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(4852),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(4854),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -9749,19 +9755,22 @@ StyleSheet(
                       offset: SourceOffset(6785),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6787),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(6789),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(6791),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6787),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(6789),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(6791),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -12595,19 +12604,22 @@ StyleSheet(
                       offset: SourceOffset(8923),
                       len: 1,
                     )),
-                    value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8925),
-                      len: 1,
-                    ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                      kind: "Number",
-                      offset: SourceOffset(8927),
-                      len: 1,
-                    )))))), Some(Width(Auto(Ident(Cursor(
-                      kind: "Ident",
-                      offset: SourceOffset(8929),
-                      len: 4,
-                    )))))))),
+                    value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                      flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8925),
+                        len: 1,
+                      ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                        kind: "Number",
+                        offset: SourceOffset(8927),
+                        len: 1,
+                      )))))),
+                      flex_basis: Some(Width(Auto(Ident(Cursor(
+                        kind: "Ident",
+                        offset: SourceOffset(8929),
+                        len: 4,
+                      ))))),
+                    ))),
                     important: None,
                     semicolon: Some(Semicolon(Cursor(
                       kind: "Semicolon",
@@ -27371,19 +27383,22 @@ StyleSheet(
                 offset: SourceOffset(19210),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(19212),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(19214),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(19216),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(19212),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(19214),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(19216),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -41027,19 +41042,22 @@ StyleSheet(
                 offset: SourceOffset(28538),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(28540),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(28542),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(28544),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(28540),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(28542),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(28544),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -41337,19 +41355,22 @@ StyleSheet(
                 offset: SourceOffset(28740),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(28742),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(28744),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(28746),
-                len: 4,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(28742),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(28744),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(28746),
+                  len: 4,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -42864,19 +42885,22 @@ StyleSheet(
                 offset: SourceOffset(29772),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(29774),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(29776),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(29778),
-                len: 4,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(29774),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(29776),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(29778),
+                  len: 4,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -42996,19 +43020,22 @@ StyleSheet(
                 offset: SourceOffset(29844),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(29846),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(29848),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(29850),
-                len: 4,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(29846),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(29848),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(29850),
+                  len: 4,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -43152,19 +43179,22 @@ StyleSheet(
                 offset: SourceOffset(29920),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(29922),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(29924),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(29926),
-                len: 2,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(29922),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(29924),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Percent(Percentage(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(29926),
+                  len: 2,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -43659,19 +43689,22 @@ StyleSheet(
                 offset: SourceOffset(30216),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(30218),
-                len: 2,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(30221),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(30223),
-                len: 1,
-              ))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(30218),
+                  len: 2,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(30221),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(30223),
+                  len: 1,
+                )))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -43816,19 +43849,22 @@ StyleSheet(
                 offset: SourceOffset(30337),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(30339),
-                len: 2,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(30342),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Zero(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(30344),
-                len: 1,
-              ))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(30339),
+                  len: 2,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(30342),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Zero(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(30344),
+                  len: 1,
+                )))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -44027,19 +44063,22 @@ StyleSheet(
                 offset: SourceOffset(30476),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(30478),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(30480),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(30482),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(30478),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(30480),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(30482),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -54147,19 +54186,22 @@ StyleSheet(
                 offset: SourceOffset(37417),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(37419),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(37421),
-                len: 1,
-              )))))), Some(Width(Auto(Ident(Cursor(
-                kind: "Ident",
-                offset: SourceOffset(37423),
-                len: 4,
-              )))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(37419),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(37421),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(Auto(Ident(Cursor(
+                  kind: "Ident",
+                  offset: SourceOffset(37423),
+                  len: 4,
+                ))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
@@ -15621,19 +15621,22 @@ StyleSheet(
                 offset: SourceOffset(10436),
                 len: 1,
               )),
-              value: FlexStyleValue(r#Some(Optionals2(Some((FlexGrowStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10438),
-                len: 1,
-              ))), Some(FlexShrinkStyleValue(Number(Cursor(
-                kind: "Number",
-                offset: SourceOffset(10440),
-                len: 1,
-              )))))), Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
-                kind: "Dimension",
-                offset: SourceOffset(10442),
-                len: 3,
-              )))))))))),
+              value: FlexStyleValue(r#Some(FlexStyleValueOptions(
+                flex_grow: Some((FlexGrowStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10438),
+                  len: 1,
+                ))), Some(FlexShrinkStyleValue(Number(Cursor(
+                  kind: "Number",
+                  offset: SourceOffset(10440),
+                  len: 1,
+                )))))),
+                flex_basis: Some(Width(LengthPercentage(Length(Px(Dimension(Cursor(
+                  kind: "Dimension",
+                  offset: SourceOffset(10442),
+                  len: 3,
+                ))))))),
+              ))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -15,11 +15,13 @@ pub fn pluralize(str: String) -> String {
 pub trait DefExt {
 	fn single_ident(ident: &Ident) -> Ident;
 	fn keyword_ident(ident: &Ident) -> Ident;
+	fn options_ident(ident: &Ident) -> Ident;
 	fn should_skip_visit(&self) -> bool;
 	fn type_attributes(&self, derives_parse: bool, derives_visitable: bool) -> TokenStream;
 	fn is_all_keywords(&self) -> bool;
 	fn get_generics(&self) -> Generics;
 	fn gather_keywords(&self) -> Vec<&Self>;
+	fn rewrite_options_type(&self, replacement: &TokenStream) -> TokenStream;
 	fn generate_additional_types(&self, vis: &Visibility, ident: &Ident, generics: &Generics) -> TokenStream;
 }
 
@@ -121,15 +123,11 @@ impl ToFieldName for Def {
 				}
 			}
 			Self::Combinator(ds, DefCombinatorStyle::Options) => {
-				let auto_generated_name = ds.iter().fold(String::new(), |str, d| match d {
-					Def::Type(d) => {
-						format!("{}{}", str, d.to_variant_name(0))
-					}
-					_ => {
-						dbg!("TODO variant name for Combinator() of Options", d);
-						todo!("variant name")
-					}
-				});
+				let auto_generated_name: String = ds
+					.iter()
+					.filter(|d| !matches!(d, Def::Punct(_)))
+					.map(|d| d.to_variant_name(0).to_string())
+					.collect();
 				format_ident!("{}", get_type_rename(&auto_generated_name).unwrap_or(&auto_generated_name))
 			}
 			Self::Combinator(ds, DefCombinatorStyle::AllMustOccur) => {
@@ -205,8 +203,8 @@ impl ToType for Def {
 				vec![quote! { ::css_parse::Optionals![#(#types),*] }]
 			}
 			Self::Combinator(ds, DefCombinatorStyle::AllMustOccur) => {
-				let types = ds.iter().map(|d| d.to_type());
-				vec![quote! { #(#types),* }]
+				let types: Vec<_> = ds.iter().map(|d| d.to_type()).collect();
+				if types.len() == 1 { types } else { vec![quote! { (#(#types),*) }] }
 			}
 			Self::Multiplier(def, DefMultiplierSeparator::Commas, range) => {
 				let ty = def.deref().to_type();
@@ -280,6 +278,34 @@ impl ToType for DefType {
 	}
 }
 
+/// Find Options combinators containing keyword (Ident) children that need helper structs.
+/// Searches: direct Alternatives children, and NoneOr/AutoOr/NormalOr/AutoNoneOr wrappers.
+fn find_options_with_keywords(def: &Def) -> Vec<&Def> {
+	fn is_options_with_keywords(def: &Def) -> bool {
+		if let Def::Combinator(defs, DefCombinatorStyle::Options) = def {
+			defs.iter().any(|d| !matches!(d, Def::Type(_) | Def::StyleValue(_)))
+		} else {
+			false
+		}
+	}
+	fn unwrap_to_options(def: &Def) -> Option<&Def> {
+		match def {
+			Def::Group(inner, _) => unwrap_to_options(inner),
+			d if is_options_with_keywords(d) => Some(d),
+			_ => None,
+		}
+	}
+	match def {
+		Def::Combinator(children, DefCombinatorStyle::Alternatives) => {
+			children.iter().filter_map(unwrap_to_options).collect()
+		}
+		Def::NoneOr(inner) | Def::AutoOr(inner) | Def::NormalOr(inner) | Def::AutoNoneOr(inner) => {
+			unwrap_to_options(inner).into_iter().collect()
+		}
+		_ => vec![],
+	}
+}
+
 impl DefExt for Def {
 	fn single_ident(ident: &Ident) -> Ident {
 		let ident = ident.to_string();
@@ -291,6 +317,12 @@ impl DefExt for Def {
 		let ident = ident.to_string();
 		let ident = ident.strip_prefix("Single").unwrap_or(&ident);
 		format_ident!("{}Keywords", ident)
+	}
+
+	fn options_ident(ident: &Ident) -> Ident {
+		let ident = ident.to_string();
+		let ident = ident.strip_prefix("Single").unwrap_or(&ident);
+		format_ident!("{}Options", ident)
 	}
 
 	fn should_skip_visit(&self) -> bool {
@@ -415,6 +447,18 @@ impl DefExt for Def {
 		}
 	}
 
+	fn rewrite_options_type(&self, replacement: &TokenStream) -> TokenStream {
+		match self {
+			Self::NoneOr(_) => quote! { crate::NoneOr<#replacement> },
+			Self::AutoOr(_) => quote! { crate::AutoOr<#replacement> },
+			Self::NormalOr(_) => quote! { crate::NormalOr<#replacement> },
+			Self::AutoNoneOr(_) => quote! { crate::AutoNoneOr<#replacement> },
+			Self::Group(inner, _) => inner.rewrite_options_type(replacement),
+			Self::Combinator(_, DefCombinatorStyle::Options) => replacement.clone(),
+			_ => self.to_type(),
+		}
+	}
+
 	fn generate_additional_types(&self, vis: &Visibility, ident: &Ident, _generics: &Generics) -> TokenStream {
 		let needs_keyword_type = match self {
 			Self::Combinator(defs, DefCombinatorStyle::Ordered) => defs.iter().any(|def| def.is_all_keywords()),
@@ -509,9 +553,41 @@ impl DefExt for Def {
 		} else {
 			quote! {}
 		};
+		// Generate Options helper structs when Options contains keyword (Ident) children.
+		// Optionals![T![Ident], T![Ident], ...] can't discriminate keywords — a named struct
+		// with #[parse(one_must_occur)] and per-field #[atom] handles this correctly.
+		let options_children = find_options_with_keywords(self);
+		let options_types = if options_children.is_empty() {
+			quote! {}
+		} else {
+			let mut result = quote! {};
+			for (i, inner) in options_children.iter().enumerate() {
+				let opts_ident = if options_children.len() == 1 {
+					Self::options_ident(ident)
+				} else {
+					format_ident!("{}Options{}", ident, i + 1)
+				};
+				let generics = inner.get_generics();
+				let def = inner.generate_definition(vis, &opts_ident, &generics, true, true);
+				result.extend(quote! {
+					#[derive(
+						::csskit_derives::Parse,
+						::csskit_derives::Peek,
+						::csskit_derives::ToSpan,
+						::csskit_derives::ToCursors,
+						::csskit_derives::SemanticEq,
+						Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+					#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+					#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
+					#def
+				});
+			}
+			result
+		};
 		quote! {
 			#keyword_type
 			#single_type
+			#options_types
 		}
 	}
 }
@@ -629,58 +705,105 @@ impl GenerateDefinition for Def {
 						}
 					},
 					_ => {
-						let ty = self.to_types();
-						let attrs = self.type_attributes(derives_parse, derives_visitable);
-						quote! { ( #(#attrs pub #ty),* ); }
+						// Check if this wraps an Options-with-keywords that has a helper struct.
+						let options_children = find_options_with_keywords(self);
+						if !options_children.is_empty() {
+							let opts_ident = Self::options_ident(ident);
+							let opts_generics = options_children[0].get_generics();
+							let ty = self.rewrite_options_type(&quote! { crate::#opts_ident #opts_generics });
+							quote! { ( pub #ty ); }
+						} else {
+							let ty = self.to_types();
+							let attrs = self.type_attributes(derives_parse, derives_visitable);
+							quote! { ( #(#attrs pub #ty),* ); }
+						}
 					}
 				};
 				quote! { #struct_attrs #vis struct #ident #type_generics #where_clause #members }
 			}
 			DataType::Enum => match self {
 				Self::Combinator(children, DefCombinatorStyle::Alternatives) => {
+					// Pre-compute which children are Options-with-keywords that have helper structs.
+					let options_indices: Vec<usize> = children
+						.iter()
+						.enumerate()
+						.filter_map(|(i, d)| {
+							let inner = match d {
+								Def::Group(inner, _) => inner.as_ref(),
+								other => other,
+							};
+							if let Def::Combinator(defs, DefCombinatorStyle::Options) = inner {
+								if defs.iter().any(|d| !matches!(d, Def::Type(_) | Def::StyleValue(_))) {
+									Some(i)
+								} else {
+									None
+								}
+							} else {
+								None
+							}
+						})
+						.collect();
+
 					let variants: TokenStream = children
 						.iter()
-						.map(|d| {
+						.enumerate()
+						.map(|(child_idx, d)| {
 							let mut attrs = Some(d.type_attributes(derives_parse, derives_visitable));
 							let name = d.to_variant_name(0);
-							let types = match d {
-								Self::Combinator(defs, DefCombinatorStyle::Ordered) => defs
-									.iter()
-									.map(|d| {
-										let ty = d.to_type();
-										let attrs = d.type_attributes(derives_parse, derives_visitable);
-										quote! { #attrs #ty }
-									})
-									.collect(),
-								Self::Combinator(defs, DefCombinatorStyle::AllMustOccur) => {
-									if derives_parse {
-										attrs = Some(quote! { #[parse(all_must_occur)] });
-									}
-									defs.iter()
+							// Check if this child has a generated Options helper struct.
+							let options_helper_idx = options_indices.iter().position(|&i| i == child_idx);
+							let types = if let Some(idx) = options_helper_idx {
+								let opts_ident = if options_indices.len() == 1 {
+									Self::options_ident(ident)
+								} else {
+									format_ident!("{}Options{}", ident, idx + 1)
+								};
+								let inner = match d {
+									Def::Group(inner, _) => inner.as_ref(),
+									other => other,
+								};
+								let generics = inner.get_generics();
+								vec![quote! { crate::#opts_ident #generics }]
+							} else {
+								match d {
+									Self::Combinator(defs, DefCombinatorStyle::Ordered) => defs
+										.iter()
 										.map(|d| {
 											let ty = d.to_type();
-											let a = d.type_attributes(derives_parse, derives_visitable);
-											quote! { #a #ty }
+											let attrs = d.type_attributes(derives_parse, derives_visitable);
+											quote! { #attrs #ty }
 										})
-										.collect()
+										.collect(),
+									Self::Combinator(defs, DefCombinatorStyle::AllMustOccur) => {
+										if derives_parse {
+											attrs = Some(quote! { #[parse(all_must_occur)] });
+										}
+										defs.iter()
+											.map(|d| {
+												let ty = d.to_type();
+												let a = d.type_attributes(derives_parse, derives_visitable);
+												quote! { #a #ty }
+											})
+											.collect()
+									}
+									Self::Ident(_) => d.to_types(),
+									Self::IntLiteral(_) | Self::DimensionLiteral(_, _) => {
+										let attrs = attrs.take().unwrap();
+										let ty = d.to_type();
+										vec![quote! { #attrs #ty }]
+									}
+									Self::Type(_) => {
+										let attrs = attrs.take().unwrap();
+										let ty = d.to_type();
+										vec![quote! { #attrs #ty }]
+									}
+									Self::Optional(inner) if matches!(inner.deref(), Def::Type(_)) => {
+										let attrs = attrs.take().unwrap();
+										let ty = d.to_type();
+										vec![quote! { #attrs #ty }]
+									}
+									_ => d.to_types(),
 								}
-								Self::Ident(_) => d.to_types(),
-								Self::IntLiteral(_) | Self::DimensionLiteral(_, _) => {
-									let attrs = attrs.take().unwrap();
-									let ty = d.to_type();
-									vec![quote! { #attrs #ty }]
-								}
-								Self::Type(_) => {
-									let attrs = attrs.take().unwrap();
-									let ty = d.to_type();
-									vec![quote! { #attrs #ty }]
-								}
-								Self::Optional(inner) if matches!(inner.deref(), Def::Type(_)) => {
-									let attrs = attrs.take().unwrap();
-									let ty = d.to_type();
-									vec![quote! { #attrs #ty }]
-								}
-								_ => d.to_types(),
 							};
 							quote! { #attrs #name(#(#types),*), }
 						})

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_options.snap
@@ -1,0 +1,45 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(
+    ::csskit_derives::Parse,
+    ::csskit_derives::Peek,
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::ToCursors,
+    ::csskit_derives::SemanticEq,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
+#[parse(one_must_occur)]
+struct FooOptions {
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    #[atom(CssAtomSet::Underline)]
+    pub underline: Option<::css_parse::T![Ident]>,
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    #[atom(CssAtomSet::Overline)]
+    pub overline: Option<::css_parse::T![Ident]>,
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    #[atom(CssAtomSet::LineThrough)]
+    pub line_through: Option<::css_parse::T![Ident]>,
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    #[atom(CssAtomSet::Blink)]
+    pub blink: Option<::css_parse::T![Ident]>,
+}
+#[derive(Parse)]
+enum Foo {
+    #[atom(CssAtomSet::None)]
+    None(::css_parse::T![Ident]),
+    UnderlineOverlineLineThroughBlink(crate::FooOptions),
+    #[atom(CssAtomSet::SpellingError)]
+    SpellingError(::css_parse::T![Ident]),
+    #[atom(CssAtomSet::GrammarError)]
+    GrammarError(::css_parse::T![Ident]),
+}

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_mixed_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_mixed_options.snap
@@ -1,0 +1,34 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(
+    ::csskit_derives::Parse,
+    ::csskit_derives::Peek,
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::ToCursors,
+    ::csskit_derives::SemanticEq,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
+#[parse(one_must_occur)]
+struct FooOptions {
+    pub angle: Option<crate::Angle>,
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    #[atom(CssAtomSet::Flip)]
+    pub flip: Option<::css_parse::T![Ident]>,
+}
+#[derive(Parse)]
+enum Foo {
+    #[atom(CssAtomSet::None)]
+    None(::css_parse::T![Ident]),
+    AngleFlip(crate::FooOptions),
+    Length(crate::Length),
+}

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_type_only_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_type_only_options.snap
@@ -1,0 +1,11 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(Parse)]
+enum Foo {
+    #[atom(CssAtomSet::None)]
+    None(::css_parse::T![Ident]),
+    AnglePercentage(::css_parse::Optionals![crate ::Angle, crate ::Percentage]),
+    Length(crate::Length),
+}

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_nonor_keyword_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_nonor_keyword_options.snap
@@ -1,0 +1,37 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(
+    ::csskit_derives::Parse,
+    ::csskit_derives::Peek,
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::ToCursors,
+    ::csskit_derives::SemanticEq,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
+#[parse(one_must_occur)]
+struct FooOptions {
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    #[atom(CssAtomSet::Weight)]
+    pub weight: Option<::css_parse::T![Ident]>,
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    #[atom(CssAtomSet::Style)]
+    pub style: Option<::css_parse::T![Ident]>,
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    #[atom(CssAtomSet::SmallCaps)]
+    pub small_caps: Option<::css_parse::T![Ident]>,
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    #[atom(CssAtomSet::Position)]
+    pub position: Option<::css_parse::T![Ident]>,
+}
+#[derive(Parse)]
+struct Foo(pub crate::NoneOr<crate::FooOptions>);

--- a/crates/csskit_proc_macro/src/test/test_generate.rs
+++ b/crates/csskit_proc_macro/src/test/test_generate.rs
@@ -458,3 +458,36 @@ fn enum_with_ordered_punct() {
 	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
 	assert_snapshot!(syntax, data, "enum_with_ordered_punct");
 }
+
+#[test]
+fn enum_with_keyword_options() {
+	// 4 alternatives stays as enum (not folded to NoneOr)
+	let syntax =
+		to_valuedef! { none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "enum_with_keyword_options");
+}
+
+#[test]
+fn enum_with_mixed_options() {
+	// 3 alternatives: keyword, type-only options, mixed options
+	let syntax = to_valuedef! { none | [ <angle> || flip ] | <length> };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "enum_with_mixed_options");
+}
+
+#[test]
+fn enum_with_type_only_options() {
+	// type-only options use Optionals! directly (no helper struct needed)
+	let syntax = to_valuedef! { none | [ <angle> || <percentage> ] | <length> };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "enum_with_type_only_options");
+}
+
+#[test]
+fn struct_nonor_keyword_options() {
+	// NoneOr wrapping Options-with-keywords generates helper struct
+	let syntax = to_valuedef! { none | [ weight || style || small-caps || position ] };
+	let data = to_deriveinput! { #[derive(Parse)] struct Foo; };
+	assert_snapshot!(syntax, data, "struct_nonor_keyword_options");
+}


### PR DESCRIPTION
Currently we don't support syntaxes like `foo | [ bar || baz ]` due to the group
needing a subtype, which gets gnarly quickly. However for this _specific_ case
we can generate a reasonable sub type: a group of optionals can be called
`Options`.

This change introduces options helper structs for such cases, removing one of
our todo!() assertions, supporting new syntax types.
