### PR TITLE
csskit_derives: massively refactor library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
 name = "csskit_derives"
 version = "0.0.20"
 dependencies = [
+ "darling",
  "heck",
  "insta",
  "itertools 0.14.0",
@@ -754,6 +755,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -916,6 +918,40 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1642,6 +1678,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,8 @@ syn = { version = "2.0.106" }
 quote = { version = "1.0.41" }
 proc-macro2 = { version = "1.0.101" }
 heck = { version = "0.5.0" }
+darling = { version = "0.23.0" }
+synstructure = { version = "0.13.2" }
 
 # Serialization
 serde = { version = "1.0.228" }

--- a/crates/csskit_derives/Cargo.toml
+++ b/crates/csskit_derives/Cargo.toml
@@ -14,11 +14,13 @@ bench = false
 proc-macro = true
 
 [dependencies]
-syn = { workspace = true, features = ["extra-traits", "full"] }
+syn = { workspace = true, features = ["extra-traits", "full", "visit"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
 itertools = { workspace = true }
 heck = { workspace = true }
+darling = { workspace = true }
+synstructure.workspace = true
 
 [dev-dependencies]
 prettyplease = { workspace = true }

--- a/crates/csskit_derives/src/attributes.rs
+++ b/crates/csskit_derives/src/attributes.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
-use syn::{Attribute, ExprPath, Ident, Meta};
+use syn::{Attribute, Error, ExprPath, Ident, Meta, Result};
 
 #[derive(Debug)]
 pub struct Atom(ExprPath);
@@ -21,7 +21,22 @@ impl Atom {
 	}
 
 	pub fn first_segment(&self) -> Ident {
-		self.0.path.segments.first().expect("keyword variant path should have at least one segment").ident.clone()
+		self.0.path.segments.first().expect("atom path must have at least one segment").ident.clone()
+	}
+
+	pub fn binding_block(&self) -> TokenStream {
+		let atom_set = self.first_segment();
+		quote! {
+			let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+				p.to_atom::<#atom_set>(c)
+			} else {
+				<#atom_set>::default()
+			};
+		}
+	}
+
+	pub fn opt_binding_block(atom: Option<&Self>) -> TokenStream {
+		atom.map(Self::binding_block).unwrap_or_default()
 	}
 }
 
@@ -31,14 +46,12 @@ impl ToTokens for Atom {
 	}
 }
 
-/// Extract #[atom(...)] attribute from a field
-pub fn extract_atom(attrs: &[Attribute]) -> Option<Atom> {
-	if let Some(Attribute { meta, .. }) = attrs.iter().find(|a| a.path().is_ident("atom")) {
-		match meta {
-			Meta::List(meta) => meta.parse_args::<ExprPath>().ok().map(Atom),
-			_ => panic!("could not parse in_range meta"),
-		}
-	} else {
-		None
+pub fn extract_atom(attrs: &[Attribute]) -> Result<Option<Atom>> {
+	let Some(attr) = attrs.iter().find(|a| a.path().is_ident("atom")) else {
+		return Ok(None);
+	};
+	match &attr.meta {
+		Meta::List(meta) => Ok(Some(Atom(meta.parse_args::<ExprPath>()?))),
+		_ => Err(Error::new_spanned(&attr.meta, "#[atom] requires a path argument, e.g. #[atom(MyAtomSet::my_atom)]")),
 	}
 }

--- a/crates/csskit_derives/src/css_feature.rs
+++ b/crates/csskit_derives/src/css_feature.rs
@@ -2,9 +2,10 @@ use heck::ToKebabCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 use std::fmt::Display;
-use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, LitStr, Meta, Result, parse::Parse};
-
-use crate::err;
+use syn::{
+	Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, LitStr, Meta, Result,
+	parse::{Parse, ParseBuffer},
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct CSSFeatureName(pub LitStr);
@@ -22,14 +23,14 @@ impl ToTokens for CSSFeatureName {
 }
 
 impl Parse for CSSFeatureName {
-	fn parse(input: syn::parse::ParseStream) -> Result<Self> {
+	fn parse(input: &ParseBuffer) -> Result<Self> {
 		input.parse::<LitStr>().map(Self)
 	}
 }
 
-impl TryFrom<&Vec<Attribute>> for CSSFeatureName {
+impl TryFrom<&[Attribute]> for CSSFeatureName {
 	type Error = Error;
-	fn try_from(attrs: &Vec<Attribute>) -> Result<Self> {
+	fn try_from(attrs: &[Attribute]) -> Result<Self> {
 		if let Some(Attribute { meta, .. }) = &attrs.iter().find(|a| a.path().is_ident("css_feature")) {
 			match meta {
 				// #[css_feature("foo")]
@@ -38,7 +39,6 @@ impl TryFrom<&Vec<Attribute>> for CSSFeatureName {
 				_ => Err(Error::new(Span::call_site(), "`css_feature` attribute has no value")),
 			}
 		} else {
-			// No attribute present
 			Err(Error::new(Span::call_site(), "Missing `css_feature` attribute"))
 		}
 	}
@@ -48,17 +48,17 @@ fn by_feature_name(feature: String) -> TokenStream {
 	quote! { ::css_feature_data::CSSFeature::by_feature_name(#feature) }
 }
 
-pub fn derive(input: DeriveInput) -> TokenStream {
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let ident = input.ident;
-	let generics = &mut input.generics.clone();
-	let (impl_generics, _, _) = generics.split_for_impl();
-	let feature: CSSFeatureName = (&input.attrs).try_into().unwrap();
+	let generics = &input.generics;
+	let (impl_generics, type_generics, _) = generics.split_for_impl();
+	let feature: CSSFeatureName = CSSFeatureName::try_from(input.attrs.as_slice())?;
 	let steps = match &input.data {
-		Data::Union(_) => err(ident.span(), "Cannot derive on a Union"),
+		Data::Union(_) => return Err(Error::new(ident.span(), "Cannot derive on a Union")),
 
 		Data::Struct(DataStruct { fields, .. }) => {
 			if fields.is_empty() {
-				err(ident.span(), "Cannot derive on empty Struct")
+				return Err(Error::new(ident.span(), "Cannot derive on empty Struct"));
 			} else {
 				quote! {}
 			}
@@ -66,7 +66,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 
 		Data::Enum(DataEnum { variants, .. }) => {
 			if variants.is_empty() {
-				err(ident.span(), "Cannot derive on empty Enum")
+				return Err(Error::new(ident.span(), "Cannot derive on empty Enum"));
 			} else {
 				let variants = variants
 					.iter()
@@ -85,7 +85,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 								quote! { Self::#variant_ident(#(#members),*) }
 							}
 						};
-						if let Ok(feature) = TryInto::<CSSFeatureName>::try_into(&variant.attrs) {
+						if let Ok(feature) = CSSFeatureName::try_from(variant.attrs.as_slice()) {
 							let step = by_feature_name(feature.to_string());
 							quote! { #pattern => { #step }, }
 						} else {
@@ -108,12 +108,12 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 		}
 	};
 	let steps = if steps.is_empty() { by_feature_name(feature.to_string()) } else { steps };
-	quote! {
+	Ok(quote! {
 		#[automatically_derived]
-		impl #impl_generics #ident #impl_generics {
+		impl #impl_generics #ident #type_generics {
 			fn to_css_feature(&self) -> Option<&'static ::css_feature_data::CSSFeature> {
 				#steps
 			}
 		}
-	}
+	})
 }

--- a/crates/csskit_derives/src/darling_ext.rs
+++ b/crates/csskit_derives/src/darling_ext.rs
@@ -1,0 +1,132 @@
+use darling::FromMeta;
+use quote::{ToTokens, format_ident};
+use syn::{
+	Ident, Meta, MetaNameValue, Result, Token, TypePath,
+	parse::{Parse, ParseStream},
+	parse2,
+};
+
+/// A `|`-separated list, e.g. `Elements | Text | None`.
+///
+/// Used for `applies_to`, `longhands`, `box_side`, `box_portion`, `node_kinds`,
+/// `used_at_rules`, `vendor_prefixes`, `declaration_kinds`, `property_kinds`.
+#[derive(Debug, Clone, Default)]
+pub struct PipeList<T>(pub Vec<T>);
+
+impl<T: Parse> FromMeta for PipeList<T> {
+	fn from_meta(meta: &Meta) -> darling::Result<Self> {
+		match meta {
+			Meta::NameValue(nv) => {
+				let ts = nv.value.to_token_stream();
+				let items = parse2::<PipeListParsed<T>>(ts)
+					.map_err(|e| darling::Error::custom(e.to_string()).with_span(&nv.value))?;
+				Ok(Self(items.0))
+			}
+			_ => Err(darling::Error::custom("expected `key = A | B | C`").with_span(meta)),
+		}
+	}
+}
+
+struct PipeListParsed<T>(Vec<T>);
+
+impl<T: Parse> Parse for PipeListParsed<T> {
+	fn parse(input: ParseStream) -> Result<Self> {
+		let mut items = vec![input.parse::<T>()?];
+		while input.parse::<Token![|]>().is_ok() {
+			items.push(input.parse::<T>()?);
+		}
+		Ok(Self(items))
+	}
+}
+
+/// Parse a `Type::Path` from a `NameValue` meta value, returning `(first_ident, last_ident)`.
+fn parse_nameval_path_idents(nv: &MetaNameValue) -> darling::Result<(Ident, Ident)> {
+	let ts = nv.value.to_token_stream();
+	let type_path: TypePath = parse2(ts).map_err(|e| darling::Error::custom(e.to_string()).with_span(&nv.value))?;
+	let first = type_path
+		.path
+		.segments
+		.first()
+		.ok_or_else(|| darling::Error::custom("expected Type::Variant path").with_span(&nv.value))?
+		.ident
+		.clone();
+	let last = type_path
+		.path
+		.segments
+		.last()
+		.ok_or_else(|| darling::Error::custom("expected Type::Variant path").with_span(&nv.value))?
+		.ident
+		.clone();
+	Ok((first, last))
+}
+
+/// Parsed from `#[parse(stop = Kind::Variant)]` or `#[parse(stop = KindSet::Variant)]`.
+///
+/// Stores the prefix (`Kind` or `KindSet`) and the variant ident separately.
+#[derive(Debug, Clone)]
+pub struct StopArg {
+	pub prefix: Ident,
+	pub variant: Ident,
+}
+
+impl FromMeta for StopArg {
+	fn from_meta(meta: &Meta) -> darling::Result<Self> {
+		match meta {
+			Meta::NameValue(nv) => {
+				let (first, last) = parse_nameval_path_idents(nv)?;
+				if first != "Kind" && first != "KindSet" {
+					return Err(darling::Error::custom("stop must use the Kind or KindSet type").with_span(&first));
+				}
+				Ok(Self { prefix: first, variant: last })
+			}
+			_ => Err(darling::Error::custom("expected `stop = Kind::Variant`").with_span(meta)),
+		}
+	}
+}
+
+/// Parsed from `#[parse(state = State::Variant)]`.
+///
+/// Stores just the variant ident (the `State::` prefix is validated then discarded).
+#[derive(Debug, Clone)]
+pub struct StateArg(pub Ident);
+
+impl FromMeta for StateArg {
+	fn from_meta(meta: &Meta) -> darling::Result<Self> {
+		match meta {
+			Meta::NameValue(nv) => {
+				let (first, last) = parse_nameval_path_idents(nv)?;
+				if first != "State" {
+					return Err(darling::Error::custom(format!("state must use the State type, saw {:?}", first))
+						.with_span(&first));
+				}
+				Ok(Self(last))
+			}
+			_ => Err(darling::Error::custom("expected `state = State::Variant`").with_span(meta)),
+		}
+	}
+}
+
+/// Parsed from `#[declaration_metadata(inherits)]` (bare → `True`)
+/// or `#[declaration_metadata(inherits = Ident)]`.
+#[derive(Debug, Clone)]
+pub struct InheritsArg(pub Ident);
+
+impl FromMeta for InheritsArg {
+	/// Bare `inherits` keyword treated as `inherits = True`.
+	fn from_word() -> darling::Result<Self> {
+		Ok(Self(format_ident!("True")))
+	}
+
+	fn from_meta(meta: &Meta) -> darling::Result<Self> {
+		match meta {
+			Meta::Path(_) => Self::from_word(),
+			Meta::NameValue(nv) => {
+				let ts = nv.value.to_token_stream();
+				let ident: Ident =
+					parse2(ts).map_err(|e| darling::Error::custom(e.to_string()).with_span(&nv.value))?;
+				Ok(Self(ident))
+			}
+			_ => Err(darling::Error::custom("expected bare `inherits` or `inherits = Ident`").with_span(meta)),
+		}
+	}
+}

--- a/crates/csskit_derives/src/declaration_metadata.rs
+++ b/crates/csskit_derives/src/declaration_metadata.rs
@@ -1,183 +1,45 @@
+use darling::FromAttributes;
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-use syn::{
-	Attribute, DeriveInput, Error, Ident, LitStr, Meta, Token,
-	parse::{Parse, ParseStream},
-};
+use quote::quote;
+use syn::{DeriveInput, Ident, Result};
 
-#[derive(Debug, Default)]
+use crate::darling_ext::{InheritsArg, PipeList};
+
+#[derive(Debug, Default, FromAttributes)]
+#[darling(attributes(declaration_metadata))]
 struct MetadataArg {
+	#[darling(default)]
 	pub initial: Option<String>,
-	pub inherits: Option<Ident>,
-	pub applies_to: Vec<Ident>,
+	#[darling(default)]
+	pub inherits: Option<InheritsArg>,
+	#[darling(default)]
+	pub applies_to: Option<PipeList<Ident>>,
+	#[darling(default)]
 	pub animation_type: Option<Ident>,
+	#[darling(default)]
 	pub percentages: Option<Ident>,
+	#[darling(default)]
 	pub shorthand_group: Option<Ident>,
-	pub longhands: Vec<Ident>,
+	#[darling(default)]
+	pub longhands: Option<PipeList<Ident>>,
+	#[darling(default)]
 	pub property_group: Option<Ident>,
+	#[darling(default)]
 	pub computed_value_type: Option<Ident>,
+	#[darling(default)]
 	pub canonical_order: Option<String>,
+	#[darling(default)]
 	pub logical_property_group: Option<Ident>,
-	pub box_side: Vec<Ident>,
-	pub box_portion: Vec<Ident>,
+	#[darling(default)]
+	pub box_side: Option<PipeList<Ident>>,
+	#[darling(default)]
+	pub box_portion: Option<PipeList<Ident>>,
+	#[darling(default)]
 	pub unitless_zero_resolves: Option<Ident>,
 }
 
-impl Parse for MetadataArg {
-	fn parse(input: ParseStream) -> syn::Result<Self> {
-		let mut args = Self::default();
-		while !input.is_empty() {
-			match input.parse::<Ident>()? {
-				i if i == "initial" => {
-					if args.initial.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'initial'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					args.initial = Some(input.parse::<LitStr>()?.value());
-				}
-				i if i == "inherits" => {
-					if args.inherits.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'inherits'".to_string()))?;
-					}
-					if input.parse::<Token![=]>().is_ok() {
-						args.inherits = Some(input.parse::<Ident>()?);
-					} else {
-						args.inherits = Some(format_ident!("True"));
-					}
-				}
-				i if i == "applies_to" => {
-					if !args.applies_to.is_empty() {
-						Err(Error::new(i.span(), "redefinition of 'applies_to'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					loop {
-						args.applies_to.push(input.parse::<Ident>()?);
-						if input.parse::<Token![|]>().is_err() {
-							break;
-						}
-					}
-				}
-				i if i == "animation_type" => {
-					if args.animation_type.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'animation_type'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					args.animation_type = Some(input.parse::<Ident>()?);
-				}
-				i if i == "percentages" => {
-					if args.percentages.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'percentages'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					args.percentages = Some(input.parse::<Ident>()?);
-				}
-				i if i == "shorthand_group" => {
-					if args.shorthand_group.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'shorthand_group'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					args.shorthand_group = Some(input.parse::<Ident>()?);
-				}
-				i if i == "longhands" => {
-					if !args.longhands.is_empty() {
-						Err(Error::new(i.span(), "redefinition of 'longhands'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					loop {
-						args.longhands.push(input.parse::<Ident>()?);
-						if input.parse::<Token![|]>().is_err() {
-							break;
-						}
-					}
-				}
-				i if i == "property_group" => {
-					if args.property_group.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'property_group'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					args.property_group = Some(input.parse::<Ident>()?);
-				}
-				i if i == "computed_value_type" => {
-					if args.computed_value_type.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'computed_value_type'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					args.computed_value_type = Some(input.parse::<Ident>()?);
-				}
-				i if i == "canonical_order" => {
-					if args.canonical_order.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'canonical_order'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					args.canonical_order = Some(input.parse::<LitStr>()?.value());
-				}
-				i if i == "logical_property_group" => {
-					if args.logical_property_group.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'logical_property_group'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					args.logical_property_group = Some(input.parse::<Ident>()?);
-				}
-				i if i == "box_side" => {
-					if !args.box_side.is_empty() {
-						Err(Error::new(i.span(), "redefinition of 'box_side'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					loop {
-						args.box_side.push(input.parse::<Ident>()?);
-						if input.parse::<Token![|]>().is_err() {
-							break;
-						}
-					}
-				}
-				i if i == "box_portion" => {
-					if !args.box_portion.is_empty() {
-						Err(Error::new(i.span(), "redefinition of 'box_portion'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					loop {
-						args.box_portion.push(input.parse::<Ident>()?);
-						if input.parse::<Token![|]>().is_err() {
-							break;
-						}
-					}
-				}
-				i if i == "unitless_zero_resolves" => {
-					if args.unitless_zero_resolves.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'unitless_zero_resolves'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					args.unitless_zero_resolves = Some(input.parse::<Ident>()?);
-				}
-				ident => Err(Error::new(ident.span(), format!("Unrecognized Value arg {ident:?}")))?,
-			}
-
-			if !input.is_empty() {
-				input.parse::<Token![,]>()?;
-			}
-		}
-		Ok(args)
-	}
-}
-
-impl From<&Vec<Attribute>> for MetadataArg {
-	fn from(attrs: &Vec<Attribute>) -> Self {
-		let mut result = Self::default();
-		// Check for #[declaration_metadata(...)] attribute
-		if let Some(Attribute { meta, .. }) = &attrs.iter().find(|a| a.path().is_ident("declaration_metadata")) {
-			match meta {
-				Meta::List(meta) => {
-					result = meta.parse_args::<MetadataArg>().unwrap();
-				}
-				_ => panic!("could not parse meta"),
-			}
-		}
-		result
-	}
-}
-
-pub fn derive(input: DeriveInput) -> TokenStream {
-	let attrs = MetadataArg::from(&input.attrs);
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
+	let attrs = MetadataArg::from_attributes(&input.attrs)?;
 	let ident = &input.ident;
 	let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
 	let initial = attrs.initial.map(|initial| {
@@ -185,17 +47,14 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 			fn initial() -> &'static str { #initial }
 		}
 	});
-	let inherits = attrs.inherits.map(|inherits| {
+	let inherits = attrs.inherits.map(|InheritsArg(inherits)| {
 		quote! {
 			fn inherits() -> Inherits { Inherits::#inherits }
 		}
 	});
-	let applies_to = if attrs.applies_to.is_empty() {
-		quote! {}
-	} else {
-		let applies_to = attrs.applies_to;
+	let applies_to = attrs.applies_to.map(|PipeList(applies_to)| {
 		quote! { fn applies_to() -> AppliesTo { #(AppliesTo::#applies_to)|* } }
-	};
+	});
 	let animation_type = attrs.animation_type.map(|animation_type| {
 		quote! {
 			fn animation_type() -> AnimationType { AnimationType::#animation_type }
@@ -231,35 +90,26 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 			fn logical_property_group() -> Option<CssAtomSet> { Some(CssAtomSet::#logical_property_group) }
 		}
 	});
-	let box_side = if attrs.box_side.is_empty() {
-		quote! {}
-	} else {
-		let box_side = attrs.box_side;
+	let box_side = attrs.box_side.map(|PipeList(box_side)| {
 		quote! { fn box_side() -> BoxSide { #(BoxSide::#box_side)|* } }
-	};
-	let box_portion = if attrs.box_portion.is_empty() {
-		quote! {}
-	} else {
-		let box_portion = attrs.box_portion;
+	});
+	let box_portion = attrs.box_portion.map(|PipeList(box_portion)| {
 		quote! { fn box_portion() -> BoxPortion { #(BoxPortion::#box_portion)|* } }
-	};
-	let longhands = if attrs.longhands.is_empty() {
-		quote! {}
-	} else {
-		let longhands = &attrs.longhands;
+	});
+	let longhands = attrs.longhands.map(|PipeList(longhands)| {
 		quote! {
 			fn longhands() -> Option<&'static [CssAtomSet]> {
 				Some(&[#(CssAtomSet::#longhands),*])
 			}
 			fn is_shorthand() -> bool { true }
 		}
-	};
+	});
 	let unitless_zero_resolves = attrs.unitless_zero_resolves.map(|unitless_zero_resolves| {
 		quote! {
 			fn unitless_zero_resolves() -> crate::UnitlessZeroResolves { crate::UnitlessZeroResolves::#unitless_zero_resolves }
 		}
 	});
-	quote! {
+	Ok(quote! {
 	  #[automatically_derived]
 	  impl #impl_generics crate::DeclarationMetadata for #ident #type_generics #where_clause {
 			#initial
@@ -277,5 +127,5 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 			#box_portion
 			#unitless_zero_resolves
 	  }
-	}
+	})
 }

--- a/crates/csskit_derives/src/field_view.rs
+++ b/crates/csskit_derives/src/field_view.rs
@@ -1,0 +1,56 @@
+use proc_macro2::{Ident, Span};
+use quote::format_ident;
+use syn::{Fields, GenericArgument, Index, Member, PathArguments, Type};
+
+/// A normalised view of a single struct or variant field.
+#[derive(Debug)]
+pub struct FieldView<'a> {
+	/// Binding identifier for use in generated code (`v0`, `v1`, or the
+	/// field's own name for named fields).
+	pub binding: Ident,
+	/// Member accessor for `self.#member` expressions (`0`, `1`, or the name).
+	pub member: Member,
+	/// The field's type with any leading `&` reference stripped.
+	pub ty: &'a Type,
+	/// `true` when `ty` is `Option<T>`.
+	pub is_option: bool,
+}
+
+/// Extension trait on `syn::Fields` to build field views.
+pub trait FieldsExt {
+	fn views(&self) -> Vec<FieldView<'_>>;
+}
+
+impl FieldsExt for Fields {
+	fn views(&self) -> Vec<FieldView<'_>> {
+		self.iter()
+			.enumerate()
+			.map(|(i, field)| {
+				let binding = field.ident.clone().unwrap_or_else(|| format_ident!("v{}", i));
+				let member: Member = match &field.ident {
+					Some(name) => Member::Named(name.clone()),
+					None => Member::Unnamed(Index { index: i as u32, span: Span::call_site() }),
+				};
+				let ty: &Type = match &field.ty {
+					Type::Reference(r) => r.elem.as_ref(),
+					t => t,
+				};
+				let is_option = option_inner(ty).is_some();
+				FieldView { binding, member, ty, is_option }
+			})
+			.collect()
+	}
+}
+
+/// If `ty` is `Option<T>`, return `Some(&T)`. Otherwise `None`.
+pub(crate) fn option_inner(ty: &Type) -> Option<&Type> {
+	if let Type::Path(path) = ty
+		&& let Some(seg) = path.path.segments.last()
+		&& seg.ident == "Option"
+		&& let PathArguments::AngleBracketed(args) = &seg.arguments
+		&& let Some(GenericArgument::Type(inner)) = args.args.first()
+	{
+		return Some(inner);
+	}
+	None
+}

--- a/crates/csskit_derives/src/into_cursor.rs
+++ b/crates/csskit_derives/src/into_cursor.rs
@@ -1,45 +1,43 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Result};
 
-use crate::err;
-
-pub fn derive(input: DeriveInput) -> TokenStream {
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let ident = input.ident;
 	let generics = &mut input.generics.clone();
 	let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 	let body = match input.data {
-		Data::Union(_) => err(ident.span(), "Cannot derive Into<Cursor> on a Union"),
+		Data::Union(_) => return Err(Error::new(ident.span(), "Cannot derive Into<Cursor> on a Union")),
 
 		Data::Struct(DataStruct { fields, .. }) => {
 			if fields.len() != 1 {
-				return err(ident.span(), "Cannot derive Into<Cursor> for a struct with many fields");
+				return Err(Error::new(ident.span(), "Cannot derive Into<Cursor> for a struct with many fields"));
 			} else {
-				let member = fields.members().next().unwrap();
+				let member = fields.members().next().expect("len checked");
 				quote! { value.#member.into() }
 			}
 		}
 
 		Data::Enum(DataEnum { variants, .. }) => {
-			let steps: TokenStream = variants
-				.iter()
-				.map(|variant| {
-					if variant.fields.len() != 1 {
-						err(ident.span(), "Cannot derive Into<Cursor> for an enum variant with none or many fields")
-					} else {
-						let variant = &variant.ident;
-						quote! { #ident::#variant(c) => c.into(), }
-					}
-				})
-				.collect();
+			let mut steps: Vec<TokenStream> = Vec::new();
+			for variant in &variants {
+				if variant.fields.len() != 1 {
+					return Err(Error::new(
+						variant.ident.span(),
+						"Cannot derive Into<Cursor> for an enum variant with none or many fields",
+					));
+				}
+				let variant_ident = &variant.ident;
+				steps.push(quote! { #ident::#variant_ident(c) => c.into(), });
+			}
 			quote! {
 				match value {
-					#steps
+					#(#steps)*
 				}
 			}
 		}
 	};
-	quote! {
+	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics From<#ident #type_generics> for ::css_parse::Cursor #where_clause {
 			fn from(value: #ident) -> ::css_parse::Cursor {
@@ -67,5 +65,5 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 				Cursor::from(*self).semantic_eq(&Cursor::from(*other))
 			}
 		}
-	}
+	})
 }

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -1,11 +1,12 @@
 #![deny(warnings)]
 use proc_macro::TokenStream;
-use proc_macro2::Span;
-use syn::{AngleBracketedGenericArguments, Error, GenericArgument, PathArguments, PathSegment, Type, TypePath};
+use syn::{DeriveInput, Generics, Result, parse_quote};
 
 mod attributes;
 mod css_feature;
+mod darling_ext;
 mod declaration_metadata;
+mod field_view;
 mod into_cursor;
 mod node_with_metadata;
 mod parse;
@@ -16,102 +17,74 @@ mod to_span;
 mod visitable;
 mod where_collector;
 
+use field_view::FieldsExt;
 use where_collector::WhereCollector;
+
+fn ensure_lifetime_a(generics: &Generics) -> Generics {
+	let mut g = generics.clone();
+	if generics.lifetimes().all(|l| l.lifetime.ident != "a") {
+		g.params.insert(0, parse_quote!('a));
+	}
+	g
+}
 
 #[cfg(test)]
 mod test;
 
+fn run<F>(stream: TokenStream, f: F) -> TokenStream
+where
+	F: FnOnce(DeriveInput) -> Result<proc_macro2::TokenStream>,
+{
+	let input = syn::parse::<DeriveInput>(stream).unwrap_or_else(|e| panic!("{e}"));
+	f(input).unwrap_or_else(|e| e.into_compile_error()).into()
+}
+
 #[proc_macro_derive(ToCursors, attributes(to_cursors))]
 pub fn derive_to_cursors(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	to_cursors::derive(input).into()
+	run(stream, to_cursors::derive)
 }
 
 #[proc_macro_derive(Parse, attributes(parse, atom))]
 pub fn derive_parse(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	parse::derive(input).into()
+	run(stream, parse::derive)
 }
 
 #[proc_macro_derive(Peek, attributes(peek, atom))]
 pub fn derive_peek(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	peek::derive(input).into()
+	run(stream, peek::derive)
 }
 
 #[proc_macro_derive(IntoCursor)]
 pub fn derive_into_cursor(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	into_cursor::derive(input).into()
+	run(stream, into_cursor::derive)
 }
 
 #[proc_macro_derive(ToSpan)]
 pub fn derive_into_span(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	to_span::derive(input).into()
+	run(stream, to_span::derive)
 }
 
 #[proc_macro_derive(Visitable, attributes(visit, queryable))]
 pub fn derive_visitable(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	visitable::derive(input).into()
+	run(stream, visitable::derive)
 }
 
 #[proc_macro_derive(NodeWithMetadata, attributes(metadata))]
 pub fn derive_node_with_metadata(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	node_with_metadata::derive(input).into()
+	run(stream, node_with_metadata::derive)
 }
 
 #[proc_macro_derive(ToCSSFeature, attributes(css_feature))]
 pub fn derive_css_feature(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	css_feature::derive(input).into()
+	run(stream, css_feature::derive)
 }
 
 #[proc_macro_derive(DeclarationMetadata, attributes(declaration_metadata))]
 pub fn derive_declaration_metadata(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	declaration_metadata::derive(input).into()
+	run(stream, declaration_metadata::derive)
 }
 
 #[proc_macro_derive(SemanticEq, attributes(semantic_eq))]
 pub fn derive_semantic_eq(stream: TokenStream) -> TokenStream {
-	let input = syn::parse(stream).unwrap();
-	semantic_eq::derive(input).into()
-}
-
-fn err(span: Span, msg: &str) -> proc_macro2::TokenStream {
-	let err = Error::new(span, msg).into_compile_error();
-	quote::quote! {#err}
-}
-
-trait TypeIsOption {
-	fn is_option(&self) -> bool;
-	fn unpack_option(&self) -> Self;
-}
-
-impl TypeIsOption for Type {
-	fn is_option(&self) -> bool {
-		match self {
-			Self::Path(TypePath { path, .. }) => path.segments.last().is_some_and(|s| s.ident == "Option"),
-			_ => false,
-		}
-	}
-
-	fn unpack_option(&self) -> Self {
-		if let Self::Path(TypePath { path, .. }) = self
-			&& let Some(PathSegment {
-				ident,
-				arguments: PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }),
-				..
-			}) = path.segments.last()
-			&& ident == "Option"
-			&& args.len() == 1
-			&& let GenericArgument::Type(inner_ty) = &args[0]
-		{
-			return inner_ty.clone();
-		}
-		self.clone()
-	}
+	run(stream, semantic_eq::derive)
 }

--- a/crates/csskit_derives/src/node_with_metadata.rs
+++ b/crates/csskit_derives/src/node_with_metadata.rs
@@ -1,276 +1,141 @@
+use darling::FromAttributes;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-	Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Ident, Meta, Token,
-	parse::{Parse, ParseStream},
+	Data, DataEnum, DataStruct, DeriveInput, Error, Fields, GenericParam, Generics, Ident, Index, Path, Result,
+	parse_quote,
 };
 
-/// Parsed metadata arguments from #[metadata(...)] attribute.
-#[derive(Debug, Default)]
+use crate::darling_ext::PipeList;
+
+#[derive(Debug, Default, FromAttributes)]
+#[darling(attributes(metadata))]
 struct MetadataArgs {
-	/// Whether to skip generating the implementation (type has manual impl).
+	#[darling(default)]
 	pub skip: bool,
-	/// node_kinds field values (e.g., Dimension, Function, AtRule).
-	pub node_kinds: Vec<Ident>,
-	/// used_at_rules field values (e.g., Media, Keyframes).
-	pub used_at_rules: Vec<Ident>,
-	/// vendor_prefixes field values (e.g., Moz, WebKit).
-	pub vendor_prefixes: Vec<Ident>,
-	/// declaration_kinds field values (e.g., Important, Custom).
-	pub declaration_kinds: Vec<Ident>,
-	/// property_kinds field values (e.g., Name).
-	pub property_kinds: Vec<Ident>,
-	/// For enums: delegate to the inner value's metadata() for each variant.
-	/// When set, generates: match self { Self::Variant(v) => v.metadata(), ... }
+	#[darling(default)]
+	pub node_kinds: Option<PipeList<Ident>>,
+	#[darling(default)]
+	pub used_at_rules: Option<PipeList<Ident>>,
+	#[darling(default)]
+	pub vendor_prefixes: Option<PipeList<Ident>>,
+	#[darling(default)]
+	pub declaration_kinds: Option<PipeList<Ident>>,
+	#[darling(default)]
+	pub property_kinds: Option<PipeList<Ident>>,
+	#[darling(default)]
 	pub delegate: bool,
 }
 
-impl Parse for MetadataArgs {
-	fn parse(input: ParseStream) -> syn::Result<Self> {
-		let mut args = Self::default();
-		while !input.is_empty() {
-			let ident = input.parse::<Ident>()?;
-			match ident.to_string().as_str() {
-				"skip" => {
-					args.skip = true;
-				}
-				"delegate" => {
-					args.delegate = true;
-				}
-				"node_kinds" => {
-					input.parse::<Token![=]>()?;
-					loop {
-						args.node_kinds.push(input.parse::<Ident>()?);
-						if input.parse::<Token![|]>().is_err() {
-							break;
-						}
-					}
-				}
-				"used_at_rules" => {
-					input.parse::<Token![=]>()?;
-					loop {
-						args.used_at_rules.push(input.parse::<Ident>()?);
-						if input.parse::<Token![|]>().is_err() {
-							break;
-						}
-					}
-				}
-				"vendor_prefixes" => {
-					input.parse::<Token![=]>()?;
-					loop {
-						args.vendor_prefixes.push(input.parse::<Ident>()?);
-						if input.parse::<Token![|]>().is_err() {
-							break;
-						}
-					}
-				}
-				"declaration_kinds" => {
-					input.parse::<Token![=]>()?;
-					loop {
-						args.declaration_kinds.push(input.parse::<Ident>()?);
-						if input.parse::<Token![|]>().is_err() {
-							break;
-						}
-					}
-				}
-				"property_kinds" => {
-					input.parse::<Token![=]>()?;
-					loop {
-						args.property_kinds.push(input.parse::<Ident>()?);
-						if input.parse::<Token![|]>().is_err() {
-							break;
-						}
-					}
-				}
-				_ => {
-					return Err(Error::new(ident.span(), format!("Unrecognized metadata argument: {ident}")));
-				}
-			}
-
-			if !input.is_empty() {
-				input.parse::<Token![,]>()?;
-			}
+impl MetadataArgs {
+	fn pipe_tokens(field: &Option<PipeList<Ident>>, type_path: Path) -> TokenStream {
+		match field.as_ref().map(|p| p.0.as_slice()) {
+			None | Some([]) => quote! { #type_path::none() },
+			Some(ids) => quote! { #(#type_path::#ids)|* },
 		}
-		Ok(args)
-	}
-}
-
-impl From<&[Attribute]> for MetadataArgs {
-	fn from(attrs: &[Attribute]) -> Self {
-		let mut result = Self::default();
-		if let Some(Attribute { meta, .. }) = attrs.iter().find(|a| a.path().is_ident("metadata"))
-			&& let Meta::List(meta) = meta
-		{
-			result = meta.parse_args::<MetadataArgs>().unwrap();
-		}
-		result
-	}
-}
-
-/// Check if a field has #[metadata(delegate)] attribute
-fn has_delegate_attr(attrs: &[Attribute]) -> bool {
-	attrs.iter().any(|attr| {
-		if attr.path().is_ident("metadata") {
-			match &attr.meta {
-				Meta::List(meta) => meta.parse_args::<MetadataArgs>().map(|args| args.delegate).unwrap_or(false),
-				_ => false,
-			}
-		} else {
-			false
-		}
-	})
-}
-
-fn has_skip_attr(attrs: &[Attribute]) -> bool {
-	attrs.iter().any(|attr| {
-		if attr.path().is_ident("metadata") {
-			match &attr.meta {
-				Meta::List(meta) => meta.parse_args::<MetadataArgs>().map(|args| args.skip).unwrap_or(false),
-				_ => false,
-			}
-		} else {
-			false
-		}
-	})
-}
-
-/// Determines which struct field to delegate `metadata()` to, if any.
-///
-/// Generic newtypes (e.g. `NonNegative<T>`) auto-delegate so that `T`'s metadata
-/// propagates without requiring an explicit attribute. Non-generic single-field structs
-/// don't auto-delegate because their inner types may not implement `NodeWithMetadata`.
-fn find_delegate_field(fields: &Fields, generics: &syn::Generics) -> Option<TokenStream> {
-	// Explicit #[metadata(delegate)] attribute takes priority
-	match fields {
-		Fields::Named(named) => {
-			for field in &named.named {
-				if has_delegate_attr(&field.attrs) {
-					let ident = field.ident.as_ref()?;
-					return Some(quote! { #ident });
-				}
-			}
-		}
-		Fields::Unnamed(unnamed) => {
-			for (i, field) in unnamed.unnamed.iter().enumerate() {
-				if has_delegate_attr(&field.attrs) {
-					let idx = syn::Index::from(i);
-					return Some(quote! { #idx });
-				}
-			}
-		}
-		Fields::Unit => return None,
 	}
 
-	// Second: auto-delegate for generic single-field structs (newtypes)
-	let has_type_params = generics.type_params().next().is_some();
-	if !has_type_params {
-		return None;
-	}
-
-	let total_fields = match fields {
-		Fields::Named(named) => named.named.len(),
-		Fields::Unnamed(unnamed) => unnamed.unnamed.len(),
-		Fields::Unit => 0,
-	};
-	if total_fields == 1 {
+	/// Which struct field to delegate `metadata()` to, if any.
+	///
+	/// Generic newtypes (e.g. `NonNegative<T>`) auto-delegate so `T`'s metadata
+	/// propagates without an explicit attribute. Non-generic single-field structs
+	/// don't auto-delegate: their inner type may not implement `NodeWithMetadata`.
+	fn delegate_field(fields: &Fields, generics: &Generics) -> Option<TokenStream> {
 		match fields {
 			Fields::Named(named) => {
-				let ident = named.named.first()?.ident.as_ref()?;
-				Some(quote! { #ident })
+				for field in &named.named {
+					if MetadataArgs::from_attributes(&field.attrs).map(|a| a.delegate).unwrap_or(false) {
+						let ident = field.ident.as_ref()?;
+						return Some(quote! { #ident });
+					}
+				}
 			}
-			Fields::Unnamed(_) => {
-				let idx = syn::Index::from(0);
-				Some(quote! { #idx })
+			Fields::Unnamed(unnamed) => {
+				for (i, field) in unnamed.unnamed.iter().enumerate() {
+					if MetadataArgs::from_attributes(&field.attrs).map(|a| a.delegate).unwrap_or(false) {
+						let idx = Index::from(i);
+						return Some(quote! { #idx });
+					}
+				}
 			}
-			Fields::Unit => None,
+			Fields::Unit => return None,
 		}
-	} else {
-		None
-	}
-}
 
-/// Check if delegation is active (struct field delegate or enum-level delegate).
-/// Used to determine if we need to add NodeWithMetadata bounds on generic type params.
-fn needs_delegation_bounds(args: &MetadataArgs, data: &Data, generics: &syn::Generics) -> bool {
-	if args.delegate {
-		return true;
-	}
-	if let Data::Struct(DataStruct { fields, .. }) = data {
-		return find_delegate_field(fields, generics).is_some();
-	}
-	false
-}
+		// Auto-delegate for generic single-field structs (newtypes).
+		let has_type_params = generics.type_params().next().is_some();
+		if !has_type_params {
+			return None;
+		}
 
-/// Ensures delegated fields can provide metadata by bounding type params with `NodeWithMetadata`.
-fn generics_with_metadata_bounds(generics: &syn::Generics) -> syn::Generics {
-	let mut generics = generics.clone();
-	for param in &mut generics.params {
-		if let syn::GenericParam::Type(type_param) = param {
-			type_param.bounds.push(syn::parse_quote!(css_parse::NodeWithMetadata<crate::CssMetadata>));
+		let total_fields = match fields {
+			Fields::Named(named) => named.named.len(),
+			Fields::Unnamed(unnamed) => unnamed.unnamed.len(),
+			Fields::Unit => 0,
+		};
+		if total_fields == 1 {
+			match fields {
+				Fields::Named(named) => {
+					let ident = named.named.first()?.ident.as_ref()?;
+					Some(quote! { #ident })
+				}
+				Fields::Unnamed(_) => {
+					let idx = Index::from(0);
+					Some(quote! { #idx })
+				}
+				Fields::Unit => None,
+			}
+		} else {
+			None
 		}
 	}
-	generics
+
+	fn needs_delegation_bounds(&self, data: &Data, generics: &Generics) -> bool {
+		if self.delegate {
+			return true;
+		}
+		if let Data::Struct(DataStruct { fields, .. }) = data {
+			return MetadataArgs::delegate_field(fields, generics).is_some();
+		}
+		false
+	}
+
+	fn generics_with_metadata_bounds(&self, generics: &Generics) -> Generics {
+		let mut generics = generics.clone();
+		for param in &mut generics.params {
+			if let GenericParam::Type(type_param) = param {
+				type_param.bounds.push(parse_quote!(css_parse::NodeWithMetadata<crate::CssMetadata>));
+			}
+		}
+		generics
+	}
 }
 
-pub fn derive(input: DeriveInput) -> TokenStream {
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let ident = input.ident;
-	let args = MetadataArgs::from(input.attrs.as_slice());
+	let args = MetadataArgs::from_attributes(&input.attrs)?;
 
-	// Check if we should skip generating NodeWithMetadata (type has manual implementation)
 	if args.skip {
-		return Error::new_spanned(
+		return Err(Error::new_spanned(
 			ident,
 			"#[metadata(skip)] should not be used with derive(NodeWithMetadata). Remove the derive instead.",
-		)
-		.into_compile_error();
+		));
 	}
 
-	// Add NodeWithMetadata bounds on generic params when delegation is active
-	let effective_generics = if needs_delegation_bounds(&args, &input.data, &input.generics) {
-		generics_with_metadata_bounds(&input.generics)
+	let effective_generics = if args.needs_delegation_bounds(&input.data, &input.generics) {
+		args.generics_with_metadata_bounds(&input.generics)
 	} else {
 		input.generics.clone()
 	};
 	let (impl_generics, type_generics, where_clause) = effective_generics.split_for_impl();
 
-	// Generate field initializers for any specified metadata
-	let node_kinds = if args.node_kinds.is_empty() {
-		quote! { crate::NodeKinds::none() }
-	} else {
-		let kinds = &args.node_kinds;
-		quote! { #(crate::NodeKinds::#kinds)|* }
-	};
-
-	let used_at_rules = if args.used_at_rules.is_empty() {
-		quote! { crate::AtRuleId::none() }
-	} else {
-		let rules = &args.used_at_rules;
-		quote! { #(crate::AtRuleId::#rules)|* }
-	};
-
-	let vendor_prefixes = if args.vendor_prefixes.is_empty() {
-		quote! { crate::VendorPrefixes::none() }
-	} else {
-		let prefixes = &args.vendor_prefixes;
-		quote! { #(crate::VendorPrefixes::#prefixes)|* }
-	};
-
-	let declaration_kinds = if args.declaration_kinds.is_empty() {
-		quote! { crate::DeclarationKind::none() }
-	} else {
-		let kinds = &args.declaration_kinds;
-		quote! { #(crate::DeclarationKind::#kinds)|* }
-	};
-
-	let property_kinds = if args.property_kinds.is_empty() {
-		quote! { crate::PropertyKind::none() }
-	} else {
-		let kinds = &args.property_kinds;
-		quote! { #(crate::PropertyKind::#kinds)|* }
-	};
+	let node_kinds = MetadataArgs::pipe_tokens(&args.node_kinds, parse_quote! { crate::NodeKinds });
+	let used_at_rules = MetadataArgs::pipe_tokens(&args.used_at_rules, parse_quote! { crate::AtRuleId });
+	let vendor_prefixes = MetadataArgs::pipe_tokens(&args.vendor_prefixes, parse_quote! { crate::VendorPrefixes });
+	let declaration_kinds = MetadataArgs::pipe_tokens(&args.declaration_kinds, parse_quote! { crate::DeclarationKind });
+	let property_kinds = MetadataArgs::pipe_tokens(&args.property_kinds, parse_quote! { crate::PropertyKind });
 
 	let field_delegate = match &input.data {
-		Data::Struct(DataStruct { fields, .. }) => find_delegate_field(fields, &input.generics),
+		Data::Struct(DataStruct { fields, .. }) => MetadataArgs::delegate_field(fields, &input.generics),
 		_ => None,
 	};
 
@@ -288,18 +153,15 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 
 	};
 
-	// Check if this is an enum with delegate flag - in that case, generate delegation
 	let metadata_body = if args.delegate {
 		if let Data::Enum(DataEnum { variants, .. }) = &input.data {
-			// Enum delegation: match on each variant and call metadata() on the inner value
 			let match_arms: TokenStream = variants
 				.iter()
 				.map(|variant| {
 					let variant_ident = &variant.ident;
 					let field_count = variant.fields.len();
 
-					// Check if variant has #[metadata(skip)] - if so, return default
-					if has_skip_attr(&variant.attrs) {
+					if MetadataArgs::from_attributes(&variant.attrs).map(|a| a.skip).unwrap_or(false) {
 						let pattern = if field_count == 0 {
 							quote! { Self::#variant_ident }
 						} else {
@@ -311,20 +173,14 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 					}
 
 					if field_count == 0 {
-						// Unit variant - return default metadata
 						quote! {
 							Self::#variant_ident => crate::CssMetadata::default(),
 						}
 					} else {
-						// Generate bindings for each field (v0, v1, v2, ...)
 						let bindings: Vec<_> = (0..field_count).map(|i| format_ident!("v{}", i)).collect();
-
-						// For enum delegation, we merge metadata from all fields
-						// First field is the base, subsequent fields are merged in
 						let metadata_expr = if field_count == 1 {
 							quote! { <_ as css_parse::NodeWithMetadata<crate::CssMetadata>>::metadata(v0) }
 						} else {
-							// Merge metadata from all fields using NodeMetadata::merge
 							let mut expr = quote! { <_ as css_parse::NodeWithMetadata<crate::CssMetadata>>::metadata(v0) };
 							for binding in bindings.iter().skip(1) {
 								expr = quote! { css_parse::NodeMetadata::merge(#expr, <_ as css_parse::NodeWithMetadata<crate::CssMetadata>>::metadata(#binding)) };
@@ -347,14 +203,12 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 				}
 			}
 		} else {
-			return Error::new_spanned(
+			return Err(Error::new_spanned(
 				ident,
 				"#[metadata(delegate)] on a type-level attribute can only be used on enums. Use field-level #[metadata(delegate)] for structs.",
-			)
-			.into_compile_error();
+			));
 		}
 	} else if let Some(field_path) = field_delegate {
-		// Struct delegate (explicit or auto for single-field newtypes) - merge from that field
 		let field_access = quote! { self.#field_path };
 		let child_meta_access =
 			quote! { <_ as css_parse::NodeWithMetadata<crate::CssMetadata>>::metadata(&#field_access) };
@@ -372,13 +226,12 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 		}
 	};
 
-	// Generate NodeWithMetadata implementation
-	quote! {
+	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics css_parse::NodeWithMetadata<crate::CssMetadata> for #ident #type_generics #where_clause {
 			#self_metadata
 
 			#metadata_body
 		}
-	}
+	})
 }

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -1,15 +1,30 @@
 use crate::{
-	TypeIsOption, WhereCollector,
+	FieldsExt, WhereCollector,
 	attributes::{Atom, extract_atom},
-	err,
+	darling_ext::{StateArg, StopArg},
+	ensure_lifetime_a,
+	field_view::option_inner,
 };
+use darling::FromAttributes;
 use itertools::{Itertools, Position};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use syn::{
-	Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Meta, Token, Type, TypePath, parse::Parse,
-	parse_quote,
-};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Result, Type, Variant, parse_quote};
+
+trait TypeIsOption {
+	fn is_option(&self) -> bool;
+	fn unpack_option(&self) -> Self;
+}
+
+impl TypeIsOption for Type {
+	fn is_option(&self) -> bool {
+		option_inner(self).is_some()
+	}
+
+	fn unpack_option(&self) -> Self {
+		option_inner(self).cloned().unwrap_or_else(|| self.clone())
+	}
+}
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 enum FieldParseMode {
@@ -19,742 +34,644 @@ enum FieldParseMode {
 	OneMustOccur,
 }
 
-trait ToVarsAndTypes {
-	fn to_vars_and_types(&self) -> Vec<(Ident, Type, ParseArg, Option<Atom>)>;
-}
-
-impl ToVarsAndTypes for Fields {
-	fn to_vars_and_types(&self) -> Vec<(Ident, Type, ParseArg, Option<Atom>)> {
-		self.into_iter()
-			.enumerate()
-			.map(|(i, field)| {
-				(
-					field.ident.clone().unwrap_or_else(|| format_ident!("f{}", i)),
-					match &field.ty {
-						Type::Reference(refty) => refty.elem.as_ref(),
-						ty => ty,
-					}
-					.clone(),
-					ParseArg::from(&field.attrs),
-					extract_atom(&field.attrs),
-				)
-			})
-			.collect::<Vec<_>>()
-	}
-}
-
-#[derive(Debug, Default)]
+#[derive(Debug, Default, FromAttributes)]
+#[darling(attributes(parse))]
 struct ParseArg {
-	pub state: Option<Ident>,
-	pub stop: Option<(Ident, Ident)>,
-	pub parse_mode: FieldParseMode,
+	pub state: Option<StateArg>,
+	pub stop: Option<StopArg>,
+	#[darling(default)]
+	pub all_must_occur: bool,
+	#[darling(default)]
+	pub one_must_occur: bool,
 }
 
-impl Parse for ParseArg {
-	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-		let mut args = ParseArg::default();
-		while !input.is_empty() {
-			match input.parse::<Ident>()? {
-				i if i == "state" => {
-					if args.state.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'state'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					let TypePath { path, .. } = input.parse::<TypePath>()?;
-					let ident = path.segments.first().map(|s| s.ident.clone()).unwrap();
-					if ident != "State" {
-						Err(Error::new(ident.span(), format!("state must use the State type, saw {ident:?}")))?;
-					}
-					let ident = path.segments.last().map(|s| s.ident.clone()).unwrap();
-					args.state = Some(ident);
-				}
-				i if i == "stop" => {
-					if args.stop.is_some() {
-						Err(Error::new(i.span(), "redefinition of 'stop'".to_string()))?;
-					}
-					input.parse::<Token![=]>()?;
-					let TypePath { path, .. } = input.parse::<TypePath>()?;
-					let kind_or_kindset = path.segments.first().map(|s| s.ident.clone()).unwrap();
-					if kind_or_kindset != "Kind" && kind_or_kindset != "KindSet" {
-						panic!("stop must use the Kind or KindSet type");
-					}
-					let ident = path.segments.last().map(|s| s.ident.clone()).unwrap();
-					args.stop = Some((kind_or_kindset, ident));
-				}
-				i if i == "all_must_occur" => {
-					if args.parse_mode != Default::default() {
-						Err(Error::new(i.span(), "redefinition of 'all_must_occur' or 'one_must_occur'".to_string()))?;
-					}
-					args.parse_mode = FieldParseMode::AllMustOccur;
-				}
-				i if i == "one_must_occur" => {
-					if args.parse_mode != Default::default() {
-						Err(Error::new(i.span(), "redefinition of 'all_must_occur' or 'one_must_occur'".to_string()))?;
-					}
-					args.parse_mode = FieldParseMode::OneMustOccur;
-				}
-				ident => Err(Error::new(ident.span(), format!("Unrecognized Value arg {ident:?}")))?,
-			}
-
-			if !input.is_empty() {
-				input.parse::<Token![,]>()?;
-			}
+impl ParseArg {
+	fn parse_mode(&self) -> FieldParseMode {
+		match (self.all_must_occur, self.one_must_occur) {
+			(true, _) => FieldParseMode::AllMustOccur,
+			(_, true) => FieldParseMode::OneMustOccur,
+			_ => FieldParseMode::Sequential,
 		}
-		Ok(args)
 	}
 }
 
-impl From<&Vec<Attribute>> for ParseArg {
-	fn from(attrs: &Vec<Attribute>) -> Self {
-		let mut result = Self::default();
-
-		// Check for #[parse(...)] attribute
-		if let Some(Attribute { meta, .. }) = &attrs.iter().find(|a| a.path().is_ident("parse")) {
-			match meta {
-				Meta::List(meta) => {
-					let parsed = meta.parse_args::<ParseArg>().unwrap();
-					result.state = parsed.state;
-					result.stop = parsed.stop;
-					result.parse_mode = parsed.parse_mode;
-				}
-				_ => panic!("could not parse meta"),
-			}
-		}
-
-		result
-	}
+#[derive(Debug)]
+struct Field {
+	var: Ident,
+	ty: Type,
+	arg: ParseArg,
+	atom: Option<Atom>,
 }
 
-fn generate_field_parsing(
-	var: &Ident,
-	ty: &Type,
-	arg: &ParseArg,
-	atom: &Option<Atom>,
-	parse_mode: FieldParseMode,
-	where_collector: &mut WhereCollector,
-) -> TokenStream {
-	if let Some(atom) = atom {
-		generate_keyword_parsing(var, ty, atom, arg, parse_mode, where_collector)
-	} else {
-		generate_normal_parsing(var, ty, arg, parse_mode, where_collector)
-	}
-}
-
-fn generate_keyword_parsing(
-	var: &Ident,
-	ty: &Type,
-	atom: &Atom,
-	_arg: &ParseArg,
-	parse_mode: FieldParseMode,
-	where_collector: &mut WhereCollector,
-) -> TokenStream {
-	match parse_mode {
-		FieldParseMode::Sequential => {
-			let condition = atom.equals_atom(format_ident!("c"));
-			let inner_ty = ty.unpack_option();
-			where_collector.add(&inner_ty);
-			if ty.is_option() {
-				quote! {
-					let #var = {
-						let c = p.peek_n(1);
-						if #condition {
-							Some(p.parse::<#inner_ty>()?)
-						} else {
-							None
-						}
-					};
-				}
-			} else {
-				quote! {
-					let #var = {
-						let c = p.peek_n(1);
-						if #condition {
-							p.parse::<#inner_ty>()?
-						} else {
-							return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
-						}
-					};
-				}
-			}
+impl Field {
+	fn parse_tokens(&self, wc: &mut WhereCollector) -> TokenStream {
+		if self.atom.is_some() {
+			self.parse_keyword_tokens(wc)
+		} else {
+			self.parse_normal_tokens(FieldParseMode::Sequential, wc)
 		}
-		FieldParseMode::AllMustOccur | FieldParseMode::OneMustOccur => {
-			let atom = atom.path();
-			let ty = ty.unpack_option();
-			where_collector.add(&ty);
+	}
+
+	fn parse_keyword_tokens(&self, wc: &mut WhereCollector) -> TokenStream {
+		let Field { var, ty, atom, .. } = self;
+		let atom = atom.as_ref().expect("parse_keyword_tokens called without atom");
+		let condition = atom.equals_atom(format_ident!("c"));
+		let inner_ty = ty.unpack_option();
+		wc.add(&inner_ty);
+		if ty.is_option() {
 			quote! {
-				if #var.is_none() && atom == #atom {
-					#var = Some(p.parse::<#ty>()?);
-					continue;
-				}
+				let #var = {
+					let c = p.peek_n(1);
+					if #condition {
+						Some(p.parse::<#inner_ty>()?)
+					} else {
+						None
+					}
+				};
 			}
-		}
-	}
-}
-
-fn generate_normal_parsing(
-	var: &Ident,
-	ty: &Type,
-	arg: &ParseArg,
-	parse_mode: FieldParseMode,
-	where_collector: &mut WhereCollector,
-) -> TokenStream {
-	match parse_mode {
-		FieldParseMode::Sequential => {
-			where_collector.add(ty);
-			if let Some(state_ident) = &arg.state {
-				quote! {
-					let #var = {
-						let old_state = p.set_state(State::#state_ident);
-						let result = p.parse::<#ty>()?;
-						p.set_state(old_state);
-						result
-					};
-				}
-			} else {
-				quote! { let #var = p.parse::<#ty>()?; }
-			}
-		}
-		FieldParseMode::AllMustOccur | FieldParseMode::OneMustOccur => {
-			let ty = ty.unpack_option();
-			where_collector.add(&ty);
+		} else {
 			quote! {
-			  if #var.is_none() && <#ty>::peek(p, c) {
-					#var = Some(p.parse::<#ty>()?);
-					continue;
-			  }
+				let #var = {
+					let c = p.peek_n(1);
+					if #condition {
+						p.parse::<#inner_ty>()?
+					} else {
+						return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
+					}
+				};
 			}
 		}
 	}
-}
 
-/// Generate a pre-loop that parses shared fields before variant discrimination.
-/// `shared_fields` are fields present in all sibling variants (same atom path).
-/// Returns `(binding_decls, loop_body)` so callers can emit them before the variant dispatch.
-fn generate_must_occur_parsing(
-	split_fields: &[(Ident, Type, ParseArg, Option<Atom>)],
-	members: Vec<TokenStream>,
-	post_parse_steps: &TokenStream,
-	parse_mode: FieldParseMode,
-	constructor: TokenStream,
-	where_collector: &mut WhereCollector,
-) -> TokenStream {
-	let mut atom_binding = None;
-	let mut atom_set_ty = None;
-	let bindings: Vec<TokenStream> = split_fields
-		.iter()
-		.map(|(var, ty, _, atom)| {
-			if atom.is_some() && atom_binding.is_none() {
-				let a = atom.as_ref().unwrap();
-				let atom_expr = a.to_atom(format_ident!("c"));
-				let atom_set = a.first_segment();
-				atom_set_ty = Some(atom_set.clone());
-				atom_binding = Some(quote! { let atom = #atom_expr; });
+	fn parse_normal_tokens(&self, parse_mode: FieldParseMode, wc: &mut WhereCollector) -> TokenStream {
+		let Field { var, ty, arg, .. } = self;
+		match parse_mode {
+			FieldParseMode::Sequential => {
+				wc.add(ty);
+				if let Some(crate::darling_ext::StateArg(state_ident)) = &arg.state {
+					quote! {
+						let #var = {
+							let old_state = p.set_state(State::#state_ident);
+							let result = p.parse::<#ty>()?;
+							p.set_state(old_state);
+							result
+						};
+					}
+				} else {
+					quote! { let #var = p.parse::<#ty>()?; }
+				}
 			}
-			if ty.is_option() {
-				quote! { let mut #var: #ty = None; }
-			} else {
-				quote! { let mut #var: Option<#ty> = None; }
+			FieldParseMode::AllMustOccur | FieldParseMode::OneMustOccur => {
+				let inner_ty = ty.unpack_option();
+				wc.add(&inner_ty);
+				quote! {
+					if #var.is_none() && <#inner_ty>::peek(p, c) {
+						#var = Some(p.parse::<#inner_ty>()?);
+						continue;
+					}
+				}
 			}
-		})
-		.collect();
+		}
+	}
 
-	let parse_steps: Vec<TokenStream> = split_fields
-		.iter()
-		.map(|(var, ty, arg, atom)| generate_field_parsing(var, ty, arg, atom, parse_mode, where_collector))
-		.collect();
-
-	let vars = split_fields.iter().map(|(var, _, _, _)| var);
-	let checks: Vec<TokenStream> = vars.clone().map(|var| quote! { #var.is_none() }).collect();
-	let assignments: Vec<_> = match parse_mode {
-		FieldParseMode::Sequential => unreachable!(),
-		FieldParseMode::OneMustOccur => vars.map(|var| quote! { #var }).collect(),
-		FieldParseMode::AllMustOccur => vars.map(|var| quote! { #var.unwrap() }).collect(),
-	};
-	let occurance_cond = match parse_mode {
-		FieldParseMode::Sequential => unreachable!(),
-		FieldParseMode::OneMustOccur => quote! { #(#checks)&&* },
-		FieldParseMode::AllMustOccur => quote! { #(#checks)||* },
-	};
-
-	let atom_binding_guarded = if let Some(atom_set) = atom_set_ty {
+	/// Emits the atom-conditional match arm used in must-occur loops.
+	fn atom_match_arm(&self) -> TokenStream {
+		let atom_path = self.atom.as_ref().expect("atom_match_arm called without atom").path();
+		let var = &self.var;
+		let inner_ty = self.ty.unpack_option();
 		quote! {
-			let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-				p.to_atom::<#atom_set>(c)
-			} else {
-				<#atom_set>::default()
-			};
+			if #var.is_none() && atom == #atom_path {
+				#var = Some(p.parse::<#inner_ty>()?);
+				continue;
+			}
 		}
-	} else {
-		quote! { #atom_binding }
-	};
+	}
+
+	fn binding(&self) -> TokenStream {
+		let Field { var, ty, .. } = self;
+		if ty.is_option() {
+			quote! { let mut #var: #ty = None; }
+		} else {
+			quote! { let mut #var: Option<#ty> = None; }
+		}
+	}
+
+	fn none_check(&self) -> TokenStream {
+		let v = &self.var;
+		quote! { #v.is_none() }
+	}
+
+	fn from_fields(fields: &Fields) -> Result<Vec<Self>> {
+		fields
+			.views()
+			.into_iter()
+			.zip(fields.iter())
+			.map(|(view, syn_field)| {
+				Ok(Self {
+					var: view.binding,
+					ty: view.ty.clone(),
+					arg: ParseArg::from_attributes(&syn_field.attrs)?,
+					atom: extract_atom(&syn_field.attrs)?,
+				})
+			})
+			.collect()
+	}
+
+	fn atom_path_string(&self) -> Option<String> {
+		self.atom.as_ref().map(|a| quote!(#a).to_string())
+	}
+
+	fn peek_tokens(&self) -> TokenStream {
+		let peek_ty = if self.ty.is_option() { self.ty.unpack_option() } else { self.ty.clone() };
+		if let Some(atom) = &self.atom {
+			let atom_path = atom.path();
+			let atom_set = atom.first_segment();
+			quote! { p.peek::<#peek_ty>() && p.to_atom::<#atom_set>(p.peek_n(1)) == #atom_path }
+		} else {
+			quote! { p.peek::<#peek_ty>() }
+		}
+	}
+}
+
+fn members_tokens(fields: &Fields) -> Vec<TokenStream> {
+	fields.members().map(|m| quote! { #m }).collect()
+}
+
+fn unexpected_at_next() -> TokenStream {
+	quote! { return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?; }
+}
+
+fn unexpected_at_c() -> TokenStream {
+	quote! { Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))? }
+}
+
+fn emit_peek_loop(atom_binding: TokenStream, parse_steps: TokenStream) -> TokenStream {
 	quote! {
-	  #(#bindings)*
-	  loop {
+		loop {
 			let c = p.peek_n(1);
-			#atom_binding_guarded
-			#(#parse_steps)*
+			#atom_binding
+			#parse_steps
 			break;
-	  }
-	  #post_parse_steps
-	  if #occurance_cond {
-			let c = p.peek_n(1);
-			Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-	  }
-	  return Ok(#constructor { #(#members: #assignments),* });
+		}
 	}
 }
 
 fn generate_sequential_parsing(
-	split_fields: &[(Ident, Type, ParseArg, Option<Atom>)],
-	members: Vec<TokenStream>,
+	fields: &[Field],
+	members: &[TokenStream],
 	post_parse_steps: &TokenStream,
+	constructor: TokenStream,
 	where_collector: &mut WhereCollector,
 ) -> TokenStream {
-	let parse_steps: Vec<TokenStream> = split_fields
-		.iter()
-		.map(|(var, ty, arg, atom)| {
-			generate_field_parsing(var, ty, arg, atom, FieldParseMode::Sequential, where_collector)
-		})
-		.collect();
-
-	let vars = split_fields.iter().map(|(var, _, _, _)| var);
-
+	let parse_steps = fields.iter().map(|f| f.parse_tokens(where_collector));
+	let vars = fields.iter().map(|f| &f.var);
 	quote! {
-	  #( #parse_steps )*
-	  #post_parse_steps
-	  return Ok(Self { #(#members: #vars),* });
+		#( #parse_steps )*
+		#post_parse_steps
+		return Ok(#constructor { #(#members: #vars),* });
 	}
 }
 
-pub fn derive(input: DeriveInput) -> TokenStream {
-	let mut where_collector = WhereCollector::new();
-	let ident = input.ident;
-	let generics = &input.generics;
-	let mut generic_with_alloc = generics.clone();
-	let (impl_generics, type_generics, _) = if generics.lifetimes().all(|l| l.lifetime.ident != "a") {
-		generic_with_alloc.params.insert(0, parse_quote!('a));
-		let (impl_generics, _, where_clause) = generic_with_alloc.split_for_impl();
-		let (_, type_generics, _) = generics.split_for_impl();
-		(impl_generics, type_generics, where_clause)
-	} else {
-		generic_with_alloc.split_for_impl()
-	};
-	let mut pre_parse_steps = quote! {};
-	let mut post_parse_steps = quote! {};
-	let ParseArg { state, stop, parse_mode, .. } = (&input.attrs).into();
-	if let Some(ident) = state {
-		pre_parse_steps = quote! {
-		  let state = p.set_state(State::#ident);
-		  #pre_parse_steps
-		};
-		post_parse_steps = quote! {
-		  #post_parse_steps
-		  p.set_state(state);
-		};
+fn generate_must_occur_parsing(
+	fields: &[Field],
+	members: &[TokenStream],
+	post_parse_steps: &TokenStream,
+	parse_mode: FieldParseMode,
+	constructor: TokenStream,
+	where_collector: &mut WhereCollector,
+	hoisted: &[&Ident],
+) -> TokenStream {
+	let bindings: TokenStream = fields.iter().filter(|f| !hoisted.contains(&&f.var)).map(Field::binding).collect();
+	let any_atom = fields.iter().find_map(|f| f.atom.as_ref());
+	let atom_binding = Atom::opt_binding_block(any_atom);
+
+	let parse_steps: TokenStream = fields
+		.iter()
+		.map(|f| if f.atom.is_some() { f.atom_match_arm() } else { f.parse_normal_tokens(parse_mode, where_collector) })
+		.collect();
+
+	// Add where bounds for atom fields (atom_match_arm doesn't call wc.add)
+	for f in fields.iter().filter(|f| f.atom.is_some()) {
+		where_collector.add(&f.ty.unpack_option());
 	}
-	if let Some((kind_or_kindset, ident)) = stop {
-		pre_parse_steps = if kind_or_kindset == "Kind" {
+
+	let vars = fields.iter().map(|f| &f.var);
+	let checks: Vec<_> = fields.iter().map(Field::none_check).collect();
+	let (occurance_cond, assignments): (TokenStream, Vec<TokenStream>) = match parse_mode {
+		FieldParseMode::Sequential => unreachable!(),
+		FieldParseMode::OneMustOccur => (quote! { #(#checks)&&* }, vars.map(|v| quote! { #v }).collect()),
+		FieldParseMode::AllMustOccur => (quote! { #(#checks)||* }, vars.map(|v| quote! { #v.unwrap() }).collect()),
+	};
+
+	let peek_loop = emit_peek_loop(atom_binding, parse_steps);
+	let unexpected = unexpected_at_c();
+	quote! {
+		#bindings
+		#peek_loop
+		#post_parse_steps
+		if #occurance_cond {
+			let c = p.peek_n(1);
+			#unexpected
+		}
+		return Ok(#constructor { #(#members: #assignments),* });
+	}
+}
+
+struct VariantPlan {
+	ident: Ident,
+	first_type: Type,
+	effective_atom: Option<Atom>,
+	body: TokenStream,
+	fields: Vec<Field>,
+	members: Vec<TokenStream>,
+	post_parse_steps: TokenStream,
+}
+
+impl VariantPlan {
+	fn new(variant: &Variant, post_parse_steps: &TokenStream, where_collector: &mut WhereCollector) -> Result<Self> {
+		let ident = variant.ident.clone();
+		let parse_mode = ParseArg::from_attributes(&variant.attrs)?.parse_mode();
+		let variant_atom = extract_atom(&variant.attrs)?;
+		let fields = Field::from_fields(&variant.fields)?;
+		let first_type = fields
+			.first()
+			.map(|f| f.ty.clone())
+			.ok_or_else(|| Error::new(ident.span(), "enum variant must have at least one field"))?;
+		let members = members_tokens(&variant.fields);
+
+		let body = if parse_mode == FieldParseMode::Sequential {
+			generate_sequential_parsing(&fields, &members, post_parse_steps, quote! { Self::#ident }, where_collector)
+		} else {
+			generate_must_occur_parsing(
+				&fields,
+				&members,
+				post_parse_steps,
+				parse_mode,
+				quote! { Self::#ident },
+				where_collector,
+				&[],
+			)
+		};
+
+		// Prefer variant-level atom; fall back to first field's atom except
+		// one_must_occur variants with all-optional fields dispatch by type only.
+		let effective_atom = if variant_atom.is_some() {
+			variant_atom
+		} else if parse_mode == FieldParseMode::OneMustOccur && fields.iter().all(|f| f.ty.is_option()) {
+			None
+		} else {
+			match variant.fields.iter().next() {
+				Some(f) => extract_atom(&f.attrs)?,
+				None => None,
+			}
+		};
+
+		Ok(Self {
+			ident,
+			first_type,
+			effective_atom,
+			body,
+			fields,
+			members,
+			post_parse_steps: post_parse_steps.clone(),
+		})
+	}
+
+	fn discriminator(&self, shared_atom_paths: &[String]) -> TokenStream {
+		let discriminating =
+			self.fields.iter().find(|f| f.atom_path_string().is_some_and(|ap| !shared_atom_paths.contains(&ap)));
+		if let Some(field) = discriminating {
+			return field.peek_tokens();
+		}
+
+		if let Some(field) = self.fields.iter().find(|f| f.atom.is_some()) {
+			return field.peek_tokens();
+		}
+
+		let mut peek_types = Vec::new();
+		for f in &self.fields {
+			let peek_ty = if f.ty.is_option() { f.ty.unpack_option() } else { f.ty.clone() };
+			peek_types.push(peek_ty);
+			if !f.ty.is_option() {
+				break;
+			}
+		}
+		let type_checks: Vec<TokenStream> = peek_types.iter().map(|t| quote! { p.peek::<#t>() }).collect();
+		if type_checks.len() == 1 {
+			type_checks.into_iter().next().expect("len checked")
+		} else {
+			quote! { #(#type_checks)||* }
+		}
+	}
+
+	fn body_with_hoisted(&self, hoisted: &[&Ident], where_collector: &mut WhereCollector) -> TokenStream {
+		let ident = &self.ident;
+		generate_must_occur_parsing(
+			&self.fields,
+			&self.members,
+			&self.post_parse_steps,
+			FieldParseMode::OneMustOccur,
+			quote! { Self::#ident },
+			where_collector,
+			hoisted,
+		)
+	}
+}
+
+enum GroupKind {
+	AtomDispatch,
+	PeekedFallback,
+}
+
+struct EnumVariantGroup<'a> {
+	first_type: Type,
+	kind: GroupKind,
+	variants: Vec<&'a VariantPlan>,
+	position: Position,
+}
+
+impl<'a> EnumVariantGroup<'a> {
+	fn render(&self, where_collector: &mut WhereCollector) -> TokenStream {
+		match self.kind {
+			GroupKind::AtomDispatch => self.render_atom_dispatch(),
+			GroupKind::PeekedFallback => self.render_peeked_fallback(where_collector),
+		}
+	}
+
+	fn render_atom_dispatch(&self) -> TokenStream {
+		let ty = &self.first_type;
+		let extract_atom: TokenStream = self
+			.variants
+			.first()
+			.iter()
+			.flat_map(|v| v.effective_atom.as_ref())
+			.map(|atom| atom.to_atom(format_ident!("c")))
+			.collect();
+
+		let atom_arms: TokenStream = self
+			.variants
+			.iter()
+			.map(|v| {
+				let atom_path = v.effective_atom.as_ref().expect("AtomDispatch variant must have atom").path();
+				let body = &v.body;
+				quote! { #atom_path => { #body }, }
+			})
+			.collect();
+
+		let is_last = matches!(self.position, Position::Last | Position::Only);
+		let unexpected = unexpected_at_next();
+		if is_last {
 			quote! {
-			  let stop = p.set_stop(KindSet::new(&[Kind::#ident]));
-			  #pre_parse_steps
+				if p.peek::<#ty>() {
+					let c = p.peek_n(1);
+					match #extract_atom {
+						#atom_arms
+						_ => {
+							return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
+						}
+					}
+				} else {
+					#unexpected
+				}
 			}
 		} else {
 			quote! {
-			  let stop = p.set_stop(KindSet::#ident);
-			  #pre_parse_steps
+				if p.peek::<#ty>() {
+					let c = p.peek_n(1);
+					match #extract_atom {
+						#atom_arms
+						_ => {}
+					}
+				}
+			}
+		}
+	}
+
+	fn render_peeked_fallback(&self, where_collector: &mut WhereCollector) -> TokenStream {
+		let last_idx = self.variants.len() - 1;
+		let is_outer_last = matches!(self.position, Position::Last | Position::Only);
+
+		let plan = OneMustOccurPlan::for_group(&self.variants);
+		let hoisted_bindings = plan.hoisted_bindings();
+		let hoisted_preloop = plan.hoisted_preloop();
+		let hoisted_var_names = plan.hoisted_var_names();
+
+		let variant_blocks: TokenStream = self
+			.variants
+			.iter()
+			.enumerate()
+			.map(|(idx, variant)| {
+				let is_last_variant = is_outer_last && idx == last_idx;
+
+				// Single trailing variant with no shared hoisting: emit
+				// body directly, no peek check needed.
+				if is_last_variant && idx == 0 && plan.shared_atom_paths.is_empty() {
+					let body = &variant.body;
+					return quote! { { #body } };
+				}
+
+				let type_check = variant.discriminator(&plan.shared_atom_paths);
+				let final_step = if hoisted_var_names.is_empty() {
+					variant.body.clone()
+				} else {
+					variant.body_with_hoisted(&hoisted_var_names, where_collector)
+				};
+
+				if is_last_variant {
+					let unexpected = unexpected_at_next();
+					quote! {
+						if #type_check { #final_step }
+						else { #unexpected }
+					}
+				} else {
+					quote! { if #type_check { #final_step } }
+				}
+			})
+			.collect();
+
+		quote! {
+			#hoisted_bindings
+			#hoisted_preloop
+			#variant_blocks
+		}
+	}
+}
+
+/// Hoisting plan for `one_must_occur` sibling variants that share atom fields.
+///
+/// When variants share a field with the same atom (e.g. `balance` in
+/// `[ wrap | wrap-reverse ] || balance`), we hoist it: declare the binding at
+/// group level and run a pre-loop to consume it before the variant discriminator.
+/// Per-variant bodies then reference the hoisted bindings instead of redeclaring them.
+struct OneMustOccurPlan<'a> {
+	shared_atom_paths: Vec<String>,
+	shared_fields: Vec<&'a Field>,
+}
+
+impl<'a> OneMustOccurPlan<'a> {
+	fn for_group(variants: &[&'a VariantPlan]) -> Self {
+		if variants.len() <= 1 {
+			return Self { shared_atom_paths: Vec::new(), shared_fields: Vec::new() };
+		}
+
+		let first_atoms: Vec<String> = variants[0].fields.iter().filter_map(Field::atom_path_string).collect();
+		let shared_atom_paths: Vec<String> = first_atoms
+			.into_iter()
+			.filter(|ap| {
+				variants[1..].iter().all(|v| v.fields.iter().any(|f| f.atom_path_string().as_deref() == Some(ap)))
+			})
+			.collect();
+
+		let shared_fields: Vec<&Field> = variants[0]
+			.fields
+			.iter()
+			.filter(|f| f.atom_path_string().is_some_and(|ap| shared_atom_paths.contains(&ap)))
+			.collect();
+
+		Self { shared_atom_paths, shared_fields }
+	}
+
+	fn shared_atom(&self) -> Option<&Atom> {
+		self.shared_fields.first().and_then(|f| f.atom.as_ref())
+	}
+
+	fn hoisted_var_names(&self) -> Vec<&Ident> {
+		self.shared_fields.iter().map(|f| &f.var).collect()
+	}
+
+	fn hoisted_bindings(&self) -> TokenStream {
+		self.shared_fields.iter().map(|f| f.binding()).collect()
+	}
+
+	fn hoisted_preloop(&self) -> TokenStream {
+		let Some(atom) = self.shared_atom() else {
+			return TokenStream::new();
+		};
+		let parse_steps: TokenStream = self.shared_fields.iter().map(|f| f.atom_match_arm()).collect();
+		let atom_binding = atom.binding_block();
+		emit_peek_loop(atom_binding, parse_steps)
+	}
+}
+
+fn derive_struct_body(
+	data: &DataStruct,
+	parse_mode: FieldParseMode,
+	post_parse_steps: &TokenStream,
+	where_collector: &mut WhereCollector,
+) -> Result<TokenStream> {
+	let fields = Field::from_fields(&data.fields)?;
+	let members = members_tokens(&data.fields);
+	Ok(if parse_mode == FieldParseMode::Sequential {
+		generate_sequential_parsing(&fields, &members, post_parse_steps, quote! { Self }, where_collector)
+	} else {
+		generate_must_occur_parsing(
+			&fields,
+			&members,
+			post_parse_steps,
+			parse_mode,
+			quote! { Self },
+			where_collector,
+			&[],
+		)
+	})
+}
+
+fn derive_enum_body(
+	data: &DataEnum,
+	post_parse_steps: &TokenStream,
+	where_collector: &mut WhereCollector,
+) -> Result<TokenStream> {
+	let plans: Vec<VariantPlan> =
+		data.variants.iter().map(|v| VariantPlan::new(v, post_parse_steps, where_collector)).collect::<Result<_>>()?;
+
+	// Group by (first-field type, has-effective-atom). No-atom variants get their
+	// own peeked-fallback group, after any atom-dispatch group for the same type.
+	let grouped = plans
+		.iter()
+		.sorted_by_key(|p| {
+			let ty = &p.first_type;
+			(quote!(#ty).to_string(), p.effective_atom.is_none())
+		})
+		.chunk_by(|p| {
+			let ty = &p.first_type;
+			(quote!(#ty).to_string(), p.effective_atom.is_none())
+		});
+
+	let ts = grouped
+		.into_iter()
+		.with_position()
+		.map(|(position, ((_type_str, no_atom), group))| {
+			let variants: Vec<&VariantPlan> = group.collect();
+			let first_type = variants[0].first_type.clone();
+			let kind = if no_atom { GroupKind::PeekedFallback } else { GroupKind::AtomDispatch };
+			let group = EnumVariantGroup { first_type, kind, variants, position };
+			Ok(group.render(where_collector))
+		})
+		.collect::<Result<TokenStream>>()?;
+	Ok(ts)
+}
+
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
+	let mut where_collector = WhereCollector::new();
+	let ident = input.ident;
+	let generics = &input.generics;
+	let generic_with_a = ensure_lifetime_a(generics);
+	let (impl_generics, _, _) = generic_with_a.split_for_impl();
+	let (_, type_generics, _) = generics.split_for_impl();
+
+	let mut pre_parse_steps = quote! {};
+	let mut post_parse_steps = quote! {};
+	let parse_arg = ParseArg::from_attributes(&input.attrs)?;
+	let parse_mode = parse_arg.parse_mode();
+	if let Some(crate::darling_ext::StateArg(state_ident)) = parse_arg.state {
+		pre_parse_steps = quote! {
+			let state = p.set_state(State::#state_ident);
+			#pre_parse_steps
+		};
+		post_parse_steps = quote! {
+			#post_parse_steps
+			p.set_state(state);
+		};
+	}
+	if let Some(stop) = parse_arg.stop {
+		let kind_ident = &stop.variant;
+		pre_parse_steps = if stop.prefix == "Kind" {
+			quote! {
+				let stop = p.set_stop(KindSet::new(&[Kind::#kind_ident]));
+				#pre_parse_steps
+			}
+		} else {
+			quote! {
+				let stop = p.set_stop(KindSet::#kind_ident);
+				#pre_parse_steps
 			}
 		};
 		post_parse_steps = quote! {
-		  #post_parse_steps
-		  p.set_stop(stop);
+			#post_parse_steps
+			p.set_stop(stop);
 		};
 	}
 
 	let body = match &input.data {
-		Data::Union(_) => return err(ident.span(), "Cannot derive Parse on a Union"),
-
-		Data::Struct(DataStruct { fields, .. }) => {
-			let members = fields.members();
-			let split_fields = fields.to_vars_and_types();
-			let members: Vec<TokenStream> = members.into_iter().map(|m| quote! { #m }).collect();
-			if parse_mode == FieldParseMode::Sequential {
-				generate_sequential_parsing(&split_fields, members, &post_parse_steps, &mut where_collector)
-			} else {
-				generate_must_occur_parsing(
-					&split_fields,
-					members,
-					&post_parse_steps,
-					parse_mode,
-					quote! { Self },
-					&mut where_collector,
-				)
-			}
-		}
-		Data::Enum(DataEnum { variants, .. }) => {
-			let variant_data: Vec<_> = variants
-				.iter()
-				.map(|variant| {
-					let variant_ident = &variant.ident;
-					let ParseArg { parse_mode, .. } = (&variant.attrs).into();
-					let atom = extract_atom(&variant.attrs);
-					let members = variant.fields.members();
-					let split_fields = variant.fields.to_vars_and_types();
-					let first_type = split_fields
-						.first()
-						.map(|(_, ty, _, _)| ty.clone())
-						.expect("Field has to have at least one type!");
-					let members: Vec<TokenStream> = members.into_iter().map(|m| quote! { #m }).collect();
-
-					let step = if parse_mode == FieldParseMode::Sequential {
-						let parse_steps: Vec<TokenStream> = split_fields
-							.iter()
-							.map(|(var, ty, arg, atom)| {
-								generate_field_parsing(
-									var,
-									ty,
-									arg,
-									atom,
-									FieldParseMode::Sequential,
-									&mut where_collector,
-								)
-							})
-							.collect();
-						let vars = split_fields.iter().map(|(var, _, _, _)| var);
-						quote! {
-						  #( #parse_steps )*
-						  #post_parse_steps
-						  return Ok(Self::#variant_ident { #(#members: #vars),* });
-						}
-					} else {
-						let constructor = quote! { Self::#variant_ident };
-						generate_must_occur_parsing(
-							&split_fields,
-							members.clone(),
-							&post_parse_steps,
-							parse_mode,
-							constructor,
-							&mut where_collector,
-						)
-					};
-
-					let effective_atom = if let Some(variant_atom) = atom {
-						Some(variant_atom)
-					} else if parse_mode == FieldParseMode::OneMustOccur
-						&& split_fields.iter().all(|(_, ty, _, _)| ty.is_option())
-					{
-						None
-					} else {
-						variant.fields.iter().next().and_then(|field| extract_atom(&field.attrs))
-					};
-
-					// Store variant_ident, members, parse_mode alongside so the sibling block can
-					// regenerate steps with hoisted vars when needed.
-					let variant_ident_ts = quote! { #variant_ident };
-					(first_type, effective_atom, step, split_fields, variant_ident_ts, members, parse_mode)
-				})
-				.collect();
-
-			// Group by first type and atom status to separate atom variants from non-atom variants of the same type
-			let grouped_variants = variant_data
-				.into_iter()
-				.sorted_by_key(|(ty, atom, _, _, _, _, _)| (quote!(#ty).to_string(), atom.is_none()))
-				.chunk_by(|(ty, atom, _, _, _, _, _)| (quote!(#ty).to_string(), atom.is_none()));
-
-			{
-				grouped_variants
-					.into_iter()
-					.with_position()
-					.map(|(pos, ((type_str, is_atom_group), group))| {
-						let ty: Type = syn::parse_str(&type_str).unwrap();
-						let variants: Vec<_> = group.collect();
-
-						if !is_atom_group {
-							let extract_atom: TokenStream = variants
-								.first()
-								.iter()
-								.flat_map(|(_, atom, _, _, _, _, _)| atom)
-								.map(|atom| atom.to_atom(format_ident!("c")))
-								.collect();
-							let atom_checks: TokenStream = variants
-								.into_iter()
-								.map(|(_, atom, step, _, _, _, _)| {
-									let atom = atom.unwrap();
-									let atom_path = atom.path();
-									quote! { #atom_path => { #step }, }
-								})
-								.collect();
-
-							let type_check = quote! { p.peek::<#ty>() };
-							if matches!(pos, Position::Last | Position::Only) {
-								quote! {
-									if #type_check {
-										let c = p.peek_n(1);
-										match #extract_atom {
-											#atom_checks
-											_ => {
-												return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
-											}
-										}
-									} else {
-										return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?;
-									}
-								}
-							} else {
-								quote! {
-									if #type_check {
-										let c = p.peek_n(1);
-										match #extract_atom {
-											#atom_checks
-											_ => {}
-										}
-									}
-								}
-							}
-				} else {
-					let variants: Vec<_> = variants.into_iter().collect();
-					let last_idx = variants.len() - 1;
-
-					// For multiple sibling one_must_occur variants, hoist fields whose atoms
-					// appear in every variant so they can be parsed before the discriminator
-					// (enabling orderings like `balance wrap` and `balance wrap-reverse`).
-					let shared_atom_paths: Vec<String> = if variants.len() > 1 {
-						let first_atoms: Vec<String> = variants[0]
-							.3
-							.iter()
-							.filter_map(|(_, _, _, atom)| atom.as_ref().map(|a| quote!(#a).to_string()))
-							.collect();
-						first_atoms
-							.into_iter()
-							.filter(|ap| {
-								variants[1..].iter().all(|(_, _, _, sf, _, _, _)| {
-									sf.iter().any(|(_, _, _, a)| a.as_ref().map(|a| quote!(#a).to_string()).as_deref() == Some(ap))
-								})
-							})
-							.collect()
-					} else {
-						vec![]
-					};
-
-					// Build hoisted binding declarations and pre-loop for shared fields.
-					// Use first variant's split_fields as representative (all share these atoms).
-					let hoisted_var_names: Vec<&Ident> = variants[0]
-						.3
-						.iter()
-						.filter(|(_, _, _, atom)| {
-							atom.as_ref().map(|a| shared_atom_paths.contains(&quote!(#a).to_string())).unwrap_or(false)
-						})
-						.map(|(var, _, _, _)| var)
-						.collect();
-
-					let hoisted_bindings: TokenStream = variants[0]
-						.3
-						.iter()
-						.filter(|(_, _, _, atom)| {
-							atom.as_ref().map(|a| shared_atom_paths.contains(&quote!(#a).to_string())).unwrap_or(false)
-						})
-						.map(|(var, ty, _, _)| {
-							if ty.is_option() {
-								quote! { let mut #var: #ty = None; }
-							} else {
-								quote! { let mut #var: Option<#ty> = None; }
-							}
-						})
-						.collect();
-
-					let hoisted_preloop: TokenStream = if !shared_atom_paths.is_empty() {
-						let atom_set = variants[0]
-							.3
-							.iter()
-							.find_map(|(_, _, _, atom)| {
-								atom.as_ref().filter(|a| shared_atom_paths.contains(&quote!(#a).to_string())).map(|a| a.first_segment().clone())
-							});
-						let parse_steps: Vec<TokenStream> = variants[0]
-							.3
-							.iter()
-							.filter(|(_, _, _, atom)| {
-								atom.as_ref().map(|a| shared_atom_paths.contains(&quote!(#a).to_string())).unwrap_or(false)
-							})
-							.map(|(var, ty, _, atom)| {
-								let atom_path = atom.as_ref().unwrap().path();
-								let inner_ty = ty.unpack_option();
-								quote! {
-									if #var.is_none() && atom == #atom_path {
-										#var = Some(p.parse::<#inner_ty>()?);
-										continue;
-									}
-								}
-							})
-							.collect();
-						if let Some(atom_set) = atom_set {
-							quote! {
-								loop {
-									let c = p.peek_n(1);
-									let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-										p.to_atom::<#atom_set>(c)
-									} else {
-										<#atom_set>::default()
-									};
-									#(#parse_steps)*
-									break;
-								}
-							}
-						} else {
-							quote! {}
-						}
-					} else {
-						quote! {}
-					};
-
-					let variant_steps: TokenStream = variants
-						.iter()
-						.enumerate()
-						.map(|(idx, (_, _, _step, split_fields, variant_ident_ts, members, _parse_mode))| {
-							let is_last_variant = matches!(pos, Position::Last | Position::Only) && idx == last_idx;
-							if is_last_variant && idx == 0 && shared_atom_paths.is_empty() {
-								// Single variant, last in outer sequence, no hoisting needed
-								quote! { { #_step } }
-							} else {
-								// Find discriminating atom: first atom NOT in shared set
-								let discriminating_field = split_fields.iter().find(|(_, _, _, atom)| {
-									atom.as_ref().map(|a| !shared_atom_paths.contains(&quote!(#a).to_string())).unwrap_or(false)
-								});
-								let type_check = if let Some((_, field_ty, _, Some(atom))) = discriminating_field {
-									let peek_ty =
-										if field_ty.is_option() { field_ty.unpack_option() } else { field_ty.clone() };
-									let atom_path = atom.path();
-									let atom_set = atom.first_segment();
-									quote! { p.peek::<#peek_ty>() && p.to_atom::<#atom_set>(p.peek_n(1)) == #atom_path }
-								} else if let Some((_, field_ty, _, Some(atom))) = split_fields.iter().find(|(_, _, _, atom)| atom.is_some()) {
-									// All fields are shared; fall back to first atom field (single variant case)
-									let peek_ty =
-										if field_ty.is_option() { field_ty.unpack_option() } else { field_ty.clone() };
-									let atom_path = atom.path();
-									let atom_set = atom.first_segment();
-									quote! { p.peek::<#peek_ty>() && p.to_atom::<#atom_set>(p.peek_n(1)) == #atom_path }
-								} else {
-									// Fallback: peek all types up to and including first non-optional
-									let mut peek_types = Vec::new();
-									for (_, field_ty, _, _) in split_fields {
-										let peek_ty = if field_ty.is_option() {
-											field_ty.unpack_option()
-										} else {
-											field_ty.clone()
-										};
-										peek_types.push(peek_ty);
-										if !field_ty.is_option() {
-											break;
-										}
-									}
-									let type_checks: Vec<TokenStream> =
-										peek_types.iter().map(|t| quote! { p.peek::<#t>() }).collect();
-									if type_checks.len() == 1 {
-										type_checks.into_iter().next().unwrap()
-									} else {
-										quote! { #(#type_checks)||* }
-									}
-								};
-
-								let final_step: TokenStream = if hoisted_var_names.is_empty() {
-									quote! { #_step }
-								} else {
-									// Regenerate step excluding hoisted binding declarations.
-									// Hoisted vars are already in scope from outer bindings.
-									let atom_set = split_fields.iter().find_map(|(_, _, _, atom)| {
-										atom.as_ref().map(|a| a.first_segment().clone())
-									});
-									let non_hoisted_bindings: Vec<TokenStream> = split_fields
-										.iter()
-										.filter(|(var, _, _, _)| !hoisted_var_names.contains(&var))
-										.map(|(var, ty, _, _)| {
-											if ty.is_option() {
-												quote! { let mut #var: #ty = None; }
-											} else {
-												quote! { let mut #var: Option<#ty> = None; }
-											}
-										})
-										.collect();
-									let loop_parse_steps: Vec<TokenStream> = split_fields
-										.iter()
-										.map(|(var, ty, _, atom)| {
-											if let Some(atom) = atom {
-												let atom_path = atom.path();
-												let inner_ty = ty.unpack_option();
-												quote! {
-													if #var.is_none() && atom == #atom_path {
-														#var = Some(p.parse::<#inner_ty>()?);
-														continue;
-													}
-												}
-											} else {
-												quote! {}
-											}
-										})
-										.collect();
-									let all_vars: Vec<&Ident> = split_fields.iter().map(|(v, _, _, _)| v).collect();
-									let all_checks: Vec<TokenStream> = all_vars.iter().map(|v| quote! { #v.is_none() }).collect();
-									let all_assignments: Vec<TokenStream> = all_vars.iter().map(|v| quote! { #v }).collect();
-									let atom_binding_guarded = if let Some(atom_set) = atom_set {
-										quote! {
-											let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-												p.to_atom::<#atom_set>(c)
-											} else {
-												<#atom_set>::default()
-											};
-										}
-									} else {
-										quote! {}
-									};
-									quote! {
-										#(#non_hoisted_bindings)*
-										loop {
-											let c = p.peek_n(1);
-											#atom_binding_guarded
-											#(#loop_parse_steps)*
-											break;
-										}
-										if #(#all_checks)&&* {
-											let c = p.peek_n(1);
-											Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-										}
-										return Ok(Self::#variant_ident_ts { #(#members: #all_assignments),* });
-									}
-								};
-
-								if is_last_variant {
-									quote! { if #type_check { #final_step } else { return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?; } }
-								} else {
-									quote! { if #type_check { #final_step } }
-								}
-							}
-						})
-						.collect();
-
-					quote! {
-						#hoisted_bindings
-						#hoisted_preloop
-						#variant_steps
-					}
-				}
-					})
-					.collect()
-			}
-		}
+		Data::Union(_) => return Err(Error::new(ident.span(), "Cannot derive Parse on a Union")),
+		Data::Struct(data) => derive_struct_body(data, parse_mode, &post_parse_steps, &mut where_collector)?,
+		Data::Enum(data) => derive_enum_body(data, &post_parse_steps, &mut where_collector)?,
 	};
 
-	let mut generics = input.generics.clone();
-	let where_clause = where_collector.extend_where_clause(&mut generics, parse_quote! { ::css_parse::Parse<'a> });
+	let generics = input.generics.clone();
+	let where_clause = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::Parse<'a> });
 
-	quote! {
-	  #[automatically_derived]
-	  impl #impl_generics ::css_parse::Parse<'a> for #ident #type_generics #where_clause {
-		fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
-		where
-			I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
-		{
-		  use css_parse::{Parse, Peek};
-			#pre_parse_steps
-		  #body
+	Ok(quote! {
+		#[automatically_derived]
+		impl #impl_generics ::css_parse::Parse<'a> for #ident #type_generics #where_clause {
+			fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
+			where
+				I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+			{
+				use css_parse::{Parse, Peek};
+				#pre_parse_steps
+				#body
+			}
 		}
-	  }
-	}
+	})
 }

--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -1,29 +1,15 @@
 use crate::{
-	WhereCollector,
+	FieldsExt, WhereCollector,
 	attributes::{Atom, extract_atom},
-	err,
+	ensure_lifetime_a,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, GenericArgument, PathArguments, Type, parse_quote};
-
-/// If `ty` is `Option<T>`, return `Some(T)`. Otherwise `None`.
-fn option_inner(ty: &Type) -> Option<&Type> {
-	if let Type::Path(path) = ty
-		&& let Some(seg) = path.path.segments.last()
-		&& seg.ident == "Option"
-		&& let PathArguments::AngleBracketed(args) = &seg.arguments
-		&& let Some(GenericArgument::Type(inner)) = args.args.first()
-	{
-		return Some(inner);
-	}
-	None
-}
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Result, Type, parse_quote};
 
 fn generate_field_peek(ty: &Type, atom: &Option<Atom>, where_collector: &mut WhereCollector) -> TokenStream {
 	where_collector.add(ty);
 	if let Some(atom) = atom {
-		// For atom fields, check both the type AND the atom
 		let atom_path = atom.path();
 		quote! { (<#ty>::peek(p, c) && p.equals_atom(c.into(), &#atom_path)) }
 	} else {
@@ -31,81 +17,50 @@ fn generate_field_peek(ty: &Type, atom: &Option<Atom>, where_collector: &mut Whe
 	}
 }
 
-pub fn derive(input: DeriveInput) -> TokenStream {
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let mut where_collector = WhereCollector::new();
 	let ident = input.ident;
 	let generics = &input.generics;
-	let mut generic_with_alloc = generics.clone();
-	let (impl_generics, type_generics, _) = if generics.lifetimes().all(|l| l.lifetime.ident != "a") {
-		generic_with_alloc.params.insert(0, parse_quote!('a));
-		let (impl_generics, _, where_clause) = generic_with_alloc.split_for_impl();
-		let (_, type_generics, _) = generics.split_for_impl();
-		(impl_generics, type_generics, where_clause)
-	} else {
-		// If 'a lifetime already exists, we already added the bounds to generic_with_alloc
-		generic_with_alloc.split_for_impl()
-	};
+	let generic_with_a = ensure_lifetime_a(generics);
+	let (impl_generics, _, _) = generic_with_a.split_for_impl();
+	let (_, type_generics, _) = generics.split_for_impl();
 	let body = match input.data {
-		Data::Union(_) => err(ident.span(), "Cannot derive Peek on a Union"),
+		Data::Union(_) => return Err(Error::new(ident.span(), "Cannot derive Peek on a Union")),
 
 		Data::Struct(DataStruct { fields, .. }) => {
-			// For structs, peek the first required field. If leading fields are Option<T>,
-			// include those inner types OR'd with the next field, until a required field.
 			let mut checks: Vec<TokenStream> = vec![];
-			let mut found_required = false;
-			for field in fields.iter() {
-				let ty = match &field.ty {
-					Type::Reference(refty) => refty.elem.as_ref(),
-					ty => ty,
-				};
-				if let Some(inner) = option_inner(ty) {
-					// Optional field: peek its inner type as a possibility
-					let atom = extract_atom(&field.attrs);
-					checks.push(generate_field_peek(inner, &atom, &mut where_collector));
-				} else {
-					// Required field: peek it and stop
-					let atom = extract_atom(&field.attrs);
-					checks.push(generate_field_peek(ty, &atom, &mut where_collector));
-					found_required = true;
+			for (view, syn_field) in fields.views().into_iter().zip(fields.iter()) {
+				let atom = extract_atom(&syn_field.attrs)?;
+				checks.push(generate_field_peek(view.ty, &atom, &mut where_collector));
+				if !view.is_option {
 					break;
 				}
-			}
-			if !found_required && checks.is_empty() {
-				// All fields are optional (or no fields) - fall back to first field peek
-				let field = fields.iter().next().unwrap();
-				let ty = match &field.ty {
-					Type::Reference(refty) => refty.elem.as_ref(),
-					ty => ty,
-				};
-				let atom = extract_atom(&field.attrs);
-				checks.push(generate_field_peek(ty, &atom, &mut where_collector));
 			}
 			quote! { #(#checks)||* }
 		}
 
 		Data::Enum(DataEnum { variants, .. }) => {
-			let type_checks = variants.iter().filter_map(|variant| {
-				// Skip variants that have atoms - they'll be handled by atom matching
-				let mut atom = extract_atom(&variant.attrs);
-				if let Some(field) = variant.fields.iter().next() {
-					let ty = match &field.ty {
-						Type::Reference(refty) => refty.elem.as_ref(),
-						ty => ty,
-					};
-					atom = atom.or_else(|| extract_atom(&field.attrs));
-					Some(generate_field_peek(ty, &atom, &mut where_collector))
-				} else {
-					None
-				}
-			});
+			let mut type_checks: Vec<TokenStream> = vec![];
+			for variant in variants.iter() {
+				let views = variant.fields.views();
+				let Some((view, syn_field)) = views.first().zip(variant.fields.iter().next()) else {
+					continue;
+				};
+				let atom = match extract_atom(&variant.attrs)? {
+					Some(a) => Some(a),
+					None => extract_atom(&syn_field.attrs)?,
+				};
+				// Use raw ty (including Option<T> if present) to preserve original behaviour.
+				type_checks.push(generate_field_peek(view.ty, &atom, &mut where_collector));
+			}
 			quote! { #(#type_checks)||* }
 		}
 	};
 
-	let mut generics = input.generics.clone();
-	let where_clause = where_collector.extend_where_clause(&mut generics, parse_quote! { ::css_parse::Peek<'a> });
+	let generics = input.generics.clone();
+	let where_clause = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::Peek<'a> });
 
-	quote! {
+	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics ::css_parse::Peek<'a> for #ident #type_generics #where_clause {
 			fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
@@ -116,5 +71,5 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 				#body
 			}
 		}
-	}
+	})
 }

--- a/crates/csskit_derives/src/semantic_eq.rs
+++ b/crates/csskit_derives/src/semantic_eq.rs
@@ -1,118 +1,95 @@
-use crate::{WhereCollector, err};
-use proc_macro2::{Span, TokenStream};
+use crate::WhereCollector;
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Index, parse_quote};
+use syn::{Data, DeriveInput, Error, Fields, Result, parse_quote};
+use synstructure::{AddBounds, BindStyle, Structure};
 
-pub fn derive(input: DeriveInput) -> TokenStream {
-	let mut where_collector = WhereCollector::new();
-	let ident = input.ident;
-	let generics = input.generics.clone();
-	let (impl_generics, type_generics, _) = generics.split_for_impl();
-	let body = match input.data {
-		Data::Struct(DataStruct { fields: Fields::Unnamed(fields), .. }) => {
-			let steps: Vec<TokenStream> = fields
-				.unnamed
-				.into_iter()
-				.enumerate()
-				.map(|(i, field)| {
-					let index = Index { index: i as u32, span: Span::call_site() };
-					where_collector.add(&field.ty);
-					quote! {
-						self.#index.semantic_eq(&other.#index)
-					}
-				})
-				.collect();
-			quote! { #(#steps)&&* }
+fn structure_with_prefix<'a>(input: &'a DeriveInput, prefix: &'static str) -> Result<Structure<'a>> {
+	let mut s = Structure::try_new(input)?;
+	s.add_bounds(AddBounds::None);
+	s.bind_with(|_| BindStyle::Move);
+	s.binding_name(move |field, i| match &field.ident {
+		Some(name) => format_ident!("{prefix}_{name}"),
+		None => format_ident!("{prefix}{i}"),
+	});
+	Ok(s)
+}
+
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
+	if let Data::Struct(ref s) = input.data
+		&& matches!(s.fields, Fields::Unit)
+	{
+		return Err(Error::new(input.ident.span(), "Cannot derive SemanticEq on this struct"));
+	}
+	if matches!(input.data, Data::Union(_)) {
+		return Err(Error::new(input.ident.span(), "Cannot derive SemanticEq on a Union"));
+	}
+
+	let s_a = structure_with_prefix(&input, "a")?;
+	let s_b = structure_with_prefix(&input, "b")?;
+
+	let mut wc = WhereCollector::new();
+	for variant in s_a.variants() {
+		for bi in variant.bindings() {
+			wc.add(&bi.ast().ty);
 		}
+	}
 
-		Data::Struct(DataStruct { fields: Fields::Named(fields), .. }) => {
-			let steps: Vec<TokenStream> = fields
-				.named
-				.into_iter()
-				.map(|f| {
-					let ident = f.ident.expect("Named field");
-					where_collector.add(&f.ty);
-					quote! {
-						self.#ident.semantic_eq(&other.#ident)
-					}
-				})
-				.collect();
-			quote! { #(#steps)&&* }
+	let ident = &input.ident;
+	let (impl_generics, type_generics, _) = input.generics.split_for_impl();
+
+	let body = if matches!(input.data, Data::Struct(_)) {
+		let steps: Vec<TokenStream> = s_a.variants()[0]
+			.bindings()
+			.iter()
+			.zip(s_b.variants()[0].bindings().iter())
+			.map(|(a, b)| {
+				let a_name = &a.binding;
+				let b_name = &b.binding;
+				quote! { #a_name.semantic_eq(&#b_name) }
+			})
+			.collect();
+		let a_pat = s_a.variants()[0].pat();
+		let b_pat = s_b.variants()[0].pat();
+		let body = steps.into_iter().reduce(|acc, item| quote! { #acc && #item }).unwrap_or_default();
+		quote! {
+			let #a_pat = self;
+			let #b_pat = other;
+			#body
 		}
-
-		Data::Struct(_) => err(ident.span(), "Cannot derive SemanticEq on this struct"),
-
-		Data::Union(_) => err(ident.span(), "Cannot derive SemanticEq on a Union"),
-
-		Data::Enum(DataEnum { variants, .. }) => {
-			let mut steps = vec![];
-			for var in variants {
-				let var_ident = var.ident;
-				match var.fields {
-					Fields::Named(fields) => {
-						let a_idents: Vec<_> =
-							fields.named.iter().map(|f| format_ident!("a_{}", f.ident.as_ref().unwrap())).collect();
-						let b_idents: Vec<_> =
-							fields.named.iter().map(|f| format_ident!("b_{}", f.ident.as_ref().unwrap())).collect();
-						let field_names: Vec<_> =
-							fields.named.iter().map(|f| f.ident.as_ref().unwrap().clone()).collect();
-						let field_steps: Vec<_> = fields
-							.named
-							.iter()
-							.zip(a_idents.iter().zip(b_idents.iter()))
-							.map(|(field, (a_ident, b_ident))| {
-								where_collector.add(&field.ty);
-								quote! { #a_ident.semantic_eq(&#b_ident) }
-							})
-							.collect();
-						let a_pats =
-							field_names.iter().zip(a_idents.iter()).map(|(fname, aname)| quote! { #fname: #aname });
-						let b_pats =
-							field_names.iter().zip(b_idents.iter()).map(|(fname, bname)| quote! { #fname: #bname });
-						let body = if field_steps.is_empty() {
-							quote! { true }
-						} else {
-							quote! { #(#field_steps)&&* }
-						};
-						steps.push(quote! {
-							(Self::#var_ident { #(#a_pats),* }, Self::#var_ident { #(#b_pats),* }) => { #body }
-						});
-					}
-					_ => {
-						let mut a_idents = vec![];
-						let mut b_idents = vec![];
-						let field_steps: Vec<_> = var
-							.fields
-							.into_iter()
-							.enumerate()
-							.map(|(i, field)| {
-								where_collector.add(&field.ty);
-								let a_ident = format_ident!("a{}", i);
-								a_idents.push(a_ident.clone());
-								let b_ident = format_ident!("b{}", i);
-								b_idents.push(b_ident.clone());
-								quote! { #a_ident.semantic_eq(&#b_ident) }
-							})
-							.collect();
-						steps.push(quote! {
-							(Self::#var_ident(#(#a_idents),*), Self::#var_ident(#(#b_idents),*)) => { #(#field_steps)&&* }
-						});
-					}
-				}
-			}
-			quote! {
-				match (self, other) {
-					#(#steps),*
-					_ => false,
-				}
+	} else {
+		let arms: TokenStream = s_a
+			.variants()
+			.iter()
+			.zip(s_b.variants().iter())
+			.map(|(va, vb)| {
+				let a_pat = va.pat();
+				let b_pat = vb.pat();
+				let steps: Vec<TokenStream> = va
+					.bindings()
+					.iter()
+					.zip(vb.bindings().iter())
+					.map(|(a, b)| {
+						let a_name = &a.binding;
+						let b_name = &b.binding;
+						quote! { #a_name.semantic_eq(&#b_name) }
+					})
+					.collect();
+				let body = steps.into_iter().reduce(|acc, item| quote! { #acc && #item }).unwrap_or(quote! { true });
+				quote! { (#a_pat, #b_pat) => { #body } }
+			})
+			.collect();
+		quote! {
+			match (self, other) {
+				#arms
+				_ => false,
 			}
 		}
 	};
 
-	let mut generics = input.generics.clone();
-	let where_clause = where_collector.extend_where_clause(&mut generics, parse_quote! { ::css_parse::SemanticEq });
+	let where_clause = wc.extend_where_clause(&input.generics, parse_quote! { ::css_parse::SemanticEq });
 
-	quote! {
+	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics ::css_parse::SemanticEq for #ident #type_generics #where_clause {
 			fn semantic_eq(&self, other: &Self) -> bool {
@@ -120,5 +97,5 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 				#body
 			}
 		}
-	}
+	})
 }

--- a/crates/csskit_derives/src/test/mod.rs
+++ b/crates/csskit_derives/src/test/mod.rs
@@ -13,3 +13,14 @@ macro_rules! to_deriveinput {
 }
 #[cfg(test)]
 pub(crate) use to_deriveinput;
+
+macro_rules! assert_derive_snapshot {
+	( $derive_fn:path, $data:ident, $name:literal) => {
+		let tokens = $derive_fn($data).expect("derive failed");
+		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
+		let pretty = ::prettyplease::unparse(&file);
+		::insta::assert_snapshot!($name, pretty)
+	};
+}
+#[cfg(test)]
+pub(crate) use assert_derive_snapshot;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
@@ -13,16 +13,16 @@ where
     {
         use css_parse::{Parse, Peek};
         if p.peek::<T>() {
-            let f0 = p.parse::<Option<T>>()?;
-            return Ok(Self::Optional { 0: f0 });
+            let v0 = p.parse::<Option<T>>()?;
+            return Ok(Self::Optional { 0: v0 });
         }
         if p.peek::<T>() {
-            let f0 = p.parse::<T>()?;
-            return Ok(Self::Single { 0: f0 });
+            let v0 = p.parse::<T>()?;
+            return Ok(Self::Single { 0: v0 });
         }
         {
-            let f0 = p.parse::<Vec<T>>()?;
-            return Ok(Self::Multiple { 0: f0 });
+            let v0 = p.parse::<Vec<T>>()?;
+            return Ok(Self::Multiple { 0: v0 });
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_and_tuple_mixed.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_and_tuple_mixed.snap
@@ -10,12 +10,12 @@ impl<'a> ::css_parse::Parse<'a> for FlexValue {
     {
         use css_parse::{Parse, Peek};
         if p.peek::<Ident>() {
-            let f0 = p.parse::<Ident>()?;
-            return Ok(Self::Auto { 0: f0 });
+            let v0 = p.parse::<Ident>()?;
+            return Ok(Self::Auto { 0: v0 });
         }
         if p.peek::<Length>() {
-            let f0 = p.parse::<Length>()?;
-            return Ok(Self::Length { 0: f0 });
+            let v0 = p.parse::<Length>()?;
+            return Ok(Self::Length { 0: v0 });
         }
         if p.peek::<Length>() {
             let min = p.parse::<Length>()?;
@@ -23,8 +23,8 @@ impl<'a> ::css_parse::Parse<'a> for FlexValue {
             return Ok(Self::MinMax { min: min, max: max });
         }
         if p.peek::<Percentage>() {
-            let f0 = p.parse::<Percentage>()?;
-            return Ok(Self::Percentage { 0: f0 });
+            let v0 = p.parse::<Percentage>()?;
+            return Ok(Self::Percentage { 0: v0 });
         }
         {
             let expr = p.parse::<String>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
@@ -13,8 +13,8 @@ impl<'a> ::css_parse::Parse<'a> for FlexWrap {
             let c = p.peek_n(1);
             match p.to_atom::<FooAtoms>(c) {
                 FooAtoms::Nowrap => {
-                    let f0 = p.parse::<Ident>()?;
-                    return Ok(Self::Nowrap { 0: f0 });
+                    let v0 = p.parse::<Ident>()?;
+                    return Ok(Self::Nowrap { 0: v0 });
                 }
                 _ => {}
             }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
@@ -13,8 +13,8 @@ impl<'a> ::css_parse::Parse<'a> for FlexWrap {
             let c = p.peek_n(1);
             match p.to_atom::<FooAtoms>(c) {
                 FooAtoms::Nowrap => {
-                    let f0 = p.parse::<Ident>()?;
-                    return Ok(Self::Nowrap { 0: f0 });
+                    let v0 = p.parse::<Ident>()?;
+                    return Ok(Self::Nowrap { 0: v0 });
                 }
                 _ => {}
             }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
@@ -51,8 +51,8 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurEnum {
             }
         }
         {
-            let f0 = p.parse::<String>()?;
-            return Ok(Self::Simple { 0: f0 });
+            let v0 = p.parse::<String>()?;
+            return Ok(Self::Simple { 0: v0 });
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
@@ -34,8 +34,8 @@ impl<'a> ::css_parse::Parse<'a> for Value {
             });
         }
         {
-            let f0 = p.parse::<String>()?;
-            return Ok(Self::Normal { 0: f0 });
+            let v0 = p.parse::<String>()?;
+            return Ok(Self::Normal { 0: v0 });
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
@@ -33,8 +33,8 @@ impl<'a> ::css_parse::Parse<'a> for TestEnum {
             }
         }
         {
-            let f0 = p.parse::<String>()?;
-            return Ok(Self::Normal { 0: f0 });
+            let v0 = p.parse::<String>()?;
+            return Ok(Self::Normal { 0: v0 });
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
@@ -13,12 +13,12 @@ impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
             let c = p.peek_n(1);
             match p.to_atom::<Keyword>(c) {
                 Keyword::Foo => {
-                    let f0 = p.parse::<Ident>()?;
-                    return Ok(Self::Foo { 0: f0 });
+                    let v0 = p.parse::<Ident>()?;
+                    return Ok(Self::Foo { 0: v0 });
                 }
                 Keyword::Bar => {
-                    let f0 = p.parse::<Ident>()?;
-                    return Ok(Self::Bar { 0: f0 });
+                    let v0 = p.parse::<Ident>()?;
+                    return Ok(Self::Bar { 0: v0 });
                 }
                 _ => {
                     return Err(

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
@@ -13,19 +13,19 @@ impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
             let c = p.peek_n(1);
             match p.to_atom::<Keyword>(c) {
                 Keyword::Foo => {
-                    let f0 = p.parse::<Ident>()?;
-                    return Ok(Self::Foo { 0: f0 });
+                    let v0 = p.parse::<Ident>()?;
+                    return Ok(Self::Foo { 0: v0 });
                 }
                 Keyword::Bar => {
-                    let f0 = p.parse::<Ident>()?;
-                    return Ok(Self::Bar { 0: f0 });
+                    let v0 = p.parse::<Ident>()?;
+                    return Ok(Self::Bar { 0: v0 });
                 }
                 _ => {}
             }
         }
         {
-            let f0 = p.parse::<Length>()?;
-            return Ok(Self::Length { 0: f0 });
+            let v0 = p.parse::<Length>()?;
+            return Ok(Self::Length { 0: v0 });
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_fields.snap
@@ -10,16 +10,16 @@ impl<'a> ::css_parse::Parse<'a> for Value {
     {
         use css_parse::{Parse, Peek};
         if p.peek::<Length>() {
-            let f0 = p.parse::<Length>()?;
-            return Ok(Self::Length { 0: f0 });
+            let v0 = p.parse::<Length>()?;
+            return Ok(Self::Length { 0: v0 });
         }
         if p.peek::<Percentage>() {
-            let f0 = p.parse::<Percentage>()?;
-            return Ok(Self::Percentage { 0: f0 });
+            let v0 = p.parse::<Percentage>()?;
+            return Ok(Self::Percentage { 0: v0 });
         }
         {
-            let f0 = p.parse::<String>()?;
-            return Ok(Self::Keyword { 0: f0 });
+            let v0 = p.parse::<String>()?;
+            return Ok(Self::Keyword { 0: v0 });
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_lifetime.snap
@@ -10,12 +10,12 @@ impl<'a> ::css_parse::Parse<'a> for CssValue<'a> {
     {
         use css_parse::{Parse, Peek};
         if p.peek::<Length>() {
-            let f0 = p.parse::<Length>()?;
-            return Ok(Self::Length { 0: f0 });
+            let v0 = p.parse::<Length>()?;
+            return Ok(Self::Length { 0: v0 });
         }
         if p.peek::<String>() {
-            let f0 = p.parse::<String>()?;
-            return Ok(Self::Keyword { 0: f0 });
+            let v0 = p.parse::<String>()?;
+            return Ok(Self::Keyword { 0: v0 });
         }
         if p.peek::<String>() {
             let name = p.parse::<String>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_struct_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_struct_variants.snap
@@ -10,8 +10,8 @@ impl<'a> ::css_parse::Parse<'a> for BorderStyle {
     {
         use css_parse::{Parse, Peek};
         if p.peek::<Ident>() {
-            let f0 = p.parse::<Ident>()?;
-            return Ok(Self::Solid { 0: f0 });
+            let v0 = p.parse::<Ident>()?;
+            return Ok(Self::Solid { 0: v0 });
         }
         if p.peek::<Length>() {
             let width = p.parse::<Length>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_enum.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_enum.snap
@@ -10,16 +10,16 @@ impl<'a> ::css_parse::Parse<'a> for Display {
     {
         use css_parse::{Parse, Peek};
         if p.peek::<Ident>() {
-            let f0 = p.parse::<Ident>()?;
-            return Ok(Self::Block { 0: f0 });
+            let v0 = p.parse::<Ident>()?;
+            return Ok(Self::Block { 0: v0 });
         }
         if p.peek::<Ident>() {
-            let f0 = p.parse::<Ident>()?;
-            return Ok(Self::Inline { 0: f0 });
+            let v0 = p.parse::<Ident>()?;
+            return Ok(Self::Inline { 0: v0 });
         }
         if p.peek::<Ident>() {
-            let f0 = p.parse::<Ident>()?;
-            return Ok(Self::None { 0: f0 });
+            let v0 = p.parse::<Ident>()?;
+            return Ok(Self::None { 0: v0 });
         } else {
             return Err(
                 crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_single_field_tuple_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_single_field_tuple_struct.snap
@@ -9,7 +9,7 @@ impl<'a> ::css_parse::Parse<'a> for Opacity {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let f0 = p.parse::<Number>()?;
-        return Ok(Self { 0: f0 });
+        let v0 = p.parse::<Number>()?;
+        return Ok(Self { 0: v0 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct.snap
@@ -9,8 +9,8 @@ impl<'a> ::css_parse::Parse<'a> for Length {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let f0 = p.parse::<Number>()?;
-        let f1 = p.parse::<Unit>()?;
-        return Ok(Self { 0: f0, 1: f1 });
+        let v0 = p.parse::<Number>()?;
+        let v1 = p.parse::<Unit>()?;
+        return Ok(Self { 0: v0, 1: v1 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_generics.snap
@@ -13,8 +13,8 @@ where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let f0 = p.parse::<T>()?;
-        let f1 = p.parse::<U>()?;
-        return Ok(Self { 0: f0, 1: f1 });
+        let v0 = p.parse::<T>()?;
+        let v1 = p.parse::<U>()?;
+        return Ok(Self { 0: v0, 1: v1 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_mixed_variants.snap
@@ -7,14 +7,20 @@ impl ::css_parse::SemanticEq for FlexWrap {
     fn semantic_eq(&self, other: &Self) -> bool {
         use ::css_parse::SemanticEq;
         match (self, other) {
-            (Self::Nowrap(a0), Self::Nowrap(b0)) => a0.semantic_eq(&b0),
+            (FlexWrap::Nowrap(a0), FlexWrap::Nowrap(b0)) => a0.semantic_eq(&b0),
             (
-                Self::Wrap { wrap: a_wrap, balance: a_balance },
-                Self::Wrap { wrap: b_wrap, balance: b_balance },
+                FlexWrap::Wrap { wrap: a_wrap, balance: a_balance },
+                FlexWrap::Wrap { wrap: b_wrap, balance: b_balance },
             ) => a_wrap.semantic_eq(&b_wrap) && a_balance.semantic_eq(&b_balance),
             (
-                Self::WrapReverse { wrap_reverse: a_wrap_reverse, balance: a_balance },
-                Self::WrapReverse { wrap_reverse: b_wrap_reverse, balance: b_balance },
+                FlexWrap::WrapReverse {
+                    wrap_reverse: a_wrap_reverse,
+                    balance: a_balance,
+                },
+                FlexWrap::WrapReverse {
+                    wrap_reverse: b_wrap_reverse,
+                    balance: b_balance,
+                },
             ) => {
                 a_wrap_reverse.semantic_eq(&b_wrap_reverse)
                     && a_balance.semantic_eq(&b_balance)

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_single_field_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_single_field_variants.snap
@@ -7,9 +7,9 @@ impl ::css_parse::SemanticEq for Display {
     fn semantic_eq(&self, other: &Self) -> bool {
         use ::css_parse::SemanticEq;
         match (self, other) {
-            (Self::Block(a0), Self::Block(b0)) => a0.semantic_eq(&b0),
-            (Self::Inline(a0), Self::Inline(b0)) => a0.semantic_eq(&b0),
-            (Self::None(a0), Self::None(b0)) => a0.semantic_eq(&b0),
+            (Display::Block(a0), Display::Block(b0)) => a0.semantic_eq(&b0),
+            (Display::Inline(a0), Display::Inline(b0)) => a0.semantic_eq(&b0),
+            (Display::None(a0), Display::None(b0)) => a0.semantic_eq(&b0),
             _ => false,
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_multiple_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_multiple_fields.snap
@@ -7,10 +7,10 @@ impl ::css_parse::SemanticEq for BorderStyle {
     fn semantic_eq(&self, other: &Self) -> bool {
         use ::css_parse::SemanticEq;
         match (self, other) {
-            (Self::Solid(), Self::Solid()) => {}
+            (BorderStyle::Solid, BorderStyle::Solid) => true,
             (
-                Self::Dotted { radius: a_radius, spacing: a_spacing },
-                Self::Dotted { radius: b_radius, spacing: b_spacing },
+                BorderStyle::Dotted { radius: a_radius, spacing: a_spacing },
+                BorderStyle::Dotted { radius: b_radius, spacing: b_spacing },
             ) => a_radius.semantic_eq(&b_radius) && a_spacing.semantic_eq(&b_spacing),
             _ => false,
         }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_single_field.snap
@@ -7,10 +7,11 @@ impl ::css_parse::SemanticEq for BorderStyle {
     fn semantic_eq(&self, other: &Self) -> bool {
         use ::css_parse::SemanticEq;
         match (self, other) {
-            (Self::Solid(), Self::Solid()) => {}
-            (Self::Dashed { width: a_width }, Self::Dashed { width: b_width }) => {
-                a_width.semantic_eq(&b_width)
-            }
+            (BorderStyle::Solid, BorderStyle::Solid) => true,
+            (
+                BorderStyle::Dashed { width: a_width },
+                BorderStyle::Dashed { width: b_width },
+            ) => a_width.semantic_eq(&b_width),
             _ => false,
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_tuple_struct_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_tuple_struct_single_field.snap
@@ -6,6 +6,8 @@ expression: pretty
 impl ::css_parse::SemanticEq for Length {
     fn semantic_eq(&self, other: &Self) -> bool {
         use ::css_parse::SemanticEq;
-        self.0.semantic_eq(&other.0)
+        let Length(a0) = self;
+        let Length(b0) = other;
+        a0.semantic_eq(&b0)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_mixed_variants.snap
@@ -5,15 +5,21 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for BorderStyle {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        use ::css_parse::ToCursors;
-        match self {
-            Self::Solid() => {}
-            Self::Dashed { width } => {
-                ToCursors::to_cursors(width, s);
+        match *self {
+            BorderStyle::Solid => {}
+            BorderStyle::Dashed { width: ref __binding_0 } => {
+                ::css_parse::ToCursors::to_cursors(__binding_0, s);
             }
-            Self::Dotted { radius, spacing } => {
-                ToCursors::to_cursors(radius, s);
-                ToCursors::to_cursors(spacing, s);
+            BorderStyle::Dotted {
+                radius: ref __binding_0,
+                spacing: ref __binding_1,
+            } => {
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
+                }
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
+                }
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_multiple_field_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_multiple_field_variants.snap
@@ -5,18 +5,25 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Value {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        use ::css_parse::ToCursors;
-        match self {
-            Self::Length(v0, v1) => {
-                ToCursors::to_cursors(v0, s);
-                ToCursors::to_cursors(v1, s);
+        match *self {
+            Value::Length(ref __binding_0, ref __binding_1) => {
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
+                }
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
+                }
             }
-            Self::Percentage(v0) => {
-                ToCursors::to_cursors(v0, s);
+            Value::Percentage(ref __binding_0) => {
+                ::css_parse::ToCursors::to_cursors(__binding_0, s);
             }
-            Self::Function(v0, v1) => {
-                ToCursors::to_cursors(v0, s);
-                ToCursors::to_cursors(v1, s);
+            Value::Function(ref __binding_0, ref __binding_1) => {
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
+                }
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
+                }
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_single_field_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_single_field_variants.snap
@@ -5,16 +5,15 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Display {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        use ::css_parse::ToCursors;
-        match self {
-            Self::Block(v0) => {
-                ToCursors::to_cursors(v0, s);
+        match *self {
+            Display::Block(ref __binding_0) => {
+                ::css_parse::ToCursors::to_cursors(__binding_0, s);
             }
-            Self::Inline(v0) => {
-                ToCursors::to_cursors(v0, s);
+            Display::Inline(ref __binding_0) => {
+                ::css_parse::ToCursors::to_cursors(__binding_0, s);
             }
-            Self::None(v0) => {
-                ToCursors::to_cursors(v0, s);
+            Display::None(ref __binding_0) => {
+                ::css_parse::ToCursors::to_cursors(__binding_0, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_with_lifetime.snap
@@ -5,14 +5,17 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::ToCursors for CssValue<'a> {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        use ::css_parse::ToCursors;
-        match self {
-            Self::Keyword(v0) => {
-                ToCursors::to_cursors(v0, s);
+        match *self {
+            CssValue::Keyword(ref __binding_0) => {
+                ::css_parse::ToCursors::to_cursors(__binding_0, s);
             }
-            Self::Function { name, args } => {
-                ToCursors::to_cursors(name, s);
-                ToCursors::to_cursors(args, s);
+            CssValue::Function { name: ref __binding_0, args: ref __binding_1 } => {
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
+                }
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
+                }
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_named_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_named_struct.snap
@@ -5,9 +5,22 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Color {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        use ::css_parse::ToCursors;
-        ToCursors::to_cursors(&self.red, s);
-        ToCursors::to_cursors(&self.green, s);
-        ToCursors::to_cursors(&self.blue, s);
+        match *self {
+            Color {
+                red: ref __binding_0,
+                green: ref __binding_1,
+                blue: ref __binding_2,
+            } => {
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
+                }
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
+                }
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_2, s);
+                }
+            }
+        }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_named_struct_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_named_struct_with_lifetime.snap
@@ -5,8 +5,15 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::ToCursors for Value<'a> {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        use ::css_parse::ToCursors;
-        ToCursors::to_cursors(&self.content, s);
-        ToCursors::to_cursors(&self.unit, s);
+        match *self {
+            Value { content: ref __binding_0, unit: ref __binding_1 } => {
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
+                }
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
+                }
+            }
+        }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_tuple_struct_multiple_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_tuple_struct_multiple_fields.snap
@@ -5,9 +5,18 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Position {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        use ::css_parse::ToCursors;
-        ToCursors::to_cursors(&self.0, s);
-        ToCursors::to_cursors(&self.1, s);
-        ToCursors::to_cursors(&self.2, s);
+        match *self {
+            Position(ref __binding_0, ref __binding_1, ref __binding_2) => {
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
+                }
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
+                }
+                {
+                    ::css_parse::ToCursors::to_cursors(__binding_2, s);
+                }
+            }
+        }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_tuple_struct_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_tuple_struct_single_field.snap
@@ -5,7 +5,10 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Length {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        use ::css_parse::ToCursors;
-        ToCursors::to_cursors(&self.0, s);
+        match *self {
+            Length(ref __binding_0) => {
+                ::css_parse::ToCursors::to_cursors(__binding_0, s);
+            }
+        }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_enum_with_named_struct_variant.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_enum_with_named_struct_variant.snap
@@ -7,16 +7,16 @@ impl crate::VisitableMut for FlexWrap {
     fn accept_mut<V: crate::VisitMut>(&mut self, v: &mut V) {
         use crate::VisitableMut;
         match self {
-            Self::Nowrap(v0) => {
-                v0.accept_mut(v);
+            Self::Nowrap(__binding_0) => {
+                __binding_0.accept_mut(v);
             }
-            Self::Wrap { wrap: f_wrap, balance: f_balance } => {
-                f_wrap.accept_mut(v);
-                f_balance.accept_mut(v);
+            Self::Wrap { wrap: __binding_0, balance: __binding_1 } => {
+                __binding_0.accept_mut(v);
+                __binding_1.accept_mut(v);
             }
-            Self::WrapReverse { wrap_reverse: f_wrap_reverse, balance: f_balance } => {
-                f_wrap_reverse.accept_mut(v);
-                f_balance.accept_mut(v);
+            Self::WrapReverse { wrap_reverse: __binding_0, balance: __binding_1 } => {
+                __binding_0.accept_mut(v);
+                __binding_1.accept_mut(v);
             }
         }
     }
@@ -26,16 +26,16 @@ impl crate::Visitable for FlexWrap {
     fn accept<V: crate::Visit>(&self, v: &mut V) {
         use crate::Visitable;
         match self {
-            Self::Nowrap(v0) => {
-                v0.accept(v);
+            Self::Nowrap(__binding_0) => {
+                __binding_0.accept(v);
             }
-            Self::Wrap { wrap: f_wrap, balance: f_balance } => {
-                f_wrap.accept(v);
-                f_balance.accept(v);
+            Self::Wrap { wrap: __binding_0, balance: __binding_1 } => {
+                __binding_0.accept(v);
+                __binding_1.accept(v);
             }
-            Self::WrapReverse { wrap_reverse: f_wrap_reverse, balance: f_balance } => {
-                f_wrap_reverse.accept(v);
-                f_balance.accept(v);
+            Self::WrapReverse { wrap_reverse: __binding_0, balance: __binding_1 } => {
+                __binding_0.accept(v);
+                __binding_1.accept(v);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_tuple_enum.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_tuple_enum.snap
@@ -7,11 +7,11 @@ impl crate::VisitableMut for Display {
     fn accept_mut<V: crate::VisitMut>(&mut self, v: &mut V) {
         use crate::VisitableMut;
         match self {
-            Self::Block(v0) => {
-                v0.accept_mut(v);
+            Self::Block(__binding_0) => {
+                __binding_0.accept_mut(v);
             }
-            Self::Inline(v0) => {
-                v0.accept_mut(v);
+            Self::Inline(__binding_0) => {
+                __binding_0.accept_mut(v);
             }
         }
     }
@@ -21,11 +21,11 @@ impl crate::Visitable for Display {
     fn accept<V: crate::Visit>(&self, v: &mut V) {
         use crate::Visitable;
         match self {
-            Self::Block(v0) => {
-                v0.accept(v);
+            Self::Block(__binding_0) => {
+                __binding_0.accept(v);
             }
-            Self::Inline(v0) => {
-                v0.accept(v);
+            Self::Inline(__binding_0) => {
+                __binding_0.accept(v);
             }
         }
     }

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -1,13 +1,9 @@
-use super::to_deriveinput;
+use super::{assert_derive_snapshot, to_deriveinput};
 use crate::parse;
 
 macro_rules! assert_parse_snapshot {
 	( $data:ident, $name:literal) => {
-		let tokens = parse::derive($data);
-		dbg!(tokens.to_string());
-		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
-		let pretty = ::prettyplease::unparse(&file);
-		::insta::assert_snapshot!($name, pretty)
+		assert_derive_snapshot!(parse::derive, $data, $name)
 	};
 }
 

--- a/crates/csskit_derives/src/test/test_peek.rs
+++ b/crates/csskit_derives/src/test/test_peek.rs
@@ -1,12 +1,9 @@
-use super::to_deriveinput;
+use super::{assert_derive_snapshot, to_deriveinput};
 use crate::peek;
 
 macro_rules! assert_peek_snapshot {
 	( $data:ident, $name:literal) => {
-		let tokens = peek::derive($data);
-		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
-		let pretty = ::prettyplease::unparse(&file);
-		::insta::assert_snapshot!($name, pretty)
+		assert_derive_snapshot!(peek::derive, $data, $name)
 	};
 }
 

--- a/crates/csskit_derives/src/test/test_semantic_eq.rs
+++ b/crates/csskit_derives/src/test/test_semantic_eq.rs
@@ -1,12 +1,9 @@
-use super::to_deriveinput;
+use super::{assert_derive_snapshot, to_deriveinput};
 use crate::semantic_eq;
 
 macro_rules! assert_semantic_eq_snapshot {
 	( $data:ident, $name:literal) => {
-		let tokens = semantic_eq::derive($data);
-		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
-		let pretty = ::prettyplease::unparse(&file);
-		::insta::assert_snapshot!($name, pretty)
+		assert_derive_snapshot!(semantic_eq::derive, $data, $name)
 	};
 }
 

--- a/crates/csskit_derives/src/test/test_to_cursors.rs
+++ b/crates/csskit_derives/src/test/test_to_cursors.rs
@@ -1,12 +1,9 @@
-use super::to_deriveinput;
+use super::{assert_derive_snapshot, to_deriveinput};
 use crate::to_cursors;
 
 macro_rules! assert_to_cursors_snapshot {
 	( $data:ident, $name:literal) => {
-		let tokens = to_cursors::derive($data);
-		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
-		let pretty = ::prettyplease::unparse(&file);
-		::insta::assert_snapshot!($name, pretty)
+		assert_derive_snapshot!(to_cursors::derive, $data, $name)
 	};
 }
 

--- a/crates/csskit_derives/src/test/test_to_span.rs
+++ b/crates/csskit_derives/src/test/test_to_span.rs
@@ -1,12 +1,9 @@
-use super::to_deriveinput;
+use super::{assert_derive_snapshot, to_deriveinput};
 use crate::to_span;
 
 macro_rules! assert_to_span_snapshot {
 	( $data:ident, $name:literal) => {
-		let tokens = to_span::derive($data);
-		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
-		let pretty = ::prettyplease::unparse(&file);
-		::insta::assert_snapshot!($name, pretty)
+		assert_derive_snapshot!(to_span::derive, $data, $name)
 	};
 }
 

--- a/crates/csskit_derives/src/test/test_visitable.rs
+++ b/crates/csskit_derives/src/test/test_visitable.rs
@@ -1,12 +1,9 @@
-use super::to_deriveinput;
+use super::{assert_derive_snapshot, to_deriveinput};
 use crate::visitable;
 
 macro_rules! assert_visitable_snapshot {
 	( $data:ident, $name:literal) => {
-		let tokens = visitable::derive($data);
-		let file = ::syn::parse2::<syn::File>(tokens).unwrap();
-		let pretty = ::prettyplease::unparse(&file);
-		::insta::assert_snapshot!($name, pretty)
+		assert_derive_snapshot!(visitable::derive, $data, $name)
 	};
 }
 

--- a/crates/csskit_derives/src/to_cursors.rs
+++ b/crates/csskit_derives/src/to_cursors.rs
@@ -1,107 +1,46 @@
-use crate::{WhereCollector, err};
-use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote};
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Index, parse_quote};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Error, Fields, Result, parse_quote};
+use synstructure::{AddBounds, BindStyle, Structure};
 
-pub fn derive(input: DeriveInput) -> TokenStream {
-	let mut where_collector = WhereCollector::new();
-	let ident = input.ident;
-	let generics = input.generics.clone();
+use crate::WhereCollector;
+
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
+	if let Data::Struct(ref s) = input.data
+		&& matches!(s.fields, Fields::Unit)
+	{
+		return Err(Error::new(input.ident.span(), "Cannot derive ToCursors on this struct"));
+	}
+	if matches!(input.data, Data::Union(_)) {
+		return Err(Error::new(input.ident.span(), "Cannot derive ToCursors on a Union"));
+	}
+
+	let mut s = Structure::try_new(&input)?;
+	s.add_bounds(AddBounds::None);
+	s.bind_with(|_| BindStyle::Ref);
+
+	let body = s.each(|bi| {
+		quote! { ::css_parse::ToCursors::to_cursors(#bi, s); }
+	});
+
+	let mut wc = WhereCollector::new();
+	for variant in s.variants() {
+		for binding in variant.bindings() {
+			wc.add(&binding.ast().ty);
+		}
+	}
+	let where_clause = wc.extend_where_clause(&input.generics, parse_quote! { ::css_parse::ToCursors });
+
+	let ident = &input.ident;
+	let generics = &input.generics;
 	let (impl_generics, type_generics, _) = generics.split_for_impl();
-	let body = match input.data {
-		Data::Struct(DataStruct { fields: Fields::Unnamed(fields), .. }) => {
-			let steps: Vec<TokenStream> = fields
-				.unnamed
-				.into_iter()
-				.enumerate()
-				.map(|(i, field)| {
-					let index = Index { index: i as u32, span: Span::call_site() };
-					where_collector.add(&field.ty);
-					quote! {
-						ToCursors::to_cursors(&self.#index, s);
-					}
-				})
-				.collect();
-			quote! { #(#steps)* }
-		}
 
-		Data::Struct(DataStruct { fields: Fields::Named(fields), .. }) => {
-			let steps: Vec<TokenStream> = fields
-				.named
-				.into_iter()
-				.map(|f| {
-					let ident = f.ident.expect("Named field");
-					where_collector.add(&f.ty);
-					quote! {
-						ToCursors::to_cursors(&self.#ident, s);
-					}
-				})
-				.collect();
-			quote! { #(#steps)* }
-		}
-
-		Data::Struct(_) => err(ident.span(), "Cannot derive ToCursors on this struct"),
-
-		Data::Union(_) => err(ident.span(), "Cannot derive ToCursors on a Union"),
-
-		Data::Enum(DataEnum { variants, .. }) => {
-			let mut steps = vec![];
-			for var in variants {
-				let var_ident = var.ident;
-				match var.fields {
-					Fields::Named(fields) => {
-						let field_idents: Vec<_> =
-							fields.named.iter().map(|f| f.ident.as_ref().unwrap().clone()).collect();
-						let field_steps: Vec<_> = fields
-							.named
-							.iter()
-							.map(|field| {
-								where_collector.add(&field.ty);
-								let fid = field.ident.as_ref().unwrap();
-								quote! { ToCursors::to_cursors(#fid, s); }
-							})
-							.collect();
-						steps.push(quote! {
-							Self::#var_ident { #(#field_idents),* } => { #(#field_steps)* }
-						});
-					}
-					_ => {
-						let mut idents = vec![];
-						let field_steps: Vec<_> = var
-							.fields
-							.into_iter()
-							.enumerate()
-							.map(|(i, field)| {
-								where_collector.add(&field.ty);
-								let ident = format_ident!("v{}", i);
-								idents.push(ident.clone());
-								quote! { ToCursors::to_cursors(#ident, s); }
-							})
-							.collect();
-						steps.push(quote! {
-							Self::#var_ident(#(#idents),*) => { #(#field_steps)* }
-						});
-					}
-				}
-			}
-			quote! {
-				match self {
-					#(#steps)*
-				}
-			}
-		}
-	};
-
-	let mut generics = input.generics.clone();
-	let where_clause = where_collector.extend_where_clause(&mut generics, parse_quote! { ::css_parse::ToCursors });
-
-	quote! {
+	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics ::css_parse::ToCursors for #ident #type_generics #where_clause {
 			fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-				use ::css_parse::ToCursors;
-				#body
+				match *self { #body }
 			}
 		}
-	}
+	})
 }

--- a/crates/csskit_derives/src/to_span.rs
+++ b/crates/csskit_derives/src/to_span.rs
@@ -1,29 +1,27 @@
-use crate::{TypeIsOption, WhereCollector, err};
+use crate::{FieldsExt, WhereCollector};
 use itertools::{Itertools, Position};
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, parse_quote};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Result, parse_quote};
 
-pub fn derive(input: DeriveInput) -> TokenStream {
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let mut where_collector = WhereCollector::new();
 	let ident = input.ident;
-	let generics = &mut input.generics.clone();
+	let generics = input.generics.clone();
 	let (impl_generics, type_generics, _) = generics.split_for_impl();
 	let body = match input.data {
-		Data::Union(_) => err(ident.span(), "Cannot derive ToSpan on a Union"),
+		Data::Union(_) => return Err(Error::new(ident.span(), "Cannot derive ToSpan on a Union")),
 
 		Data::Struct(DataStruct { fields, .. }) => {
-			for field in fields.iter() {
-				where_collector.add(&field.ty);
+			for syn_field in fields.iter() {
+				where_collector.add(&syn_field.ty);
 			}
-			let members: Vec<_> = fields.members().zip(fields.iter().map(|f| f.ty.is_option())).collect();
-			// All members are Option<T>, so we have no choice but to try and add them all to get something useful.
+			let members: Vec<_> = fields.views().into_iter().map(|v| (v.member, v.is_option)).collect();
+
 			if members.len() == 1 || members.iter().all(|(_, is_option)| *is_option) {
-				let members = fields.members();
+				let members = members.iter().map(|(m, _)| m);
 				quote! { #(self.#members.to_span())+* }
 			} else {
-				// To get a reliable span we need to find the first member, and the last. However as some members are
-				// Optional<T>, and could potentially all be none, we need to find the first non-optional member to guarantee we can get a Span.
 				members
 					.iter()
 					.take_while_inclusive(|(_, is_option)| *is_option)
@@ -76,22 +74,26 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 				.iter()
 				.map(|variant| {
 					let variant_ident = &variant.ident;
-					let len = variant.fields.len();
-					for field in variant.fields.iter() {
-						where_collector.add(&field.ty);
+					let views = variant.fields.views();
+					let len = views.len();
+					for syn_field in variant.fields.iter() {
+						where_collector.add(&syn_field.ty);
 					}
 					match &variant.fields {
-						Fields::Named(fields) => {
-							let field_idents: Vec<_> = fields.named.iter().map(|f| f.ident.as_ref().unwrap()).collect();
+						Fields::Named(_) => {
 							if len == 1 {
-								let fid = field_idents[0];
-								quote! { #ident::#variant_ident { #fid: val } => val.to_span(), }
+								let m = &views[0].member;
+								quote! { #ident::#variant_ident { #m: val } => val.to_span(), }
 							} else {
-								let first = field_idents[0];
-								let last = field_idents[len - 1];
-								let rest_pats = field_idents[1..len - 1].iter().map(|f| quote! { #f: _ });
+								let first_m = &views[0].member;
+								let last_m = &views[len - 1].member;
+								let rest_pats = views[1..len - 1].iter().map(|v| {
+									let m = &v.member;
+									quote! { #m: _ }
+								});
 								quote! {
-									#ident::#variant_ident { #first: first, #(#rest_pats,)* #last: last } => first.to_span() + last.to_span(),
+									#ident::#variant_ident { #first_m: first, #(#rest_pats,)* #last_m: last }
+										=> first.to_span() + last.to_span(),
 								}
 							}
 						}
@@ -99,7 +101,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 							if len == 1 {
 								quote! { #ident::#variant_ident(val) => val.to_span(), }
 							} else {
-								let rest = (2..len).map(|_| quote! { _ }).chain([quote! {last}]);
+								let rest = (2..len).map(|_| quote! { _ }).chain([quote! { last }]);
 								quote! {
 									#ident::#variant_ident(first, #(#rest),*) => first.to_span() + last.to_span(),
 								}
@@ -108,18 +110,13 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 					}
 				})
 				.collect();
-			quote! {
-				match self {
-					#steps
-				}
-			}
+			quote! { match self { #steps } }
 		}
 	};
 
-	let mut generics = input.generics.clone();
-	let where_clause = where_collector.extend_where_clause(&mut generics, parse_quote! { ::css_parse::ToSpan });
+	let where_clause = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::ToSpan });
 
-	quote! {
+	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics ::css_parse::ToSpan for #ident #type_generics #where_clause {
 			fn to_span(&self) -> ::css_parse::Span {
@@ -127,5 +124,5 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 				#body
 			}
 		}
-	}
+	})
 }

--- a/crates/csskit_derives/src/visitable.rs
+++ b/crates/csskit_derives/src/visitable.rs
@@ -1,12 +1,14 @@
+use crate::{FieldsExt, WhereCollector};
 use heck::ToSnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-	Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Ident, Meta, parse::Parse, parse_quote,
+	Attribute, Data, DeriveInput, Error, Fields, Ident, Meta, Result,
+	parse::{Parse, ParseStream},
+	parse_quote,
 	token::SelfValue,
 };
-
-use crate::{WhereCollector, err};
+use synstructure::{AddBounds, Structure};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 enum VisitStyle {
@@ -27,7 +29,7 @@ impl VisitStyle {
 }
 
 impl Parse for VisitStyle {
-	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+	fn parse(input: ParseStream) -> Result<Self> {
 		if input.parse::<SelfValue>().is_ok() {
 			return Ok(Self::OnlySelf);
 		}
@@ -40,24 +42,19 @@ impl Parse for VisitStyle {
 	}
 }
 
-impl From<&Vec<Attribute>> for VisitStyle {
-	fn from(attrs: &Vec<Attribute>) -> Self {
+impl From<&[Attribute]> for VisitStyle {
+	fn from(attrs: &[Attribute]) -> Self {
 		if let Some(Attribute { meta, .. }) = &attrs.iter().find(|a| a.path().is_ident("visit")) {
 			match meta {
-				// #[visit(keyword)]
 				Meta::List(meta) => meta.parse_args::<VisitStyle>().unwrap(),
-				// #[visit]
 				_ => Self::All,
 			}
 		} else {
-			// No attribute present
 			Self::default()
 		}
 	}
 }
 
-/// Check if the type has a #[queryable(skip)] attribute, indicating it has a manual
-/// QueryableNode implementation.
 fn has_queryable_skip(attrs: &[Attribute]) -> bool {
 	attrs.iter().any(|attr| {
 		if attr.path().is_ident("queryable") {
@@ -71,13 +68,88 @@ fn has_queryable_skip(attrs: &[Attribute]) -> bool {
 	})
 }
 
-pub fn derive(input: DeriveInput) -> TokenStream {
-	let mut where_collector = WhereCollector::new();
-	let ident = input.ident;
-	let generics = &mut input.generics.clone();
-	let (impl_generics, type_generics, _) = generics.split_for_impl();
-	let style: VisitStyle = (&input.attrs).into();
+fn make_body(s: &Structure, accept: &syn::Ident, wc: &mut WhereCollector) -> TokenStream {
+	match &s.ast().data {
+		Data::Struct(ds) => {
+			let steps: Vec<TokenStream> = ds
+				.fields
+				.views()
+				.into_iter()
+				.zip(ds.fields.iter())
+				.filter_map(|(view, syn_field)| {
+					if VisitStyle::from(syn_field.attrs.as_slice()) == VisitStyle::Skip {
+						return None;
+					}
+					wc.add(&syn_field.ty);
+					let m = &view.member;
+					Some(quote! { self.#m.#accept(v); })
+				})
+				.collect();
+			quote! { #(#steps)* }
+		}
+		Data::Enum(_) => {
+			let arms: TokenStream = s
+				.variants()
+				.iter()
+				.map(|variant| {
+					let var_ident = variant.ast().ident;
+					let skip_variant = VisitStyle::from(variant.ast().attrs) == VisitStyle::Skip;
+					let bindings: Vec<_> = variant.bindings().iter().collect();
+					let named = bindings.first().and_then(|bi| bi.ast().ident.as_ref()).is_some();
+
+					let (patterns, calls): (Vec<TokenStream>, Vec<TokenStream>) = bindings
+						.iter()
+						.map(|bi| {
+							let skip_field =
+								skip_variant || VisitStyle::from(bi.ast().attrs.as_slice()) == VisitStyle::Skip;
+							let binding = &bi.binding;
+							if named {
+								let field_name = bi.ast().ident.as_ref().unwrap();
+								if skip_field {
+									(quote! { #field_name: _ }, quote! {})
+								} else {
+									wc.add(&bi.ast().ty);
+									(quote! { #field_name: #binding }, quote! { #binding.#accept(v) })
+								}
+							} else if skip_field {
+								(quote! { _ }, quote! {})
+							} else {
+								wc.add(&bi.ast().ty);
+								(quote! { #binding }, quote! { #binding.#accept(v) })
+							}
+						})
+						.unzip();
+
+					let pattern = if bindings.is_empty() {
+						quote! { Self::#var_ident }
+					} else if named {
+						quote! { Self::#var_ident { #(#patterns),* } }
+					} else {
+						quote! { Self::#var_ident(#(#patterns),*) }
+					};
+					quote! { #pattern => { #(#calls;)* }, }
+				})
+				.collect();
+			quote! { match self { #arms } }
+		}
+		Data::Union(_) => unreachable!("checked above"),
+	}
+}
+
+pub fn derive(input: DeriveInput) -> Result<TokenStream> {
+	if matches!(input.data, Data::Union(_)) {
+		return Err(Error::new(input.ident.span(), "Cannot derive Visitable on a Union"));
+	}
+	if let Data::Struct(ref s) = input.data
+		&& matches!(s.fields, Fields::Unit)
+	{
+		return Err(Error::new(input.ident.span(), "Cannot derive Visitable on this struct"));
+	}
+
+	let style: VisitStyle = VisitStyle::from(input.attrs.as_slice());
 	let is_queryable = style.visit_self();
+	let ident = &input.ident;
+	let (impl_generics, type_generics, _) = input.generics.split_for_impl();
 
 	let (visit, exit) = if style.visit_self() {
 		let visit_method = format_ident!("visit_{}", ident.to_string().to_snake_case());
@@ -93,84 +165,26 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 		(quote! {}, quote! {})
 	};
 
-	let [body_mut, body] = if style.visit_children() {
-		[format_ident!("accept_mut"), format_ident!("accept")].map(|accept| match &input.data {
-			Data::Union(_) => err(ident.span(), "Cannot derive Into<Span> on a Union"),
+	let mut s = Structure::try_new(&input)?;
+	s.add_bounds(AddBounds::None);
 
-			Data::Struct(DataStruct { fields, .. }) => {
-				let members = fields.members().zip(fields).filter_map(|(member, field)| {
-					if Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip { None } else { Some(member) }
-				});
-				quote! { #(self.#members.#accept(v);)* }
-			}
+	let mut wc = WhereCollector::new();
 
-			Data::Enum(DataEnum { variants, .. }) => {
-				let steps: TokenStream = variants
-					.iter()
-					.map(|variant| {
-						let variant_ident = &variant.ident;
-						let skip_variant = Into::<VisitStyle>::into(&variant.attrs) == VisitStyle::Skip;
-						match &variant.fields {
-							Fields::Named(fields) => {
-								let (bindings, steps): (Vec<_>, Vec<_>) = fields
-									.named
-									.iter()
-									.map(|field| {
-										let fname = field.ident.as_ref().unwrap();
-										let binding = format_ident!("f_{}", fname);
-										if skip_variant || Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip {
-											(quote! { #fname: _ }, quote! {})
-										} else {
-											where_collector.add(&field.ty);
-											(quote! { #fname: #binding }, quote! { #binding.#accept(v) })
-										}
-									})
-									.unzip();
-								quote! {
-									Self::#variant_ident { #(#bindings),* } => { #(#steps;)* },
-								}
-							}
-							_ => {
-								let (members, steps): (Vec<_>, Vec<_>) = variant
-									.fields
-									.iter()
-									.enumerate()
-									.map(|(i, field)| {
-										if skip_variant || Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip {
-											(format_ident!("_"), quote! {})
-										} else {
-											let ident = format_ident!("v{}", i);
-											where_collector.add(&field.ty);
-											(ident.clone(), quote! { #ident.#accept(v) })
-										}
-									})
-									.collect::<Vec<_>>()
-									.into_iter()
-									.unzip();
-								quote! {
-									Self::#variant_ident(#(#members),*) => { #(#steps;)* },
-								}
-							}
-						}
-					})
-					.collect();
-				quote! { match self { #steps } }
-			}
-		})
+	let (body_mut, body) = if style.visit_children() {
+		let accept_mut = format_ident!("accept_mut");
+		let accept = format_ident!("accept");
+		let b_mut = make_body(&s, &accept_mut, &mut wc);
+		let b = make_body(&s, &accept, &mut wc);
+		(b_mut, b)
 	} else {
-		[quote! {}, quote! {}]
+		(quote! {}, quote! {})
 	};
 
-	let mut generics = input.generics.clone();
-	let where_clause = where_collector.extend_where_clause(&mut generics, parse_quote! { crate::Visitable });
-	let mut_where_clause = where_collector.extend_where_clause(&mut generics, parse_quote! { crate::VisitableMut });
+	let where_clause = wc.extend_where_clause(&input.generics, parse_quote! { crate::Visitable });
+	let mut_where_clause = wc.extend_where_clause(&input.generics, parse_quote! { crate::VisitableMut });
 
-	// Check if we should skip generating QueryableNode (type has manual implementation)
 	let skip_queryable = has_queryable_skip(&input.attrs);
 
-	// Implement QueryableNode for nodes that visit themselves (not just children)
-	// This matches the types that get NodeId variants generated in build.rs
-	// Skip if queryable(skip) is present (manual impl provided)
 	let queryable_impl = if style.visit_self() && !skip_queryable {
 		quote! {
 			#[automatically_derived]
@@ -182,7 +196,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 		quote! {}
 	};
 
-	quote! {
+	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics crate::VisitableMut for #ident #type_generics #mut_where_clause {
 			fn accept_mut<V: crate::VisitMut>(&mut self, v: &mut V) {
@@ -206,5 +220,5 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 		}
 
 		#queryable_impl
-	}
+	})
 }

--- a/crates/csskit_derives/src/where_collector.rs
+++ b/crates/csskit_derives/src/where_collector.rs
@@ -1,10 +1,21 @@
 use std::collections::HashSet;
-use syn::{GenericParam, Generics, Type, TypeParam, WhereClause, parse_quote};
+use syn::{
+	GenericParam, Generics, Type, TypeParam, TypePath, WhereClause, parse_quote,
+	visit::{Visit, visit_type_path},
+};
 
-/// A collector for tracking which generic type parameters are used during derive macro generation.
-/// As the derive macro generates calls, it can report which generics are actually used, and can
-/// then expand the collected types into a Where clause.
 pub struct WhereCollector(HashSet<String>);
+
+struct TypeParamCollector<'a>(&'a mut HashSet<String>);
+
+impl<'ast> Visit<'ast> for TypeParamCollector<'_> {
+	fn visit_type_path(&mut self, ty: &'ast TypePath) {
+		if let Some(ident) = ty.path.get_ident() {
+			self.0.insert(ident.to_string());
+		}
+		visit_type_path(self, ty);
+	}
+}
 
 impl WhereCollector {
 	pub fn new() -> Self {
@@ -12,42 +23,10 @@ impl WhereCollector {
 	}
 
 	pub fn add(&mut self, ty: &Type) {
-		match ty {
-			Type::Path(type_path) => {
-				if let Some(ident) = type_path.path.get_ident() {
-					let ident_str = ident.to_string();
-					self.0.insert(ident_str);
-				}
-				// Also check generic arguments in the path
-				for segment in &type_path.path.segments {
-					if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-						for arg in &args.args {
-							if let syn::GenericArgument::Type(ty) = arg {
-								self.add(ty);
-							}
-						}
-					}
-				}
-			}
-			Type::Reference(type_ref) => {
-				self.add(&type_ref.elem);
-			}
-			Type::Tuple(type_tuple) => {
-				for elem in &type_tuple.elems {
-					self.add(elem);
-				}
-			}
-			Type::Array(type_array) => {
-				self.add(&type_array.elem);
-			}
-			Type::Slice(type_slice) => {
-				self.add(&type_slice.elem);
-			}
-			_ => {}
-		}
+		TypeParamCollector(&mut self.0).visit_type(ty);
 	}
 
-	pub fn extend_where_clause(&self, generics: &mut Generics, predicate: Type) -> Option<WhereClause> {
+	pub fn extend_where_clause(&self, generics: &Generics, predicate: Type) -> Option<WhereClause> {
 		let (_, _, wheres) = generics.split_for_impl();
 		if self.0.is_empty() {
 			return wheres.cloned();


### PR DESCRIPTION
csskit_derives is getting a little unwieldy and hard to follow. There is a lot
of duplication and repeated operations, and the whole thing is a bit of a mess.

This change refactors all of it to be simpler and DRYer:

- It uses darling to handle parsing of macro attributes, vastly reducing
	boilerplate. darling_ext exists to retain the few odd syntaxes we have (the
	bitwise pipe combinator usage and the attribute presence for truthiness).
- Use synstructure to simplify our field walking operations.
- Introduce FieldView to help with modelling the way we work on fields.
- Making code a little more idiomatic in various places.
