### PR TITLE
csskit_proc_macro: Flatten nested options into separate fields for enums

### DIFF
--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -811,12 +811,28 @@ impl GenerateDefinition for Def {
 								} else {
 									inner.to_variant_name(0)
 								};
-								let members = opts_children.iter().map(|child| {
-									let member_name = child.to_member_name(0);
-									let ty = child.to_type();
-									let field_attrs = child.type_attributes(derives_parse, derives_visitable);
-									quote! { #field_attrs #member_name: Option<#ty> }
-								});
+								let members: Vec<_> = opts_children
+									.iter()
+									.flat_map(|child| {
+										if let Def::Combinator(nested, DefCombinatorStyle::Options) = child {
+											nested
+												.iter()
+												.map(|nc| {
+													let member_name = nc.to_member_name(0);
+													let ty = nc.to_type();
+													let field_attrs =
+														nc.type_attributes(derives_parse, derives_visitable);
+													quote! { #field_attrs #member_name: Option<#ty> }
+												})
+												.collect::<Vec<_>>()
+										} else {
+											let member_name = child.to_member_name(0);
+											let ty = child.to_type();
+											let field_attrs = child.type_attributes(derives_parse, derives_visitable);
+											vec![quote! { #field_attrs #member_name: Option<#ty> }]
+										}
+									})
+									.collect();
 								let variant_attrs = if derives_parse {
 									quote! { #[parse(one_must_occur)] }
 								} else {

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_with_nested_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_with_nested_options.snap
@@ -1,0 +1,25 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+---
+#[derive(Parse)]
+enum Foo<'a> {
+    #[parse(one_must_occur)]
+    Foo {
+        #[atom(CssAtomSet::Foo)]
+        foo: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Baz)]
+        baz: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Qux)]
+        qux: Option<::css_parse::T![Ident]>,
+    },
+    #[parse(one_must_occur)]
+    Bar {
+        #[atom(CssAtomSet::Bar)]
+        bar: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Baz)]
+        baz: Option<::css_parse::T![Ident]>,
+        #[atom(CssAtomSet::Qux)]
+        qux: Option<::css_parse::T![Ident]>,
+    },
+}

--- a/crates/csskit_proc_macro/src/test/test_generate.rs
+++ b/crates/csskit_proc_macro/src/test/test_generate.rs
@@ -519,3 +519,10 @@ fn struct_keyword_group_options_with_style_values() {
 	let data = to_deriveinput! { #[derive(Parse)] enum Foo<'a> {} };
 	assert_snapshot!(syntax, data, "struct_keyword_group_options_with_style_values");
 }
+
+#[test]
+fn enum_keyword_group_with_nested_options() {
+	let syntax = to_valuedef!(" [ foo | bar ] || [ baz || qux ] ");
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo<'a> {} };
+	assert_snapshot!(syntax, data, "enum_keyword_group_with_nested_options");
+}


### PR DESCRIPTION
When generating enum variants using the `||` grammar, nested Options are
collapsed into a single Optionals!. This would be fine, except it loses the
keyword atoms for each, therefore just becoming e.g. `Optionals![Ident, Ident]`.

This changes the nested options to be flattened as separate atom constrained
fields with `one_must_occur`. This results in a different, but compatible parse
routine.
