### PR TITLE
csskit_derives: guard atom extraction in parse, when encountering non-atom values

### DIFF
--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -236,12 +236,16 @@ fn generate_must_occur_parsing(
 	where_collector: &mut WhereCollector,
 ) -> TokenStream {
 	let mut atom_binding = None;
+	let mut atom_set_ty = None;
 	let bindings: Vec<TokenStream> = split_fields
 		.iter()
 		.map(|(var, ty, _, atom)| {
 			if atom.is_some() && atom_binding.is_none() {
-				let atom = atom.as_ref().unwrap().to_atom(format_ident!("c"));
-				atom_binding = Some(quote! { let atom = #atom; });
+				let a = atom.as_ref().unwrap();
+				let atom_expr = a.to_atom(format_ident!("c"));
+				let atom_set = a.first_segment();
+				atom_set_ty = Some(atom_set.clone());
+				atom_binding = Some(quote! { let atom = #atom_expr; });
 			}
 			if ty.is_option() {
 				quote! { let mut #var: #ty = None; }
@@ -269,11 +273,22 @@ fn generate_must_occur_parsing(
 		FieldParseMode::AllMustOccur => quote! { #(#checks)||* },
 	};
 
+	let atom_binding_guarded = if let Some(atom_set) = atom_set_ty {
+		quote! {
+			let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+				p.to_atom::<#atom_set>(c)
+			} else {
+				<#atom_set>::default()
+			};
+		}
+	} else {
+		quote! { #atom_binding }
+	};
 	quote! {
 	  #(#bindings)*
 	  loop {
 			let c = p.peek_n(1);
-			#atom_binding
+			#atom_binding_guarded
 			#(#parse_steps)*
 			break;
 	  }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
@@ -24,7 +24,11 @@ impl<'a> ::css_parse::Parse<'a> for FlexWrap {
             let mut balance: Option<Ident> = None;
             loop {
                 let c = p.peek_n(1);
-                let atom = p.to_atom::<FooAtoms>(c);
+                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                    p.to_atom::<FooAtoms>(c)
+                } else {
+                    <FooAtoms>::default()
+                };
                 if wrap.is_none() && atom == FooAtoms::Wrap {
                     wrap = Some(p.parse::<Ident>()?);
                     continue;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
@@ -24,7 +24,11 @@ impl<'a> ::css_parse::Parse<'a> for FlexWrap {
             let mut balance: Option<Ident> = None;
             loop {
                 let c = p.peek_n(1);
-                let atom = p.to_atom::<FooAtoms>(c);
+                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                    p.to_atom::<FooAtoms>(c)
+                } else {
+                    <FooAtoms>::default()
+                };
                 if wrap.is_none() && atom == FooAtoms::Wrap {
                     wrap = Some(p.parse::<Ident>()?);
                     continue;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
@@ -18,7 +18,11 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurEnum {
                     let mut length: Option<Length> = None;
                     loop {
                         let c = p.peek_n(1);
-                        let atom = p.to_atom::<FooKeywords>(c);
+                        let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                            p.to_atom::<FooKeywords>(c)
+                        } else {
+                            <FooKeywords>::default()
+                        };
                         if auto_field.is_none() && atom == FooKeywords::Auto {
                             auto_field = Some(p.parse::<AutoValue>()?);
                             continue;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
@@ -14,7 +14,11 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurNewtypeTest {
         let mut length: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            let atom = p.to_atom::<Auto>(c);
+            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                p.to_atom::<Auto>(c)
+            } else {
+                <Auto>::default()
+            };
             if auto_value.is_none() && atom == Auto {
                 auto_value = Some(p.parse::<Auto>()?);
                 continue;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
@@ -14,7 +14,11 @@ impl<'a> ::css_parse::Parse<'a> for SpecificKeywordTest {
         let mut length: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            let atom = p.to_atom::<FooKeywords>(c);
+            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                p.to_atom::<FooKeywords>(c)
+            } else {
+                <FooKeywords>::default()
+            };
             if auto_field.is_none() && atom == FooKeywords::Auto {
                 auto_field = Some(p.parse::<AutoValue>()?);
                 continue;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
@@ -13,7 +13,11 @@ impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
         let mut none_value: Option<Ident> = None;
         loop {
             let c = p.peek_n(1);
-            let atom = p.to_atom::<FooKeywords>(c);
+            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                p.to_atom::<FooKeywords>(c)
+            } else {
+                <FooKeywords>::default()
+            };
             if auto_value.is_none() && atom == FooKeywords::Auto {
                 auto_value = Some(p.parse::<Ident>()?);
                 continue;


### PR DESCRIPTION
AllMustOccur types can be a mixture of atoms or not, by binding atom early we
might sometimes try to extract atoms from non-Ident tokens, causing a panic.

This change avoids the panic by guarding for non-Ident tokens and just sets the
defualt atom. It's not the prettiest - we should probably do something more
elegant here, such as refactoring to add more branches ahead of the atom checks,
but this will do for now.
