### PR TITLE
csskit_proc_macro: Inline Options-with-keywords as enum struct variants

### DIFF
--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -556,7 +556,15 @@ impl DefExt for Def {
 		// Generate Options helper structs when Options contains keyword (Ident) children.
 		// Optionals![T![Ident], T![Ident], ...] can't discriminate keywords — a named struct
 		// with #[parse(one_must_occur)] and per-field #[atom] handles this correctly.
-		let options_children = find_options_with_keywords(self);
+		// When `self` is an Alternatives (i.e. an enum), Options-with-keywords children are
+		// inlined as struct variants on the enum directly (see DataType::Enum codegen below) —
+		// so no helper structs are needed here. Helper structs are still emitted for struct
+		// cases (e.g. NoneOr-wrapped Options).
+		let options_children = if matches!(self, Self::Combinator(_, DefCombinatorStyle::Alternatives)) {
+			vec![]
+		} else {
+			find_options_with_keywords(self)
+		};
 		let options_types = if options_children.is_empty() {
 			quote! {}
 		} else {
@@ -723,8 +731,9 @@ impl GenerateDefinition for Def {
 			}
 			DataType::Enum => match self {
 				Self::Combinator(children, DefCombinatorStyle::Alternatives) => {
-					// Pre-compute which children are Options-with-keywords that have helper structs.
-					let options_indices: Vec<usize> = children
+					// Pre-compute which children are Options-with-keywords; these are inlined as
+					// struct variants on the enum (rather than referencing a helper struct).
+					let options_children_refs: Vec<(usize, &Def)> = children
 						.iter()
 						.enumerate()
 						.filter_map(|(i, d)| {
@@ -732,40 +741,46 @@ impl GenerateDefinition for Def {
 								Def::Group(inner, _) => inner.as_ref(),
 								other => other,
 							};
-							if let Def::Combinator(defs, DefCombinatorStyle::Options) = inner {
-								if defs.iter().any(|d| !matches!(d, Def::Type(_) | Def::StyleValue(_))) {
-									Some(i)
-								} else {
-									None
-								}
-							} else {
-								None
+							if let Def::Combinator(defs, DefCombinatorStyle::Options) = inner
+								&& defs.iter().any(|d| !matches!(d, Def::Type(_) | Def::StyleValue(_)))
+							{
+								return Some((i, inner));
 							}
+							None
 						})
 						.collect();
+					let options_indices: Vec<usize> = options_children_refs.iter().map(|(i, _)| *i).collect();
+					let options_inner_defs: Vec<&Def> = options_children_refs.iter().map(|(_, d)| *d).collect();
 
 					let variants: TokenStream = children
 						.iter()
 						.enumerate()
 						.map(|(child_idx, d)| {
 							let mut attrs = Some(d.type_attributes(derives_parse, derives_visitable));
-							let name = d.to_variant_name(0);
-							// Check if this child has a generated Options helper struct.
+							// Locate this child in the Options list (if it is one).
 							let options_helper_idx = options_indices.iter().position(|&i| i == child_idx);
-							let types = if let Some(idx) = options_helper_idx {
-								let opts_ident = if options_indices.len() == 1 {
-									Self::options_ident(ident)
+							if let Some(idx) = options_helper_idx {
+								// Inline as struct variant with #[parse(one_must_occur)].
+								let inner = options_inner_defs[idx];
+								let Def::Combinator(opts_children, DefCombinatorStyle::Options) = inner else {
+									unreachable!("filtered above");
+								};
+								let name = inner.to_variant_name(0);
+								let members = opts_children.iter().map(|child| {
+									let member_name = child.to_member_name(0);
+									let ty = child.to_type();
+									let field_attrs = child.type_attributes(derives_parse, derives_visitable);
+									quote! { #field_attrs pub #member_name: Option<#ty> }
+								});
+								let variant_attrs = if derives_parse {
+									quote! { #[parse(one_must_occur)] }
 								} else {
-									format_ident!("{}Options{}", ident, idx + 1)
+									quote! {}
 								};
-								let inner = match d {
-									Def::Group(inner, _) => inner.as_ref(),
-									other => other,
-								};
-								let generics = inner.get_generics();
-								vec![quote! { crate::#opts_ident #generics }]
+								quote! { #variant_attrs #name { #(#members),* }, }
 							} else {
-								match d {
+								let name = d.to_variant_name(0);
+								let types = match d {
 									Self::Combinator(defs, DefCombinatorStyle::Ordered) => defs
 										.iter()
 										.map(|d| {
@@ -803,9 +818,9 @@ impl GenerateDefinition for Def {
 										vec![quote! { #attrs #ty }]
 									}
 									_ => d.to_types(),
-								}
-							};
-							quote! { #attrs #name(#(#types),*), }
+								};
+								quote! { #attrs #name(#(#types),*), }
+							}
 						})
 						.collect();
 					quote! { #vis enum #ident #type_generics #where_clause { #variants } }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_group_in_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_group_in_options.snap
@@ -1,0 +1,23 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(Parse)]
+enum Foo {
+    #[atom(CssAtomSet::Nowrap)]
+    Nowrap(::css_parse::T![Ident]),
+    #[parse(one_must_occur)]
+    WrapBalance {
+        #[atom(CssAtomSet::Wrap)]
+        pub wrap: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Balance)]
+        pub balance: Option<::css_parse::T![Ident]>,
+    },
+    #[parse(one_must_occur)]
+    WrapReverseBalance {
+        #[atom(CssAtomSet::WrapReverse)]
+        pub wrap_reverse: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Balance)]
+        pub balance: Option<::css_parse::T![Ident]>,
+    },
+}

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_options.snap
@@ -2,42 +2,21 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[derive(
-    ::csskit_derives::Parse,
-    ::csskit_derives::Peek,
-    ::csskit_derives::ToSpan,
-    ::csskit_derives::ToCursors,
-    ::csskit_derives::SemanticEq,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
-#[parse(one_must_occur)]
-struct FooOptions {
-    #[cfg_attr(feature = "visitable", visit(skip))]
-    #[atom(CssAtomSet::Underline)]
-    pub underline: Option<::css_parse::T![Ident]>,
-    #[cfg_attr(feature = "visitable", visit(skip))]
-    #[atom(CssAtomSet::Overline)]
-    pub overline: Option<::css_parse::T![Ident]>,
-    #[cfg_attr(feature = "visitable", visit(skip))]
-    #[atom(CssAtomSet::LineThrough)]
-    pub line_through: Option<::css_parse::T![Ident]>,
-    #[cfg_attr(feature = "visitable", visit(skip))]
-    #[atom(CssAtomSet::Blink)]
-    pub blink: Option<::css_parse::T![Ident]>,
-}
 #[derive(Parse)]
 enum Foo {
     #[atom(CssAtomSet::None)]
     None(::css_parse::T![Ident]),
-    UnderlineOverlineLineThroughBlink(crate::FooOptions),
+    #[parse(one_must_occur)]
+    UnderlineOverlineLineThroughBlink {
+        #[atom(CssAtomSet::Underline)]
+        pub underline: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Overline)]
+        pub overline: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::LineThrough)]
+        pub line_through: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Blink)]
+        pub blink: Option<::css_parse::T![Ident]>,
+    },
     #[atom(CssAtomSet::SpellingError)]
     SpellingError(::css_parse::T![Ident]),
     #[atom(CssAtomSet::GrammarError)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_mixed_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_mixed_options.snap
@@ -2,33 +2,15 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[derive(
-    ::csskit_derives::Parse,
-    ::csskit_derives::Peek,
-    ::csskit_derives::ToSpan,
-    ::csskit_derives::ToCursors,
-    ::csskit_derives::SemanticEq,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
-#[parse(one_must_occur)]
-struct FooOptions {
-    pub angle: Option<crate::Angle>,
-    #[cfg_attr(feature = "visitable", visit(skip))]
-    #[atom(CssAtomSet::Flip)]
-    pub flip: Option<::css_parse::T![Ident]>,
-}
 #[derive(Parse)]
 enum Foo {
     #[atom(CssAtomSet::None)]
     None(::css_parse::T![Ident]),
-    AngleFlip(crate::FooOptions),
+    #[parse(one_must_occur)]
+    AngleFlip {
+        pub angle: Option<crate::Angle>,
+        #[atom(CssAtomSet::Flip)]
+        pub flip: Option<::css_parse::T![Ident]>,
+    },
     Length(crate::Length),
 }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_only_alternation_group_in_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_only_alternation_group_in_options.snap
@@ -1,0 +1,21 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(Parse)]
+enum Foo {
+    #[parse(one_must_occur)]
+    WrapBalance {
+        #[atom(CssAtomSet::Wrap)]
+        pub wrap: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Balance)]
+        pub balance: Option<::css_parse::T![Ident]>,
+    },
+    #[parse(one_must_occur)]
+    WrapReverseBalance {
+        #[atom(CssAtomSet::WrapReverse)]
+        pub wrap_reverse: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Balance)]
+        pub balance: Option<::css_parse::T![Ident]>,
+    },
+}

--- a/crates/csskit_proc_macro/src/test/test_generate.rs
+++ b/crates/csskit_proc_macro/src/test/test_generate.rs
@@ -491,3 +491,24 @@ fn struct_nonor_keyword_options() {
 	let data = to_deriveinput! { #[derive(Parse)] struct Foo; };
 	assert_snapshot!(syntax, data, "struct_nonor_keyword_options");
 }
+
+#[test]
+fn enum_with_keyword_group_in_options() {
+	// Upcoming flex-wrap grammar: `nowrap | [ wrap | wrap-reverse ] || balance`.
+	// The `||` operand `[ wrap | wrap-reverse ]` is a keyword-only alternation
+	// group. Codegen should mint an inline keyword enum so the Options helper
+	// struct's field can hold it.
+	let syntax = to_valuedef! { nowrap | [ wrap | wrap-reverse ] || balance };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "enum_with_keyword_group_in_options");
+}
+
+#[test]
+fn keyword_only_alternation_group_in_options() {
+	// Isolated form: `||` over a keyword-only alternation group plus a plain
+	// keyword. The optimiser distributes the inner alternation over `||`,
+	// producing a top-level alternation that requires an enum.
+	let syntax = to_valuedef! { [ wrap | wrap-reverse ] || balance };
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "keyword_only_alternation_group_in_options");
+}


### PR DESCRIPTION
When an enum's Alternatives child is a `||` combinator containing keywords
(e.g. `[a||b||c]` or distributed `[a|b]||c` siblings), codegen emitts a variant
referencing a `FooOptions` helper struct. This intermediate type is a bit noisy.

This changes inlines these intermediate types as enum struct variants carrying
`#[parse(one_must_occur)]` directly so the generated code is self-contained and
avoids the indirection through helper types.

Helper struct emission is suppressed only for the Alternatives parent case so
struct cases (e.g. NoneOr-wrapped Options) keep the existing helper.
