### PR TITLE
css_parse: Allow nested CommaSeparated items without failures

### DIFF
--- a/coverage/popular/bootstrap.5.3.0.find.1.txt
+++ b/coverage/popular/bootstrap.5.3.0.find.1.txt
@@ -76,6 +76,7 @@ coverage/popular/bootstrap.5.3.0.css
 2827:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
 2832:3:  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
 2841:3:  background-position: right 0.75rem center, center right 2.25rem;
+2842:3:  background-size: 16px 12px, calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 2846:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
 2860:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
 2875:3:  z-index: 3;
@@ -84,6 +85,7 @@ coverage/popular/bootstrap.5.3.0.css
 2917:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
 2922:3:  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
 2931:3:  background-position: right 0.75rem center, center right 2.25rem;
+2932:3:  background-size: 16px 12px, calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 2936:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
 2950:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
 2965:3:  z-index: 4;

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.min.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.min.snap
@@ -71555,7 +71555,7 @@ StyleSheet(
                 offset: SourceOffset(47881),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Dimension(Cursor(
                     kind: "Dimension",
@@ -75745,7 +75745,7 @@ StyleSheet(
                 offset: SourceOffset(51379),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Dimension(Cursor(
                     kind: "Dimension",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
@@ -77641,7 +77641,7 @@ StyleSheet(
                 offset: SourceOffset(59224),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -82145,7 +82145,7 @@ StyleSheet(
                 offset: SourceOffset(63064),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",

--- a/crates/css_parse/src/syntax/comma_separated.rs
+++ b/crates/css_parse/src/syntax/comma_separated.rs
@@ -71,15 +71,24 @@ impl<'a, T: Parse<'a> + Peek<'a>, const MIN: usize> Parse<'a> for CommaSeparated
 		}
 		loop {
 			let item = p.parse::<T>()?;
-			let comma = p.parse_if_peek::<Comma>()?;
-			items.items.push((item, comma));
-			if comma.is_none() {
-				if MIN > items.len() {
-					p.parse::<Comma>()?;
+			if p.peek::<Comma>() {
+				let checkpoint = p.checkpoint();
+				let comma = p.parse::<Comma>()?;
+				if !<T>::peek(p, p.peek_n(1)) {
+					p.rewind(checkpoint);
+					items.items.push((item, None));
+					break;
 				}
-				return Ok(items);
+				items.items.push((item, Some(comma)));
+			} else {
+				items.items.push((item, None));
+				break;
 			}
 		}
+		if MIN > items.len() {
+			p.parse::<Comma>()?;
+		}
+		Ok(items)
 	}
 }
 
@@ -167,6 +176,7 @@ mod tests {
 		assert_parse!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, "one,two");
 		assert_parse!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, "one,two,three");
 		assert_parse!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident], 0>, "");
+		assert_parse!(EmptyAtomSet::ATOMS, CommaSeparated<(T![Number], CommaSeparated<T![Ident]>)>, "1 foo, 2 bar");
 	}
 
 	#[test]


### PR DESCRIPTION
Some grammars in CSS allow for nesting comma separated values, this can lead to
error cases where the inner CommaSeparated type greedily consumes the comma
token, despite being unable to parse the next type, therefore exiting its parse
steps and bubbling up to the outer CommaSeparated, which no longer sees a viable
token and therefore errors.

This change fixes this by issuing a checkpoint before parsing the comma, and
rewinding if the peek after the comma fails.
