### PR TITLE
css_value_definition_parser: Pre-flatten nested Alternatives

### DIFF
--- a/crates/css_value_definition_parser/src/lib.rs
+++ b/crates/css_value_definition_parser/src/lib.rs
@@ -377,6 +377,19 @@ impl Def {
 	}
 
 	pub fn optimize(&self) -> Self {
+		if let Self::Combinator(defs, DefCombinatorStyle::Alternatives) = self {
+			let optimized: Vec<Def> = defs.iter().map(Self::optimize).collect();
+			if optimized.iter().any(|d| matches!(d, Def::Combinator(_, DefCombinatorStyle::Alternatives))) {
+				let flat: Vec<Def> = optimized
+					.into_iter()
+					.flat_map(|d| match d {
+						Def::Combinator(inner, DefCombinatorStyle::Alternatives) => inner,
+						other => vec![other],
+					})
+					.collect();
+				return Self::Combinator(flat, DefCombinatorStyle::Alternatives).optimize();
+			}
+		}
 		match self {
 			Self::Combinator(defs, DefCombinatorStyle::Alternatives)
 				if defs.iter().any(Self::has_distributable_group) =>

--- a/crates/css_value_definition_parser/src/test.rs
+++ b/crates/css_value_definition_parser/src/test.rs
@@ -697,3 +697,52 @@ fn optimize_distributes_top_level_all_must_occur() {
 		)
 	);
 }
+
+#[test]
+fn def_flattens_distributed_options_over_alternation_group() {
+	assert_eq!(
+		to_valuedef! { nowrap | [ wrap | wrap-reverse ] || balance },
+		Def::Combinator(
+			vec![
+				Def::Ident(DefIdent("nowrap".into())),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("wrap".into())), Def::Ident(DefIdent("balance".into()))],
+					DefCombinatorStyle::Options,
+				),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("wrap-reverse".into())), Def::Ident(DefIdent("balance".into()))],
+					DefCombinatorStyle::Options,
+				),
+			],
+			DefCombinatorStyle::Alternatives,
+		)
+	);
+}
+
+#[test]
+fn def_flattens_two_distributed_options_in_alternatives() {
+	assert_eq!(
+		to_valuedef! { [ a | b ] || c | [ d | e ] || f },
+		Def::Combinator(
+			vec![
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("a".into())), Def::Ident(DefIdent("c".into()))],
+					DefCombinatorStyle::Options,
+				),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("b".into())), Def::Ident(DefIdent("c".into()))],
+					DefCombinatorStyle::Options,
+				),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("d".into())), Def::Ident(DefIdent("f".into()))],
+					DefCombinatorStyle::Options,
+				),
+				Def::Combinator(
+					vec![Def::Ident(DefIdent("e".into())), Def::Ident(DefIdent("f".into()))],
+					DefCombinatorStyle::Options,
+				),
+			],
+			DefCombinatorStyle::Alternatives,
+		)
+	);
+}


### PR DESCRIPTION
Nested `Alternatives` can occur inside an outer `Alternatives`, but enum codegen requires a single flat list of variants.

This change optimises children first so a child whose optimisation yields an `Alternatives` is absorbed by the parent.
