### PR TITLE
csskit_derives: Fix AllMustOccur occurance check to skip the optional fields

### DIFF
--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -276,12 +276,33 @@ impl<'a> Plan for MustOccurPlan<'a> {
 			wc.add(&f.ty.unpack_option());
 		}
 
-		let vars = fields.iter().map(|f| &f.var);
-		let checks: Vec<_> = fields.iter().map(Field::none_check).collect();
+		let all_checks: Vec<_> = fields.iter().map(Field::none_check).collect();
+		let required_checks: Vec<_> = fields.iter().filter(|f| !f.ty.is_option()).map(Field::none_check).collect();
 		let (occurance_cond, assignments): (TokenStream, Vec<TokenStream>) = match parse_mode {
 			FieldParseMode::Sequential => unreachable!(),
-			FieldParseMode::OneMustOccur => (quote! { #(#checks)&&* }, vars.map(|v| quote! { #v }).collect()),
-			FieldParseMode::AllMustOccur => (quote! { #(#checks)||* }, vars.map(|v| quote! { #v.unwrap() }).collect()),
+			FieldParseMode::OneMustOccur => {
+				let vars = fields.iter().map(|f| &f.var);
+				(quote! { #(#all_checks)&&* }, vars.map(|v| quote! { #v }).collect())
+			}
+			FieldParseMode::AllMustOccur => {
+				let cond = if required_checks.is_empty() {
+					quote! { false }
+				} else {
+					quote! { #(#required_checks)||* }
+				};
+				let assignments = fields
+					.iter()
+					.map(|f| {
+						let v = &f.var;
+						if f.ty.is_option() {
+							quote! { #v }
+						} else {
+							quote! { #v.unwrap() }
+						}
+					})
+					.collect();
+				(cond, assignments)
+			}
 		};
 
 		let peek_loop = emit_peek_loop(atom_binding, parse_steps);

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_optional_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_optional_fields.snap
@@ -1,0 +1,60 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for ScrollbarGutter {
+    fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use css_parse::{Parse, Peek};
+        if p.peek::<Ident>() {
+            let c = p.peek_n(1);
+            match p.to_atom::<CssAtomSet>(c) {
+                CssAtomSet::Auto => {
+                    let v0 = p.parse::<Ident>()?;
+                    return Ok(Self::Auto { 0: v0 });
+                }
+                CssAtomSet::Stable => {
+                    let mut stable: Option<Ident> = None;
+                    let mut both_edges: Option<Ident> = None;
+                    loop {
+                        let c = p.peek_n(1);
+                        let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                            p.to_atom::<CssAtomSet>(c)
+                        } else {
+                            <CssAtomSet>::default()
+                        };
+                        if stable.is_none() && atom == CssAtomSet::Stable {
+                            stable = Some(p.parse::<Ident>()?);
+                            continue;
+                        }
+                        if both_edges.is_none() && atom == CssAtomSet::BothEdges {
+                            both_edges = Some(p.parse::<Ident>()?);
+                            continue;
+                        }
+                        break;
+                    }
+                    if stable.is_none() {
+                        let c = p.peek_n(1);
+                        Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+                    }
+                    return Ok(Self::Stable {
+                        stable: stable.unwrap(),
+                        both_edges: both_edges,
+                    });
+                }
+                _ => {
+                    return Err(
+                        crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
+                    )?;
+                }
+            }
+        } else {
+            return Err(
+                crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected),
+            )?;
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_sequential_optional_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_sequential_optional_keyword.snap
@@ -1,0 +1,30 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for AxisWithOptionalSnap {
+    fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use css_parse::{Parse, Peek};
+        let v0 = {
+            let c = p.peek_n(1);
+            if p.equals_atom(c.into(), &CssAtomSet::X) {
+                p.parse::<Ident>()?
+            } else {
+                return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
+            }
+        };
+        let v1 = {
+            let c = p.peek_n(1);
+            if p.equals_atom(c.into(), &CssAtomSet::Mandatory) {
+                Some(p.parse::<Ident>()?)
+            } else {
+                None
+            }
+        };
+        return Ok(Self { 0: v0, 1: v1 });
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_optional_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_optional_fields.snap
@@ -1,0 +1,40 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for StableWithOptionalEdges {
+    fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use css_parse::{Parse, Peek};
+        let mut stable: Option<Ident> = None;
+        let mut both_edges: Option<Ident> = None;
+        loop {
+            let c = p.peek_n(1);
+            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                p.to_atom::<CssAtomSet>(c)
+            } else {
+                <CssAtomSet>::default()
+            };
+            if stable.is_none() && atom == CssAtomSet::Stable {
+                stable = Some(p.parse::<Ident>()?);
+                continue;
+            }
+            if both_edges.is_none() && atom == CssAtomSet::BothEdges {
+                both_edges = Some(p.parse::<Ident>()?);
+                continue;
+            }
+            break;
+        }
+        if stable.is_none() {
+            let c = p.peek_n(1);
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+        }
+        return Ok(Self {
+            stable: stable.unwrap(),
+            both_edges: both_edges,
+        });
+    }
+}

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -487,3 +487,48 @@ fn parse_enum_variant_discriminated_by_second_field_atom() {
 	};
 	assert_parse_snapshot!(data, "parse_enum_variant_discriminated_by_second_field_atom");
 }
+
+#[test]
+fn parse_struct_all_must_occur_with_optional_fields() {
+	let data = to_deriveinput! {
+		#[parse(all_must_occur)]
+		struct StableWithOptionalEdges {
+			#[atom(CssAtomSet::Stable)]
+			stable: Ident,
+			#[atom(CssAtomSet::BothEdges)]
+			both_edges: Option<Ident>,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_all_must_occur_with_optional_fields");
+}
+
+#[test]
+fn parse_enum_variant_all_must_occur_with_optional_fields() {
+	let data = to_deriveinput! {
+		enum ScrollbarGutter {
+			#[atom(CssAtomSet::Auto)]
+			Auto(Ident),
+			#[parse(all_must_occur)]
+			Stable {
+				#[atom(CssAtomSet::Stable)]
+				stable: Ident,
+				#[atom(CssAtomSet::BothEdges)]
+				both_edges: Option<Ident>,
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_variant_all_must_occur_with_optional_fields");
+}
+
+#[test]
+fn parse_sequential_optional_keyword() {
+	let data = to_deriveinput! {
+		struct AxisWithOptionalSnap(
+			#[atom(CssAtomSet::X)]
+			Ident,
+			#[atom(CssAtomSet::Mandatory)]
+			Option<Ident>,
+		);
+	};
+	assert_parse_snapshot!(data, "parse_sequential_optional_keyword");
+}


### PR DESCRIPTION
`AllMustOccur` variants use all fields - including optional ones - when
guarding. This causes incorrect behaviour when required fields are missing, and
can panic in unwrapping optional fields that were never set.

This change splits the occurance check to only consider required fields, mapping
optional fields through as-is, instead of unwrapping.
