### PR TITLE
csskit_derives: Add support for named struct variants

### DIFF
--- a/crates/csskit_derives/src/css_feature.rs
+++ b/crates/csskit_derives/src/css_feature.rs
@@ -2,7 +2,7 @@ use heck::ToKebabCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 use std::fmt::Display;
-use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, LitStr, Meta, Result, parse::Parse};
+use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, LitStr, Meta, Result, parse::Parse};
 
 use crate::err;
 
@@ -72,17 +72,28 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 					.iter()
 					.map(|variant| {
 						let variant_ident = &variant.ident;
-						let members = variant.fields.members().map(|_| quote! { _ });
+						let pattern = match &variant.fields {
+							Fields::Named(fields) => {
+								let ignores = fields.named.iter().map(|f| {
+									let fname = f.ident.as_ref().unwrap();
+									quote! { #fname: _ }
+								});
+								quote! { Self::#variant_ident { #(#ignores),* } }
+							}
+							_ => {
+								let members = variant.fields.members().map(|_| quote! { _ });
+								quote! { Self::#variant_ident(#(#members),*) }
+							}
+						};
 						if let Ok(feature) = TryInto::<CSSFeatureName>::try_into(&variant.attrs) {
 							let step = by_feature_name(feature.to_string());
-							quote! { Self::#variant_ident(#(#members),*) => { #step }, }
+							quote! { #pattern => { #step }, }
 						} else {
-							// enum candidates are very likely to be candidates for their own feature name, so just try guessing:
 							let str = feature.to_string();
 							let guessed_step =
 								by_feature_name(format!("{}.{}", str, variant_ident.to_string().to_kebab_case()));
 							let or_step = by_feature_name(feature.to_string());
-							quote! { Self::#variant_ident(#(#members),*) => { #guessed_step.or_else(|| #or_step) }, }
+							quote! { #pattern => { #guessed_step.or_else(|| #or_step) }, }
 						}
 					})
 					.collect::<Vec<_>>();

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -421,6 +421,10 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 
 					let effective_atom = if let Some(variant_atom) = atom {
 						Some(variant_atom)
+					} else if parse_mode == FieldParseMode::OneMustOccur
+						&& split_fields.iter().all(|(_, ty, _, _)| ty.is_option())
+					{
+						None
 					} else {
 						variant.fields.iter().next().and_then(|field| extract_atom(&field.attrs))
 					};

--- a/crates/csskit_derives/src/semantic_eq.rs
+++ b/crates/csskit_derives/src/semantic_eq.rs
@@ -48,24 +48,57 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 			let mut steps = vec![];
 			for var in variants {
 				let var_ident = var.ident;
-				let mut a_idents = vec![];
-				let mut b_idents = vec![];
-				let field_steps: Vec<_> = var
-					.fields
-					.into_iter()
-					.enumerate()
-					.map(|(i, field)| {
-						where_collector.add(&field.ty);
-						let a_ident = format_ident!("a{}", i);
-						a_idents.push(a_ident.clone());
-						let b_ident = format_ident!("b{}", i);
-						b_idents.push(b_ident.clone());
-						quote! { #a_ident.semantic_eq(&#b_ident) }
-					})
-					.collect();
-				steps.push(quote! {
-					(Self::#var_ident(#(#a_idents),*), Self::#var_ident(#(#b_idents),*)) => { #(#field_steps)&&* }
-				});
+				match var.fields {
+					Fields::Named(fields) => {
+						let a_idents: Vec<_> =
+							fields.named.iter().map(|f| format_ident!("a_{}", f.ident.as_ref().unwrap())).collect();
+						let b_idents: Vec<_> =
+							fields.named.iter().map(|f| format_ident!("b_{}", f.ident.as_ref().unwrap())).collect();
+						let field_names: Vec<_> =
+							fields.named.iter().map(|f| f.ident.as_ref().unwrap().clone()).collect();
+						let field_steps: Vec<_> = fields
+							.named
+							.iter()
+							.zip(a_idents.iter().zip(b_idents.iter()))
+							.map(|(field, (a_ident, b_ident))| {
+								where_collector.add(&field.ty);
+								quote! { #a_ident.semantic_eq(&#b_ident) }
+							})
+							.collect();
+						let a_pats =
+							field_names.iter().zip(a_idents.iter()).map(|(fname, aname)| quote! { #fname: #aname });
+						let b_pats =
+							field_names.iter().zip(b_idents.iter()).map(|(fname, bname)| quote! { #fname: #bname });
+						let body = if field_steps.is_empty() {
+							quote! { true }
+						} else {
+							quote! { #(#field_steps)&&* }
+						};
+						steps.push(quote! {
+							(Self::#var_ident { #(#a_pats),* }, Self::#var_ident { #(#b_pats),* }) => { #body }
+						});
+					}
+					_ => {
+						let mut a_idents = vec![];
+						let mut b_idents = vec![];
+						let field_steps: Vec<_> = var
+							.fields
+							.into_iter()
+							.enumerate()
+							.map(|(i, field)| {
+								where_collector.add(&field.ty);
+								let a_ident = format_ident!("a{}", i);
+								a_idents.push(a_ident.clone());
+								let b_ident = format_ident!("b{}", i);
+								b_idents.push(b_ident.clone());
+								quote! { #a_ident.semantic_eq(&#b_ident) }
+							})
+							.collect();
+						steps.push(quote! {
+							(Self::#var_ident(#(#a_idents),*), Self::#var_ident(#(#b_idents),*)) => { #(#field_steps)&&* }
+						});
+					}
+				}
 			}
 			quote! {
 				match (self, other) {

--- a/crates/csskit_derives/src/test/mod.rs
+++ b/crates/csskit_derives/src/test/mod.rs
@@ -1,6 +1,9 @@
 mod test_parse;
 mod test_peek;
+mod test_semantic_eq;
 mod test_to_cursors;
+mod test_to_span;
+mod test_visitable;
 
 #[macro_export]
 macro_rules! to_deriveinput {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
@@ -1,0 +1,48 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for FlexWrap {
+    fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use css_parse::{Parse, Peek};
+        if p.peek::<Ident>() {
+            let c = p.peek_n(1);
+            match p.to_atom::<FooAtoms>(c) {
+                FooAtoms::Nowrap => {
+                    let f0 = p.parse::<Ident>()?;
+                    return Ok(Self::Nowrap { 0: f0 });
+                }
+                _ => {}
+            }
+        }
+        {
+            let mut wrap: Option<Ident> = None;
+            let mut balance: Option<Ident> = None;
+            loop {
+                let c = p.peek_n(1);
+                let atom = p.to_atom::<FooAtoms>(c);
+                if wrap.is_none() && atom == FooAtoms::Wrap {
+                    wrap = Some(p.parse::<Ident>()?);
+                    continue;
+                }
+                if balance.is_none() && atom == FooAtoms::Balance {
+                    balance = Some(p.parse::<Ident>()?);
+                    continue;
+                }
+                break;
+            }
+            if wrap.is_none() && balance.is_none() {
+                let c = p.peek_n(1);
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            }
+            return Ok(Self::Wrap {
+                wrap: wrap,
+                balance: balance,
+            });
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
@@ -1,0 +1,48 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for FlexWrap {
+    fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use css_parse::{Parse, Peek};
+        if p.peek::<Ident>() {
+            let c = p.peek_n(1);
+            match p.to_atom::<FooAtoms>(c) {
+                FooAtoms::Nowrap => {
+                    let f0 = p.parse::<Ident>()?;
+                    return Ok(Self::Nowrap { 0: f0 });
+                }
+                _ => {}
+            }
+        }
+        {
+            let mut wrap: Option<Ident> = None;
+            let mut balance: Option<Ident> = None;
+            loop {
+                let c = p.peek_n(1);
+                let atom = p.to_atom::<FooAtoms>(c);
+                if wrap.is_none() && atom == FooAtoms::Wrap {
+                    wrap = Some(p.parse::<Ident>()?);
+                    continue;
+                }
+                if balance.is_none() && atom == FooAtoms::Balance {
+                    balance = Some(p.parse::<Ident>()?);
+                    continue;
+                }
+                break;
+            }
+            if wrap.is_none() && balance.is_none() {
+                let c = p.peek_n(1);
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            }
+            return Ok(Self::Wrap {
+                wrap: wrap,
+                balance: balance,
+            });
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_struct_variant_one_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_struct_variant_one_must_occur.snap
@@ -1,0 +1,17 @@
+---
+source: crates/csskit_derives/src/test/test_peek.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for FlexWrap {
+    fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use ::css_parse::Peek;
+        (<Ident>::peek(p, c) && p.equals_atom(c.into(), &FooAtoms::Nowrap))
+            || (<Option<Ident>>::peek(p, c) && p.equals_atom(c.into(), &FooAtoms::Wrap))
+            || (<Option<Ident>>::peek(p, c)
+                && p.equals_atom(c.into(), &FooAtoms::WrapReverse))
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_mixed_variants.snap
@@ -1,0 +1,25 @@
+---
+source: crates/csskit_derives/src/test/test_semantic_eq.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::SemanticEq for FlexWrap {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        use ::css_parse::SemanticEq;
+        match (self, other) {
+            (Self::Nowrap(a0), Self::Nowrap(b0)) => a0.semantic_eq(&b0),
+            (
+                Self::Wrap { wrap: a_wrap, balance: a_balance },
+                Self::Wrap { wrap: b_wrap, balance: b_balance },
+            ) => a_wrap.semantic_eq(&b_wrap) && a_balance.semantic_eq(&b_balance),
+            (
+                Self::WrapReverse { wrap_reverse: a_wrap_reverse, balance: a_balance },
+                Self::WrapReverse { wrap_reverse: b_wrap_reverse, balance: b_balance },
+            ) => {
+                a_wrap_reverse.semantic_eq(&b_wrap_reverse)
+                    && a_balance.semantic_eq(&b_balance)
+            }
+            _ => false,
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_single_field_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_single_field_variants.snap
@@ -1,0 +1,16 @@
+---
+source: crates/csskit_derives/src/test/test_semantic_eq.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::SemanticEq for Display {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        use ::css_parse::SemanticEq;
+        match (self, other) {
+            (Self::Block(a0), Self::Block(b0)) => a0.semantic_eq(&b0),
+            (Self::Inline(a0), Self::Inline(b0)) => a0.semantic_eq(&b0),
+            (Self::None(a0), Self::None(b0)) => a0.semantic_eq(&b0),
+            _ => false,
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_multiple_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_multiple_fields.snap
@@ -1,0 +1,18 @@
+---
+source: crates/csskit_derives/src/test/test_semantic_eq.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::SemanticEq for BorderStyle {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        use ::css_parse::SemanticEq;
+        match (self, other) {
+            (Self::Solid(), Self::Solid()) => {}
+            (
+                Self::Dotted { radius: a_radius, spacing: a_spacing },
+                Self::Dotted { radius: b_radius, spacing: b_spacing },
+            ) => a_radius.semantic_eq(&b_radius) && a_spacing.semantic_eq(&b_spacing),
+            _ => false,
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_single_field.snap
@@ -1,0 +1,17 @@
+---
+source: crates/csskit_derives/src/test/test_semantic_eq.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::SemanticEq for BorderStyle {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        use ::css_parse::SemanticEq;
+        match (self, other) {
+            (Self::Solid(), Self::Solid()) => {}
+            (Self::Dashed { width: a_width }, Self::Dashed { width: b_width }) => {
+                a_width.semantic_eq(&b_width)
+            }
+            _ => false,
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_tuple_struct_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_tuple_struct_single_field.snap
@@ -1,0 +1,11 @@
+---
+source: crates/csskit_derives/src/test/test_semantic_eq.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::SemanticEq for Length {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        use ::css_parse::SemanticEq;
+        self.0.semantic_eq(&other.0)
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_mixed_variants.snap
@@ -8,12 +8,12 @@ impl ::css_parse::ToCursors for BorderStyle {
         use ::css_parse::ToCursors;
         match self {
             Self::Solid() => {}
-            Self::Dashed(v0) => {
-                ToCursors::to_cursors(v0, s);
+            Self::Dashed { width } => {
+                ToCursors::to_cursors(width, s);
             }
-            Self::Dotted(v0, v1) => {
-                ToCursors::to_cursors(v0, s);
-                ToCursors::to_cursors(v1, s);
+            Self::Dotted { radius, spacing } => {
+                ToCursors::to_cursors(radius, s);
+                ToCursors::to_cursors(spacing, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_with_lifetime.snap
@@ -10,9 +10,9 @@ impl<'a> ::css_parse::ToCursors for CssValue<'a> {
             Self::Keyword(v0) => {
                 ToCursors::to_cursors(v0, s);
             }
-            Self::Function(v0, v1) => {
-                ToCursors::to_cursors(v0, s);
-                ToCursors::to_cursors(v1, s);
+            Self::Function { name, args } => {
+                ToCursors::to_cursors(name, s);
+                ToCursors::to_cursors(args, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_mixed_variants.snap
@@ -1,0 +1,19 @@
+---
+source: crates/csskit_derives/src/test/test_to_span.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::ToSpan for FlexWrap {
+    fn to_span(&self) -> ::css_parse::Span {
+        use ::css_parse::{Span, ToSpan};
+        match self {
+            FlexWrap::Nowrap(val) => val.to_span(),
+            FlexWrap::Wrap { wrap: first, balance: last } => {
+                first.to_span() + last.to_span()
+            }
+            FlexWrap::WrapReverse { wrap_reverse: first, balance: last } => {
+                first.to_span() + last.to_span()
+            }
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_single_field_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_single_field_variants.snap
@@ -1,0 +1,15 @@
+---
+source: crates/csskit_derives/src/test/test_to_span.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::ToSpan for Display {
+    fn to_span(&self) -> ::css_parse::Span {
+        use ::css_parse::{Span, ToSpan};
+        match self {
+            Display::Block(val) => val.to_span(),
+            Display::Inline(val) => val.to_span(),
+            Display::None(val) => val.to_span(),
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_with_named_struct_variant_multiple_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_with_named_struct_variant_multiple_fields.snap
@@ -1,0 +1,16 @@
+---
+source: crates/csskit_derives/src/test/test_to_span.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::ToSpan for BorderStyle {
+    fn to_span(&self) -> ::css_parse::Span {
+        use ::css_parse::{Span, ToSpan};
+        match self {
+            BorderStyle::Solid(first, last) => first.to_span() + last.to_span(),
+            BorderStyle::Dotted { radius: first, spacing: last } => {
+                first.to_span() + last.to_span()
+            }
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_with_named_struct_variant_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_with_named_struct_variant_single_field.snap
@@ -1,0 +1,14 @@
+---
+source: crates/csskit_derives/src/test/test_to_span.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::ToSpan for BorderStyle {
+    fn to_span(&self) -> ::css_parse::Span {
+        use ::css_parse::{Span, ToSpan};
+        match self {
+            BorderStyle::Solid(first, last) => first.to_span() + last.to_span(),
+            BorderStyle::Dashed { width: val } => val.to_span(),
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_multiple_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_multiple_fields.snap
@@ -1,0 +1,12 @@
+---
+source: crates/csskit_derives/src/test/test_to_span.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::ToSpan for Range {
+    fn to_span(&self) -> ::css_parse::Span {
+        use ::css_parse::{Span, ToSpan};
+        let first = self.0.to_span();
+        first + self.1.to_span()
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_single_field.snap
@@ -1,0 +1,11 @@
+---
+source: crates/csskit_derives/src/test/test_to_span.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::ToSpan for Length {
+    fn to_span(&self) -> ::css_parse::Span {
+        use ::css_parse::{Span, ToSpan};
+        self.0.to_span()
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_enum_with_named_struct_variant.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_enum_with_named_struct_variant.snap
@@ -1,0 +1,42 @@
+---
+source: crates/csskit_derives/src/test/test_visitable.rs
+expression: pretty
+---
+#[automatically_derived]
+impl crate::VisitableMut for FlexWrap {
+    fn accept_mut<V: crate::VisitMut>(&mut self, v: &mut V) {
+        use crate::VisitableMut;
+        match self {
+            Self::Nowrap(v0) => {
+                v0.accept_mut(v);
+            }
+            Self::Wrap { wrap: f_wrap, balance: f_balance } => {
+                f_wrap.accept_mut(v);
+                f_balance.accept_mut(v);
+            }
+            Self::WrapReverse { wrap_reverse: f_wrap_reverse, balance: f_balance } => {
+                f_wrap_reverse.accept_mut(v);
+                f_balance.accept_mut(v);
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl crate::Visitable for FlexWrap {
+    fn accept<V: crate::Visit>(&self, v: &mut V) {
+        use crate::Visitable;
+        match self {
+            Self::Nowrap(v0) => {
+                v0.accept(v);
+            }
+            Self::Wrap { wrap: f_wrap, balance: f_balance } => {
+                f_wrap.accept(v);
+                f_balance.accept(v);
+            }
+            Self::WrapReverse { wrap_reverse: f_wrap_reverse, balance: f_balance } => {
+                f_wrap_reverse.accept(v);
+                f_balance.accept(v);
+            }
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_tuple_enum.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_tuple_enum.snap
@@ -1,0 +1,32 @@
+---
+source: crates/csskit_derives/src/test/test_visitable.rs
+expression: pretty
+---
+#[automatically_derived]
+impl crate::VisitableMut for Display {
+    fn accept_mut<V: crate::VisitMut>(&mut self, v: &mut V) {
+        use crate::VisitableMut;
+        match self {
+            Self::Block(v0) => {
+                v0.accept_mut(v);
+            }
+            Self::Inline(v0) => {
+                v0.accept_mut(v);
+            }
+        }
+    }
+}
+#[automatically_derived]
+impl crate::Visitable for Display {
+    fn accept<V: crate::Visit>(&self, v: &mut V) {
+        use crate::Visitable;
+        match self {
+            Self::Block(v0) => {
+                v0.accept(v);
+            }
+            Self::Inline(v0) => {
+                v0.accept(v);
+            }
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -434,3 +434,46 @@ fn parse_enum_variant_with_keyword_variants_or_type() {
 	};
 	assert_parse_snapshot!(data, "parse_enum_variant_with_keyword_variants_or_type");
 }
+
+#[test]
+fn parse_enum_struct_variant_one_must_occur() {
+	let data = to_deriveinput! {
+		enum FlexWrap {
+			#[atom(FooAtoms::Nowrap)]
+			Nowrap(Ident),
+			#[parse(one_must_occur)]
+			Wrap {
+				#[atom(FooAtoms::Wrap)]
+				wrap: Option<Ident>,
+				#[atom(FooAtoms::Balance)]
+				balance: Option<Ident>,
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_struct_variant_one_must_occur");
+}
+
+#[test]
+fn parse_enum_struct_variants_one_must_occur_siblings() {
+	let data = to_deriveinput! {
+		enum FlexWrap {
+			#[atom(FooAtoms::Nowrap)]
+			Nowrap(Ident),
+			#[parse(one_must_occur)]
+			Wrap {
+				#[atom(FooAtoms::Wrap)]
+				wrap: Option<Ident>,
+				#[atom(FooAtoms::Balance)]
+				balance: Option<Ident>,
+			},
+			#[parse(one_must_occur)]
+			WrapReverse {
+				#[atom(FooAtoms::WrapReverse)]
+				wrap_reverse: Option<Ident>,
+				#[atom(FooAtoms::Balance)]
+				balance: Option<Ident>,
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_struct_variants_one_must_occur_siblings");
+}

--- a/crates/csskit_derives/src/test/test_peek.rs
+++ b/crates/csskit_derives/src/test/test_peek.rs
@@ -99,3 +99,28 @@ fn peek_enum_with_lifetime() {
 	};
 	assert_peek_snapshot!(data, "peek_enum_with_lifetime");
 }
+
+#[test]
+fn peek_enum_struct_variant_one_must_occur() {
+	let data = to_deriveinput! {
+		enum FlexWrap {
+			#[atom(FooAtoms::Nowrap)]
+			Nowrap(Ident),
+			#[parse(one_must_occur)]
+			Wrap {
+				#[atom(FooAtoms::Wrap)]
+				wrap: Option<Ident>,
+				#[atom(FooAtoms::Balance)]
+				balance: Option<Ident>,
+			},
+			#[parse(one_must_occur)]
+			WrapReverse {
+				#[atom(FooAtoms::WrapReverse)]
+				wrap_reverse: Option<Ident>,
+				#[atom(FooAtoms::Balance)]
+				balance: Option<Ident>,
+			},
+		}
+	};
+	assert_peek_snapshot!(data, "peek_enum_struct_variant_one_must_occur");
+}

--- a/crates/csskit_derives/src/test/test_semantic_eq.rs
+++ b/crates/csskit_derives/src/test/test_semantic_eq.rs
@@ -1,0 +1,65 @@
+use super::to_deriveinput;
+use crate::semantic_eq;
+
+macro_rules! assert_semantic_eq_snapshot {
+	( $data:ident, $name:literal) => {
+		let tokens = semantic_eq::derive($data);
+		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
+		let pretty = ::prettyplease::unparse(&file);
+		::insta::assert_snapshot!($name, pretty)
+	};
+}
+
+#[test]
+fn semantic_eq_tuple_struct_single_field() {
+	let data = to_deriveinput! {
+		struct Length(Number);
+	};
+	assert_semantic_eq_snapshot!(data, "semantic_eq_tuple_struct_single_field");
+}
+
+#[test]
+fn semantic_eq_enum_single_field_variants() {
+	let data = to_deriveinput! {
+		enum Display {
+			Block(Ident),
+			Inline(Ident),
+			None(Ident),
+		}
+	};
+	assert_semantic_eq_snapshot!(data, "semantic_eq_enum_single_field_variants");
+}
+
+#[test]
+fn semantic_eq_enum_with_named_struct_variant_single_field() {
+	let data = to_deriveinput! {
+		enum BorderStyle {
+			Solid,
+			Dashed { width: Length },
+		}
+	};
+	assert_semantic_eq_snapshot!(data, "semantic_eq_enum_with_named_struct_variant_single_field");
+}
+
+#[test]
+fn semantic_eq_enum_with_named_struct_variant_multiple_fields() {
+	let data = to_deriveinput! {
+		enum BorderStyle {
+			Solid,
+			Dotted { radius: Length, spacing: Length },
+		}
+	};
+	assert_semantic_eq_snapshot!(data, "semantic_eq_enum_with_named_struct_variant_multiple_fields");
+}
+
+#[test]
+fn semantic_eq_enum_mixed_variants() {
+	let data = to_deriveinput! {
+		enum FlexWrap {
+			Nowrap(Ident),
+			Wrap { wrap: Option<Ident>, balance: Option<Ident> },
+			WrapReverse { wrap_reverse: Option<Ident>, balance: Option<Ident> },
+		}
+	};
+	assert_semantic_eq_snapshot!(data, "semantic_eq_enum_mixed_variants");
+}

--- a/crates/csskit_derives/src/test/test_to_span.rs
+++ b/crates/csskit_derives/src/test/test_to_span.rs
@@ -1,0 +1,73 @@
+use super::to_deriveinput;
+use crate::to_span;
+
+macro_rules! assert_to_span_snapshot {
+	( $data:ident, $name:literal) => {
+		let tokens = to_span::derive($data);
+		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
+		let pretty = ::prettyplease::unparse(&file);
+		::insta::assert_snapshot!($name, pretty)
+	};
+}
+
+#[test]
+fn to_span_tuple_struct_single_field() {
+	let data = to_deriveinput! {
+		struct Length(Number);
+	};
+	assert_to_span_snapshot!(data, "to_span_tuple_struct_single_field");
+}
+
+#[test]
+fn to_span_tuple_struct_multiple_fields() {
+	let data = to_deriveinput! {
+		struct Range(Number, Number);
+	};
+	assert_to_span_snapshot!(data, "to_span_tuple_struct_multiple_fields");
+}
+
+#[test]
+fn to_span_enum_single_field_variants() {
+	let data = to_deriveinput! {
+		enum Display {
+			Block(Ident),
+			Inline(Ident),
+			None(Ident),
+		}
+	};
+	assert_to_span_snapshot!(data, "to_span_enum_single_field_variants");
+}
+
+#[test]
+fn to_span_enum_with_named_struct_variant_single_field() {
+	let data = to_deriveinput! {
+		enum BorderStyle {
+			Solid,
+			Dashed { width: Length },
+		}
+	};
+	assert_to_span_snapshot!(data, "to_span_enum_with_named_struct_variant_single_field");
+}
+
+#[test]
+fn to_span_enum_with_named_struct_variant_multiple_fields() {
+	let data = to_deriveinput! {
+		enum BorderStyle {
+			Solid,
+			Dotted { radius: Length, spacing: Length },
+		}
+	};
+	assert_to_span_snapshot!(data, "to_span_enum_with_named_struct_variant_multiple_fields");
+}
+
+#[test]
+fn to_span_enum_mixed_variants() {
+	let data = to_deriveinput! {
+		enum FlexWrap {
+			Nowrap(Ident),
+			Wrap { wrap: Option<Ident>, balance: Option<Ident> },
+			WrapReverse { wrap_reverse: Option<Ident>, balance: Option<Ident> },
+		}
+	};
+	assert_to_span_snapshot!(data, "to_span_enum_mixed_variants");
+}

--- a/crates/csskit_derives/src/test/test_visitable.rs
+++ b/crates/csskit_derives/src/test/test_visitable.rs
@@ -1,0 +1,40 @@
+use super::to_deriveinput;
+use crate::visitable;
+
+macro_rules! assert_visitable_snapshot {
+	( $data:ident, $name:literal) => {
+		let tokens = visitable::derive($data);
+		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
+		let pretty = ::prettyplease::unparse(&file);
+		::insta::assert_snapshot!($name, pretty)
+	};
+}
+
+#[test]
+fn visitable_tuple_enum() {
+	let data = to_deriveinput! {
+		enum Display {
+			Block(Ident),
+			Inline(Ident),
+		}
+	};
+	assert_visitable_snapshot!(data, "visitable_tuple_enum");
+}
+
+#[test]
+fn visitable_enum_with_named_struct_variant() {
+	let data = to_deriveinput! {
+		enum FlexWrap {
+			Nowrap(Ident),
+			Wrap {
+				wrap: Option<Ident>,
+				balance: Option<Ident>,
+			},
+			WrapReverse {
+				wrap_reverse: Option<Ident>,
+				balance: Option<Ident>,
+			},
+		}
+	};
+	assert_visitable_snapshot!(data, "visitable_enum_with_named_struct_variant");
+}

--- a/crates/csskit_derives/src/to_cursors.rs
+++ b/crates/csskit_derives/src/to_cursors.rs
@@ -48,21 +48,41 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 			let mut steps = vec![];
 			for var in variants {
 				let var_ident = var.ident;
-				let mut idents = vec![];
-				let field_steps: Vec<_> = var
-					.fields
-					.into_iter()
-					.enumerate()
-					.map(|(i, field)| {
-						where_collector.add(&field.ty);
-						let ident = format_ident!("v{}", i);
-						idents.push(ident.clone());
-						quote! { ToCursors::to_cursors(#ident, s); }
-					})
-					.collect();
-				steps.push(quote! {
-					Self::#var_ident(#(#idents),*) => { #(#field_steps)* }
-				});
+				match var.fields {
+					Fields::Named(fields) => {
+						let field_idents: Vec<_> =
+							fields.named.iter().map(|f| f.ident.as_ref().unwrap().clone()).collect();
+						let field_steps: Vec<_> = fields
+							.named
+							.iter()
+							.map(|field| {
+								where_collector.add(&field.ty);
+								let fid = field.ident.as_ref().unwrap();
+								quote! { ToCursors::to_cursors(#fid, s); }
+							})
+							.collect();
+						steps.push(quote! {
+							Self::#var_ident { #(#field_idents),* } => { #(#field_steps)* }
+						});
+					}
+					_ => {
+						let mut idents = vec![];
+						let field_steps: Vec<_> = var
+							.fields
+							.into_iter()
+							.enumerate()
+							.map(|(i, field)| {
+								where_collector.add(&field.ty);
+								let ident = format_ident!("v{}", i);
+								idents.push(ident.clone());
+								quote! { ToCursors::to_cursors(#ident, s); }
+							})
+							.collect();
+						steps.push(quote! {
+							Self::#var_ident(#(#idents),*) => { #(#field_steps)* }
+						});
+					}
+				}
 			}
 			quote! {
 				match self {

--- a/crates/csskit_derives/src/to_span.rs
+++ b/crates/csskit_derives/src/to_span.rs
@@ -2,7 +2,7 @@ use crate::{TypeIsOption, WhereCollector, err};
 use itertools::{Itertools, Position};
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, parse_quote};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, parse_quote};
 
 pub fn derive(input: DeriveInput) -> TokenStream {
 	let mut where_collector = WhereCollector::new();
@@ -80,12 +80,30 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 					for field in variant.fields.iter() {
 						where_collector.add(&field.ty);
 					}
-					if len == 1 {
-						quote! { #ident::#variant_ident(val) => val.to_span(), }
-					} else {
-						let rest = (2..len).map(|_| quote! { _ }).chain([quote! {last}]);
-						quote! {
-							#ident::#variant_ident(first, #(#rest),*) => first.to_span() + last.to_span(),
+					match &variant.fields {
+						Fields::Named(fields) => {
+							let field_idents: Vec<_> = fields.named.iter().map(|f| f.ident.as_ref().unwrap()).collect();
+							if len == 1 {
+								let fid = field_idents[0];
+								quote! { #ident::#variant_ident { #fid: val } => val.to_span(), }
+							} else {
+								let first = field_idents[0];
+								let last = field_idents[len - 1];
+								let rest_pats = field_idents[1..len - 1].iter().map(|f| quote! { #f: _ });
+								quote! {
+									#ident::#variant_ident { #first: first, #(#rest_pats,)* #last: last } => first.to_span() + last.to_span(),
+								}
+							}
+						}
+						_ => {
+							if len == 1 {
+								quote! { #ident::#variant_ident(val) => val.to_span(), }
+							} else {
+								let rest = (2..len).map(|_| quote! { _ }).chain([quote! {last}]);
+								quote! {
+									#ident::#variant_ident(first, #(#rest),*) => first.to_span() + last.to_span(),
+								}
+							}
 						}
 					}
 				})

--- a/crates/csskit_derives/src/visitable.rs
+++ b/crates/csskit_derives/src/visitable.rs
@@ -2,7 +2,8 @@ use heck::ToSnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-	Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Ident, Meta, parse::Parse, parse_quote, token::SelfValue,
+	Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Ident, Meta, parse::Parse, parse_quote,
+	token::SelfValue,
 };
 
 use crate::{WhereCollector, err};
@@ -108,26 +109,48 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 					.iter()
 					.map(|variant| {
 						let variant_ident = &variant.ident;
-						let (members, steps): (Vec<_>, Vec<_>) = variant
-							.fields
-							.iter()
-							.enumerate()
-							.map(|(i, field)| {
-								if Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip
-									|| Into::<VisitStyle>::into(&variant.attrs) == VisitStyle::Skip
-								{
-									(format_ident!("_"), quote! {})
-								} else {
-									let ident = format_ident!("v{}", i);
-									where_collector.add(&field.ty);
-									(ident.clone(), quote! { #ident.#accept(v) })
+						let skip_variant = Into::<VisitStyle>::into(&variant.attrs) == VisitStyle::Skip;
+						match &variant.fields {
+							Fields::Named(fields) => {
+								let (bindings, steps): (Vec<_>, Vec<_>) = fields
+									.named
+									.iter()
+									.map(|field| {
+										let fname = field.ident.as_ref().unwrap();
+										let binding = format_ident!("f_{}", fname);
+										if skip_variant || Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip {
+											(quote! { #fname: _ }, quote! {})
+										} else {
+											where_collector.add(&field.ty);
+											(quote! { #fname: #binding }, quote! { #binding.#accept(v) })
+										}
+									})
+									.unzip();
+								quote! {
+									Self::#variant_ident { #(#bindings),* } => { #(#steps;)* },
 								}
-							})
-							.collect::<Vec<_>>()
-							.into_iter()
-							.unzip();
-						quote! {
-							Self::#variant_ident(#(#members),*) => { #(#steps;)* },
+							}
+							_ => {
+								let (members, steps): (Vec<_>, Vec<_>) = variant
+									.fields
+									.iter()
+									.enumerate()
+									.map(|(i, field)| {
+										if skip_variant || Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip {
+											(format_ident!("_"), quote! {})
+										} else {
+											let ident = format_ident!("v{}", i);
+											where_collector.add(&field.ty);
+											(ident.clone(), quote! { #ident.#accept(v) })
+										}
+									})
+									.collect::<Vec<_>>()
+									.into_iter()
+									.unzip();
+								quote! {
+									Self::#variant_ident(#(#members),*) => { #(#steps;)* },
+								}
+							}
 						}
 					})
 					.collect();


### PR DESCRIPTION
https://github.com/csskit/csskit/pull/1031, &
https://github.com/csskit/csskit/pull/1032 have built up towards struct variants
in enums. The code generation for these is now working well, but the derive
macros do not support these types yet.

This change supports enum struct variants in SemanticEq, ToSpan, ToCursors,
Visitable, and ToCssFeature while improving support for Parse/Peek, as well as
adding a bunch of tests around these.