### PR TITLE
css_ast: add negative border-spacing red test

### DIFF
--- a/crates/css_ast/src/values/tables/impls.rs
+++ b/crates/css_ast/src/values/tables/impls.rs
@@ -37,6 +37,7 @@ mod tests {
 		assert_parse_error!(CssAtomSet::ATOMS, BorderCollapseStyleValue, "separate collapse");
 
 		assert_parse_error!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "10%");
+		assert_parse_error!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "-20px");
 		assert_parse_error!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "30");
 		assert_parse_error!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "40px 50px 60px");
 


### PR DESCRIPTION
Spec was fixed upstream to use <length [0,inf]>{1,2}; so this test can be
introduced.
