### PR TITLE
csskit_derives: Support AllMustOccur/OneMustOccur in peek.

### DIFF
--- a/crates/csskit_derives/src/attributes.rs
+++ b/crates/csskit_derives/src/attributes.rs
@@ -1,6 +1,45 @@
+use darling::FromAttributes;
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use syn::{Attribute, Error, ExprPath, Ident, Meta, Result};
+
+/// How fields within a struct variant must be satisfied.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldParseMode {
+	/// Fields are consumed in order; first non-optional field ends the variant.
+	#[default]
+	Sequential,
+	/// All optional fields must appear (in any order).
+	AllMustOccur,
+	/// At least one optional field must appear (in any order).
+	OneMustOccur,
+}
+
+impl FieldParseMode {
+	/// Any field can be the first token (unordered multi-field modes).
+	pub fn any_field_can_start(self) -> bool {
+		matches!(self, Self::AllMustOccur | Self::OneMustOccur)
+	}
+}
+
+#[derive(Debug, Default, FromAttributes)]
+#[darling(attributes(parse))]
+struct ParseModeArgs {
+	#[darling(default)]
+	all_must_occur: bool,
+	#[darling(default)]
+	one_must_occur: bool,
+}
+
+pub fn extract_field_parse_mode(attrs: &[Attribute]) -> Result<FieldParseMode> {
+	let args = ParseModeArgs::from_attributes(attrs)
+		.map_err(|e| syn::Error::new(proc_macro2::Span::call_site(), e.to_string()))?;
+	Ok(match (args.all_must_occur, args.one_must_occur) {
+		(true, _) => FieldParseMode::AllMustOccur,
+		(_, true) => FieldParseMode::OneMustOccur,
+		_ => FieldParseMode::Sequential,
+	})
+}
 
 #[derive(Debug)]
 pub struct Atom(ExprPath);

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -1,6 +1,6 @@
 use crate::{
 	FieldsExt, WhereCollector,
-	attributes::{Atom, extract_atom},
+	attributes::{Atom, FieldParseMode, extract_atom},
 	darling_ext::{StateArg, StopArg},
 	ensure_lifetime_a,
 	field_view::option_inner,
@@ -24,14 +24,6 @@ impl TypeIsOption for Type {
 	fn unpack_option(&self) -> Self {
 		option_inner(self).cloned().unwrap_or_else(|| self.clone())
 	}
-}
-
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-enum FieldParseMode {
-	#[default]
-	Sequential,
-	AllMustOccur,
-	OneMustOccur,
 }
 
 #[derive(Debug, Default, FromAttributes)]

--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -1,19 +1,26 @@
 use crate::{
 	FieldsExt, WhereCollector,
-	attributes::{Atom, extract_atom},
+	attributes::{Atom, extract_atom, extract_field_parse_mode},
 	ensure_lifetime_a,
+	field_view::option_inner,
 };
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{ToTokens, quote};
+use std::collections::HashMap;
 use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Result, Type, parse_quote};
 
-fn generate_field_peek(ty: &Type, atom: &Option<Atom>, where_collector: &mut WhereCollector) -> TokenStream {
+/// Build a peek check for a single type, optionally constrained to a set of atoms.
+/// `atoms` empty means unconstrained (just `peek`); non-empty means `peek && (atom || atom || ...)`.
+fn generate_type_peek(ty: &Type, atoms: &[Atom], where_collector: &mut WhereCollector) -> TokenStream {
 	where_collector.add(ty);
-	if let Some(atom) = atom {
-		let atom_path = atom.path();
-		quote! { (<#ty>::peek(p, c) && p.equals_atom(c.into(), &#atom_path)) }
-	} else {
+	if atoms.is_empty() {
 		quote! { <#ty>::peek(p, c) }
+	} else {
+		let atom_checks = atoms.iter().map(|a| {
+			let path = a.path();
+			quote! { p.equals_atom(c.into(), &#path) }
+		});
+		quote! { (<#ty>::peek(p, c) && (#(#atom_checks)||*)) }
 	}
 }
 
@@ -31,7 +38,9 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 			let mut checks: Vec<TokenStream> = vec![];
 			for (view, syn_field) in fields.views().into_iter().zip(fields.iter()) {
 				let atom = extract_atom(&syn_field.attrs)?;
-				checks.push(generate_field_peek(view.ty, &atom, &mut where_collector));
+				let atoms = atom.map(|a| vec![a]).unwrap_or_default();
+				let peek_ty = option_inner(view.ty).unwrap_or(view.ty);
+				checks.push(generate_type_peek(peek_ty, &atoms, &mut where_collector));
 				if !view.is_option {
 					break;
 				}
@@ -40,18 +49,65 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 		}
 
 		Data::Enum(DataEnum { variants, .. }) => {
-			let mut type_checks: Vec<TokenStream> = vec![];
+			let mut seen: Vec<String> = vec![];
+			let mut by_type: HashMap<String, Option<Vec<Atom>>> = HashMap::new();
+
+			let mut register = |peek_ty: &Type, atom: Option<Atom>| {
+				let key = peek_ty.to_token_stream().to_string();
+				match by_type.entry(key.clone()) {
+					std::collections::hash_map::Entry::Vacant(e) => {
+						seen.push(key);
+						e.insert(atom.map(|a| vec![a]));
+					}
+					std::collections::hash_map::Entry::Occupied(mut e) => match (e.get_mut(), atom) {
+						(None, _) => {}
+						(slot @ Some(_), None) => *slot = None,
+						(Some(existing), Some(a)) => {
+							let path = a.path().to_token_stream().to_string();
+							if !existing.iter().any(|x| x.path().to_token_stream().to_string() == path) {
+								existing.push(a);
+							}
+						}
+					},
+				}
+			};
+
 			for variant in variants.iter() {
 				let views = variant.fields.views();
-				let Some((view, syn_field)) = views.first().zip(variant.fields.iter().next()) else {
-					continue;
-				};
-				let atom = match extract_atom(&variant.attrs)? {
-					Some(a) => Some(a),
-					None => extract_atom(&syn_field.attrs)?,
-				};
-				// Use raw ty (including Option<T> if present) to preserve original behaviour.
-				type_checks.push(generate_field_peek(view.ty, &atom, &mut where_collector));
+				let parse_mode = extract_field_parse_mode(&variant.attrs)?;
+				if parse_mode.any_field_can_start() {
+					for (view, syn_field) in views.iter().zip(variant.fields.iter()) {
+						let atom = extract_atom(&syn_field.attrs)?;
+						let peek_ty = option_inner(view.ty).unwrap_or(view.ty);
+						register(peek_ty, atom);
+					}
+				} else {
+					let Some((view, syn_field)) = views.first().zip(variant.fields.iter().next()) else {
+						continue;
+					};
+					let atom = match extract_atom(&variant.attrs)? {
+						Some(a) => Some(a),
+						None => extract_atom(&syn_field.attrs)?,
+					};
+					let peek_ty = option_inner(view.ty).unwrap_or(view.ty);
+					register(peek_ty, atom);
+				}
+			}
+
+			let mut type_checks: Vec<TokenStream> = vec![];
+			for key in &seen {
+				let entry = by_type.remove(key).unwrap();
+				let ty = variants
+					.iter()
+					.find_map(|v| {
+						v.fields.views().into_iter().find_map(|vw| {
+							let peek_ty = option_inner(vw.ty).unwrap_or(vw.ty);
+							if peek_ty.to_token_stream().to_string() == *key { Some(peek_ty.clone()) } else { None }
+						})
+					})
+					.unwrap();
+				let atoms = entry.unwrap_or_default();
+				type_checks.push(generate_type_peek(&ty, &atoms, &mut where_collector));
 			}
 			quote! { #(#type_checks)||* }
 		}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_struct_variant_one_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_struct_variant_one_must_occur.snap
@@ -9,9 +9,10 @@ impl<'a> ::css_parse::Peek<'a> for FlexWrap {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use ::css_parse::Peek;
-        (<Ident>::peek(p, c) && p.equals_atom(c.into(), &FooAtoms::Nowrap))
-            || (<Option<Ident>>::peek(p, c) && p.equals_atom(c.into(), &FooAtoms::Wrap))
-            || (<Option<Ident>>::peek(p, c)
-                && p.equals_atom(c.into(), &FooAtoms::WrapReverse))
+        (<Ident>::peek(p, c)
+            && (p.equals_atom(c.into(), &FooAtoms::Nowrap)
+                || p.equals_atom(c.into(), &FooAtoms::Wrap)
+                || p.equals_atom(c.into(), &FooAtoms::Balance)
+                || p.equals_atom(c.into(), &FooAtoms::WrapReverse)))
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_variant_all_must_occur_distinct_types.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_variant_all_must_occur_distinct_types.snap
@@ -3,12 +3,13 @@ source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Display {
+impl<'a> ::css_parse::Peek<'a> for TextDecoration {
     fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use ::css_parse::Peek;
-        <Ident>::peek(p, c)
+        (<Ident>::peek(p, c) && (p.equals_atom(c.into(), &FooAtoms::Underline)))
+            || <DecorationStyle>::peek(p, c) || <Color>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_variant_one_must_occur_distinct_types.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_variant_one_must_occur_distinct_types.snap
@@ -3,12 +3,13 @@ source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Display {
+impl<'a> ::css_parse::Peek<'a> for TextDecoration {
     fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use ::css_parse::Peek;
-        <Ident>::peek(p, c)
+        (<Ident>::peek(p, c) && (p.equals_atom(c.into(), &FooAtoms::Underline)))
+            || <DecorationStyle>::peek(p, c) || <Color>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_duplicate_types.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_duplicate_types.snap
@@ -9,6 +9,6 @@ impl<'a> ::css_parse::Peek<'a> for Color {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use ::css_parse::Peek;
-        <CSSInt>::peek(p, c) || <CSSInt>::peek(p, c) || <CSSInt>::peek(p, c)
+        <CSSInt>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_multiple_identical_types.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_multiple_identical_types.snap
@@ -3,12 +3,13 @@ source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Display {
+impl<'a> ::css_parse::Peek<'a> for FlowInto {
     fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use ::css_parse::Peek;
-        <Ident>::peek(p, c)
+        (<Ident>::peek(p, c) && (p.equals_atom(c.into(), &FooAtoms::None)))
+            || <CustomIdent>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_struct_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_struct_variants.snap
@@ -9,6 +9,6 @@ impl<'a> ::css_parse::Peek<'a> for BorderStyle {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use ::css_parse::Peek;
-        <Length>::peek(p, c) || <Length>::peek(p, c)
+        <Length>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/test_peek.rs
+++ b/crates/csskit_derives/src/test/test_peek.rs
@@ -121,3 +121,57 @@ fn peek_enum_struct_variant_one_must_occur() {
 	};
 	assert_peek_snapshot!(data, "peek_enum_struct_variant_one_must_occur");
 }
+
+#[test]
+fn peek_enum_variant_one_must_occur_distinct_types() {
+	let data = to_deriveinput! {
+		enum TextDecoration {
+			#[parse(one_must_occur)]
+			Decorated {
+				#[atom(FooAtoms::Underline)]
+				line: Option<Ident>,
+				style: Option<DecorationStyle>,
+				color: Option<Color>,
+			},
+		}
+	};
+	assert_peek_snapshot!(data, "peek_enum_variant_one_must_occur_distinct_types");
+}
+
+#[test]
+fn peek_enum_variant_all_must_occur_distinct_types() {
+	let data = to_deriveinput! {
+		enum TextDecoration {
+			#[parse(all_must_occur)]
+			Decorated {
+				#[atom(FooAtoms::Underline)]
+				line: Option<Ident>,
+				style: Option<DecorationStyle>,
+				color: Option<Color>,
+			},
+		}
+	};
+	assert_peek_snapshot!(data, "peek_enum_variant_all_must_occur_distinct_types");
+}
+
+#[test]
+fn peek_enum_with_multiple_identical_types() {
+	let data = to_deriveinput! {
+		enum FlowInto {
+			#[atom(FooAtoms::None)]
+			None(Ident),
+			Element(
+				CustomIdent,
+				#[atom(FooAtoms::Element)]
+				Ident,
+			),
+			Content(
+				CustomIdent,
+				#[atom(CssAtomSet::Content)]
+				Ident,
+			),
+			CustomIdent(CustomIdent),
+		}
+	};
+	assert_peek_snapshot!(data, "peek_enum_with_multiple_identical_types");
+}


### PR DESCRIPTION
Currently peek naively peeks the first type, even if that's optional, for
example from a OneMustOccur/AllMustOccur style field. This is not good because
it means derived Peek impls return false negatives for what would otherwise
successfully parse.

This change refactors Parse & Peek derives to share a FieldParseMode, and
improves the field iteration for Peek to gather unique types (and atoms) - not
just getting the first field of any variant.

This also - as a side benefit - prevents Peek impls will from repeatedly trying
identical types, e.g. `<Length>::peek(p, c) || <Length>::peek(p, c)`.
