### PR TITLE
csskit_proc_macro: always lowercase idents

### DIFF
--- a/crates/css_ast/src/css_atom_set.rs
+++ b/crates/css_ast/src/css_atom_set.rs
@@ -1130,6 +1130,7 @@ pub enum CssAtomSet {
 	LinearGradient,
 	LinearRgb,
 	Lineargradient,
+	Linearrgb,
 	Linen,
 	Link,
 	LinkParameters,

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -68,7 +68,7 @@ pub trait ToType {
 
 impl ToFieldName for DefIdent {
 	fn to_variant_name(&self, size_hint: usize) -> Ident {
-		let pascal = self.0.to_pascal_case();
+		let pascal = self.0.to_lowercase().to_pascal_case();
 		format_ident!("{}", if size_hint > 0 { pluralize(pascal) } else { pascal })
 	}
 }
@@ -398,12 +398,12 @@ impl DefExt for Def {
 				quote! { #[atom(CssAtomSet::#name)] }
 			}
 			Def::Ident(DefIdent(str)) if derives_parse => {
-				let name = format_ident!("{}", str.to_pascal_case());
+				let name = format_ident!("{}", str.to_lowercase().to_pascal_case());
 				quote! { #[atom(CssAtomSet::#name)] }
 			}
 			Def::Optional(inner) => match inner.as_ref() {
 				Def::Ident(DefIdent(str)) if derives_parse => {
-					let name = format_ident!("{}", str.to_pascal_case());
+					let name = format_ident!("{}", str.to_lowercase().to_pascal_case());
 					quote! { #[atom(CssAtomSet::#name)] }
 				}
 				_ => quote! {},
@@ -513,7 +513,7 @@ impl DefExt for Def {
 				.unique_by(|def| if let Self::Ident(DefIdent(str)) = def { str } else { "" })
 				.filter_map(|def| {
 					if let Self::Ident(def) = def {
-						let ident = format_ident!("{}", def.to_string().to_pascal_case());
+						let ident = format_ident!("{}", def.to_string().to_lowercase().to_pascal_case());
 						let ty = def.to_type();
 						Some(quote! { #[atom(CssAtomSet::#ident)] #ident(#ty), })
 					} else {


### PR DESCRIPTION
Idents from spec may have mixed casing, which is irrelevant for spec as they're
always case insensitive, however this can break Atom names, if e.g. a spec has
`linearSrgb` (cap s to delineate words) to mean `linearsrgb`; our Atoms
automatically kebab case, so `CssAtomSet::LinearSrgb` would be stringified as
`linear-srgb`.
