### PR TITLE
csskit_proc_macro: Generate more concise names for varaitns

### DIFF
--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -306,6 +306,42 @@ fn find_options_with_keywords(def: &Def) -> Vec<&Def> {
 	}
 }
 
+/// For a list of sibling `Combinator(Options, ...)` children, compute each child's
+/// distinguishing keyword set: the keywords that appear in this child but NOT in some other
+/// sibling. Used to derive concise variant names when distribution produces multiple Options
+/// siblings sharing common keywords (e.g. `[a|b] || c` distributes to `(a||c)|(b||c)` whose
+/// distinguishing sets are `{a}` and `{b}`).
+///
+/// Returns `None` for a child if it cannot be uniquely distinguished, in which case the caller
+/// should fall back to the full concatenated name.
+fn distinguishing_keyword_names(siblings: &[&Def]) -> Vec<Option<Vec<String>>> {
+	if siblings.len() < 2 {
+		return siblings.iter().map(|_| None).collect();
+	}
+	let keyword_sets: Vec<Vec<String>> = siblings
+		.iter()
+		.map(|sibling| match sibling {
+			Def::Combinator(children, DefCombinatorStyle::Options) => children
+				.iter()
+				.filter_map(|d| if let Def::Ident(DefIdent(s)) = d { Some(s.clone()) } else { None })
+				.collect(),
+			_ => vec![],
+		})
+		.collect();
+	keyword_sets
+		.iter()
+		.enumerate()
+		.map(|(i, mine)| {
+			let unique: Vec<String> = mine
+				.iter()
+				.filter(|kw| keyword_sets.iter().enumerate().any(|(j, other)| j != i && !other.contains(kw)))
+				.cloned()
+				.collect();
+			if unique.is_empty() || unique.len() == mine.len() { None } else { Some(unique) }
+		})
+		.collect()
+}
+
 impl DefExt for Def {
 	fn single_ident(ident: &Ident) -> Ident {
 		let ident = ident.to_string();
@@ -751,6 +787,9 @@ impl GenerateDefinition for Def {
 						.collect();
 					let options_indices: Vec<usize> = options_children_refs.iter().map(|(i, _)| *i).collect();
 					let options_inner_defs: Vec<&Def> = options_children_refs.iter().map(|(_, d)| *d).collect();
+					// For multi-sibling Options, derive each variant's distinguishing keywords so
+					// names reflect the discriminator rather than concatenating shared keywords.
+					let distinguishing = distinguishing_keyword_names(&options_inner_defs);
 
 					let variants: TokenStream = children
 						.iter()
@@ -765,7 +804,13 @@ impl GenerateDefinition for Def {
 								let Def::Combinator(opts_children, DefCombinatorStyle::Options) = inner else {
 									unreachable!("filtered above");
 								};
-								let name = inner.to_variant_name(0);
+								// Variant name: distinguishing keywords (if computed) else full
+								// concatenation of all child names.
+								let name = if let Some(keywords) = &distinguishing[idx] {
+									format_ident!("{}", keywords.iter().map(|k| k.to_pascal_case()).collect::<String>())
+								} else {
+									inner.to_variant_name(0)
+								};
 								let members = opts_children.iter().map(|child| {
 									let member_name = child.to_member_name(0);
 									let ty = child.to_type();

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_group_in_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_group_in_options.snap
@@ -7,14 +7,14 @@ enum Foo {
     #[atom(CssAtomSet::Nowrap)]
     Nowrap(::css_parse::T![Ident]),
     #[parse(one_must_occur)]
-    WrapBalance {
+    Wrap {
         #[atom(CssAtomSet::Wrap)]
         pub wrap: Option<::css_parse::T![Ident]>,
         #[atom(CssAtomSet::Balance)]
         pub balance: Option<::css_parse::T![Ident]>,
     },
     #[parse(one_must_occur)]
-    WrapReverseBalance {
+    WrapReverse {
         #[atom(CssAtomSet::WrapReverse)]
         pub wrap_reverse: Option<::css_parse::T![Ident]>,
         #[atom(CssAtomSet::Balance)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_only_alternation_group_in_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_only_alternation_group_in_options.snap
@@ -5,14 +5,14 @@ expression: pretty
 #[derive(Parse)]
 enum Foo {
     #[parse(one_must_occur)]
-    WrapBalance {
+    Wrap {
         #[atom(CssAtomSet::Wrap)]
         pub wrap: Option<::css_parse::T![Ident]>,
         #[atom(CssAtomSet::Balance)]
         pub balance: Option<::css_parse::T![Ident]>,
     },
     #[parse(one_must_occur)]
-    WrapReverseBalance {
+    WrapReverse {
         #[atom(CssAtomSet::WrapReverse)]
         pub wrap_reverse: Option<::css_parse::T![Ident]>,
         #[atom(CssAtomSet::Balance)]


### PR DESCRIPTION
When optimisation distributes `[a|b] || c` into multiple Options siblings,
they're named by concatenating every keyword in each Options child meaning
e.g. `[wrap | wrap-reverse ] || balance` would add the `WrapBalance` and
`WrapReverseBalance` variants. The shared keyword (`balance`) is noise that we
can be a bit smarter about.

This change compute each sibling's distinguishing keyword set (keywords present
here but absent in at least one sibling) and uses those for the variant name.
If they can't be uniquely distinguished, it falls back to the old full
concatenation.
