### PR TITLE
csskit_derives: Fix one_must_occur discriminator to OR atoms

### DIFF
--- a/crates/css_ast/src/values/box/impls.rs
+++ b/crates/css_ast/src/values/box/impls.rs
@@ -36,6 +36,10 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "block");
 		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "block-start");
 		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "block-start block-end");
+		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "inline");
+		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "inline-start");
+		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "inline-end");
+		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "block inline");
 		assert_parse_error!(CssAtomSet::ATOMS, MarginTrimStyleValue, "");
 		assert_parse_error!(CssAtomSet::ATOMS, MarginTrimStyleValue, "auto");
 	}

--- a/crates/css_ast/src/values/text_decor/impls.rs
+++ b/crates/css_ast/src/values/text_decor/impls.rs
@@ -33,6 +33,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "from-font");
 		assert_parse!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "under");
 		assert_parse!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "from-font left");
+		assert_parse!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "left");
+		assert_parse!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "right");
 		assert_parse_error!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "");
 		assert_parse_error!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "1px");
 	}

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -390,6 +390,18 @@ impl VariantPlan {
 	}
 
 	fn discriminator(&self, shared_atom_paths: &[String], hoisted_type_var_names: &[&Ident]) -> TokenStream {
+		if self.parse_mode == FieldParseMode::OneMustOccur {
+			let peeks: Vec<TokenStream> = self
+				.fields
+				.iter()
+				.filter(|f| f.atom_path_string().is_some_and(|ap| !shared_atom_paths.contains(&ap)))
+				.map(|f| f.peek_tokens())
+				.collect();
+			if !peeks.is_empty() {
+				return quote! { #(#peeks)||* };
+			}
+		}
+
 		let discriminating =
 			self.fields.iter().find(|f| f.atom_path_string().is_some_and(|ap| !shared_atom_paths.contains(&ap)));
 		if let Some(field) = discriminating {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_siblings_no_shared_atoms.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_siblings_no_shared_atoms.snap
@@ -1,0 +1,89 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for MarginTrim {
+    fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use css_parse::{Parse, Peek};
+        if p.peek::<Ident>() {
+            let c = p.peek_n(1);
+            match p.to_atom::<FooAtoms>(c) {
+                FooAtoms::None => {
+                    let v0 = p.parse::<Ident>()?;
+                    return Ok(Self::None { 0: v0 });
+                }
+                _ => {}
+            }
+        }
+        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::Block
+            || p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::Inline
+        {
+            let mut block: Option<Ident> = None;
+            let mut inline: Option<Ident> = None;
+            loop {
+                let c = p.peek_n(1);
+                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                    p.to_atom::<FooAtoms>(c)
+                } else {
+                    <FooAtoms>::default()
+                };
+                if block.is_none() && atom == FooAtoms::Block {
+                    block = Some(p.parse::<Ident>()?);
+                    continue;
+                }
+                if inline.is_none() && atom == FooAtoms::Inline {
+                    inline = Some(p.parse::<Ident>()?);
+                    continue;
+                }
+                break;
+            }
+            if block.is_none() && inline.is_none() {
+                let c = p.peek_n(1);
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            }
+            return Ok(Self::BlockInline {
+                block: block,
+                inline: inline,
+            });
+        }
+        if p.peek::<Ident>()
+            && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::BlockStart
+            || p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::BlockEnd
+        {
+            let mut block_start: Option<Ident> = None;
+            let mut block_end: Option<Ident> = None;
+            loop {
+                let c = p.peek_n(1);
+                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                    p.to_atom::<FooAtoms>(c)
+                } else {
+                    <FooAtoms>::default()
+                };
+                if block_start.is_none() && atom == FooAtoms::BlockStart {
+                    block_start = Some(p.parse::<Ident>()?);
+                    continue;
+                }
+                if block_end.is_none() && atom == FooAtoms::BlockEnd {
+                    block_end = Some(p.parse::<Ident>()?);
+                    continue;
+                }
+                break;
+            }
+            if block_start.is_none() && block_end.is_none() {
+                let c = p.peek_n(1);
+                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            }
+            return Ok(Self::BlockStartBlockEnd {
+                block_start: block_start,
+                block_end: block_end,
+            });
+        }
+        return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?;
+    }
+}

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -555,3 +555,28 @@ fn parse_enum_one_must_occur_variant_mixed_atom_and_type_fields() {
 	};
 	assert_parse_snapshot!(data, "parse_enum_one_must_occur_variant_mixed_atom_and_type_fields");
 }
+
+#[test]
+fn parse_enum_one_must_occur_siblings_no_shared_atoms() {
+	let data = to_deriveinput! {
+		enum MarginTrim {
+			#[atom(FooAtoms::None)]
+			None(Ident),
+			#[parse(one_must_occur)]
+			BlockInline {
+				#[atom(FooAtoms::Block)]
+				block: Option<Ident>,
+				#[atom(FooAtoms::Inline)]
+				inline: Option<Ident>,
+			},
+			#[parse(one_must_occur)]
+			BlockStartBlockEnd {
+				#[atom(FooAtoms::BlockStart)]
+				block_start: Option<Ident>,
+				#[atom(FooAtoms::BlockEnd)]
+				block_end: Option<Ident>,
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_one_must_occur_siblings_no_shared_atoms");
+}


### PR DESCRIPTION
Enum variants for one_must_occur only use the first shared atom as the branch
check, which means in some cases branches can fall all the way through to the
error condition.

This change fixes the issue by collecting all non-shared atom fields and ORs
them so that the variant arms successfully execute.
