### PR TITLE
csskit_derives: Fix AllMustOccur all-optional non-atom dispatch

### DIFF
--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -286,7 +286,7 @@ impl<'a> Plan for MustOccurPlan<'a> {
 			}
 			FieldParseMode::AllMustOccur => {
 				let cond = if required_checks.is_empty() {
-					quote! { false }
+					quote! { #(#all_checks)&&* }
 				} else {
 					quote! { #(#required_checks)||* }
 				};
@@ -342,11 +342,14 @@ impl VariantPlan {
 			.ok_or_else(|| Error::new(ident.span(), "enum variant must have at least one field"))?;
 		let members = members_tokens(&variant.fields);
 
-		// Prefer variant-level atom; fall back to first field's atom except
-		// one_must_occur variants with all-optional fields dispatch by type only.
+		// Prefer variant-level atom; fall back to first field's atom except for
+		// must-occur variants with all-optional fields.
+		let all_optional = fields.iter().all(|f| f.ty.is_option());
 		let effective_atom = if variant_atom.is_some() {
 			variant_atom
-		} else if parse_mode == FieldParseMode::OneMustOccur && fields.iter().all(|f| f.ty.is_option()) {
+		} else if (parse_mode == FieldParseMode::OneMustOccur || parse_mode == FieldParseMode::AllMustOccur)
+			&& all_optional
+		{
 			None
 		} else {
 			fields.first().and_then(|f| f.atom.clone())
@@ -390,11 +393,17 @@ impl VariantPlan {
 	}
 
 	fn discriminator(&self, shared_atom_paths: &[String], hoisted_type_var_names: &[&Ident]) -> TokenStream {
-		if self.parse_mode == FieldParseMode::OneMustOccur {
+		let all_optional = self.fields.iter().all(|f| f.ty.is_option());
+		let is_all_optional_must_occur =
+			matches!(self.parse_mode, FieldParseMode::OneMustOccur | FieldParseMode::AllMustOccur) && all_optional;
+		if is_all_optional_must_occur {
 			let peeks: Vec<TokenStream> = self
 				.fields
 				.iter()
-				.filter(|f| f.atom_path_string().is_some_and(|ap| !shared_atom_paths.contains(&ap)))
+				.filter(|f| {
+					f.atom_path_string().is_none_or(|ap| !shared_atom_paths.contains(&ap))
+						&& !hoisted_type_var_names.contains(&&f.var)
+				})
 				.map(|f| f.peek_tokens())
 				.collect();
 			if !peeks.is_empty() {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_non_atom_only_input.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_non_atom_only_input.snap
@@ -1,0 +1,50 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Foo {
+    fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use css_parse::{Parse, Peek};
+        if p.peek::<Ident>() {
+            let c = p.peek_n(1);
+            match p.to_atom::<FooAtoms>(c) {
+                FooAtoms::None => {
+                    let v0 = p.parse::<Ident>()?;
+                    return Ok(Self::None { 0: v0 });
+                }
+                _ => {}
+            }
+        }
+        let mut auto: Option<Ident> = None;
+        let mut length: Option<Length> = None;
+        loop {
+            let c = p.peek_n(1);
+            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
+                p.to_atom::<FooAtoms>(c)
+            } else {
+                <FooAtoms>::default()
+            };
+            if auto.is_none() && atom == FooAtoms::Auto {
+                auto = Some(p.parse::<Ident>()?);
+                continue;
+            }
+            if length.is_none() && <Length>::peek(p, c) {
+                length = Some(p.parse::<Length>()?);
+                continue;
+            }
+            break;
+        }
+        if auto.is_none() && length.is_none() {
+            let c = p.peek_n(1);
+            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+        }
+        return Ok(Self::Valued {
+            auto: auto,
+            length: length,
+        });
+    }
+}

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -580,3 +580,20 @@ fn parse_enum_one_must_occur_siblings_no_shared_atoms() {
 	};
 	assert_parse_snapshot!(data, "parse_enum_one_must_occur_siblings_no_shared_atoms");
 }
+
+#[test]
+fn parse_enum_all_must_occur_non_atom_only_input() {
+	let data = to_deriveinput! {
+		enum Foo {
+			#[atom(FooAtoms::None)]
+			None(Ident),
+			#[parse(all_must_occur)]
+			Valued {
+				#[atom(FooAtoms::Auto)]
+				auto: Option<Ident>,
+				length: Option<Length>,
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_all_must_occur_non_atom_only_input");
+}


### PR DESCRIPTION
When all fields are Option, Parse only peeked for Ident tokens, so inputs
starting with a non-atom type (e.g. <length>, <decibel>) would never enter the
variant body.

This change extends peek to non-atom field types.
