### PR TITLE
csskit_derives: Avoid getting atom from Idents only.

### DIFF
--- a/crates/csskit_derives/src/attributes.rs
+++ b/crates/csskit_derives/src/attributes.rs
@@ -62,21 +62,6 @@ impl Atom {
 	pub fn first_segment(&self) -> Ident {
 		self.0.path.segments.first().expect("atom path must have at least one segment").ident.clone()
 	}
-
-	pub fn binding_block(&self) -> TokenStream {
-		let atom_set = self.first_segment();
-		quote! {
-			let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-				p.to_atom::<#atom_set>(c)
-			} else {
-				<#atom_set>::default()
-			};
-		}
-	}
-
-	pub fn opt_binding_block(atom: Option<&Self>) -> TokenStream {
-		atom.map(Self::binding_block).unwrap_or_default()
-	}
 }
 
 impl ToTokens for Atom {

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -132,11 +132,13 @@ impl Field {
 
 	/// Emits the atom-conditional match arm used in must-occur loops.
 	fn atom_match_arm(&self) -> TokenStream {
-		let atom_path = self.atom.as_ref().expect("atom_match_arm called without atom").path();
+		let atom = self.atom.as_ref().expect("atom_match_arm called without atom");
+		let atom_path = atom.path();
+		let atom_set = atom.first_segment();
 		let var = &self.var;
 		let inner_ty = self.ty.unpack_option();
 		quote! {
-			if #var.is_none() && atom == #atom_path {
+			if #var.is_none() && p.peek::<#inner_ty>() && p.to_atom::<#atom_set>(c) == #atom_path {
 				#var = Some(p.parse::<#inner_ty>()?);
 				continue;
 			}
@@ -151,8 +153,8 @@ impl Field {
 		let var = &self.var;
 		let inner_ty = self.ty.unpack_option();
 		quote! {
-			if p.peek::<::css_parse::token_macros::Ident>()
-				&& p.to_atom::<#atom_set>(p.peek_n(1)) == #atom_path
+			if p.peek::<#inner_ty>()
+				&& p.to_atom::<#atom_set>(c) == #atom_path
 			{
 				#var = Some(p.parse::<#inner_ty>()?);
 			}
@@ -198,7 +200,7 @@ impl Field {
 		if let Some(atom) = &self.atom {
 			let atom_path = atom.path();
 			let atom_set = atom.first_segment();
-			quote! { p.peek::<#peek_ty>() && p.to_atom::<#atom_set>(p.peek_n(1)) == #atom_path }
+			quote! { p.peek::<#peek_ty>() && p.to_atom::<#atom_set>(c) == #atom_path }
 		} else {
 			quote! { p.peek::<#peek_ty>() }
 		}
@@ -215,17 +217,6 @@ fn unexpected_at_next() -> TokenStream {
 
 fn unexpected_at_c() -> TokenStream {
 	quote! { Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))? }
-}
-
-fn emit_peek_loop(atom_binding: TokenStream, parse_steps: TokenStream) -> TokenStream {
-	quote! {
-		loop {
-			let c = p.peek_n(1);
-			#atom_binding
-			#parse_steps
-			break;
-		}
-	}
 }
 
 struct SequentialPlan<'a> {
@@ -263,8 +254,6 @@ impl<'a> Plan for MustOccurPlan<'a> {
 	fn render(&self, wc: &mut WhereCollector) -> TokenStream {
 		let MustOccurPlan { fields, members, post_parse_steps, parse_mode, constructor, hoisted } = self;
 		let bindings: TokenStream = fields.iter().filter(|f| !hoisted.contains(&&f.var)).map(Field::binding).collect();
-		let any_atom = fields.iter().find_map(|f| f.atom.as_ref());
-		let atom_binding = Atom::opt_binding_block(any_atom);
 
 		let parse_steps: TokenStream = fields
 			.iter()
@@ -277,6 +266,7 @@ impl<'a> Plan for MustOccurPlan<'a> {
 		}
 
 		let all_checks: Vec<_> = fields.iter().map(Field::none_check).collect();
+
 		let required_checks: Vec<_> = fields.iter().filter(|f| !f.ty.is_option()).map(Field::none_check).collect();
 		let (occurance_cond, assignments): (TokenStream, Vec<TokenStream>) = match parse_mode {
 			FieldParseMode::Sequential => unreachable!(),
@@ -305,11 +295,14 @@ impl<'a> Plan for MustOccurPlan<'a> {
 			}
 		};
 
-		let peek_loop = emit_peek_loop(atom_binding, parse_steps);
 		let unexpected = unexpected_at_c();
 		quote! {
 			#bindings
-			#peek_loop
+			loop {
+				let c = p.peek_n(1);
+				#parse_steps
+				break;
+			}
 			#post_parse_steps
 			if #occurance_cond {
 				let c = p.peek_n(1);
@@ -669,9 +662,26 @@ impl<'a, 'b> Plan for MultiVariantBlocksPlan<'a, 'b> {
 			TokenStream::new()
 		};
 
+		let needs_c = !self.hoist.shared_fields.is_empty()
+			|| self.variants.iter().any(|v| {
+				let shared = &self.hoist.shared_atom_paths;
+				let hoisted = self.hoist.hoisted_type_var_names();
+				v.fields.iter().any(|f| {
+					f.atom.is_some()
+						&& f.atom_path_string().is_none_or(|ap| !shared.contains(&ap))
+						&& !hoisted.contains(&&f.var)
+				})
+			});
+		let peek_binding = if needs_c {
+			quote! { let c = p.peek_n(1); }
+		} else {
+			quote! {}
+		};
+
 		quote! {
 			#hoisted_bindings
 			#hoisted_preloop
+			#peek_binding
 			#variant_blocks
 			#trailing
 		}
@@ -739,10 +749,6 @@ impl<'a> SharedAtomHoistPlan<'a> {
 		Self { shared_atom_paths, shared_fields, shared_type_fields }
 	}
 
-	fn shared_atom(&self) -> Option<&Atom> {
-		self.shared_fields.first().and_then(|f| f.atom.as_ref())
-	}
-
 	fn hoisted_type_var_names(&self) -> Vec<&Ident> {
 		self.shared_type_fields.iter().map(|f| &f.var).collect()
 	}
@@ -758,11 +764,19 @@ impl<'a> SharedAtomHoistPlan<'a> {
 	fn hoisted_preloop(&self, wc: &mut WhereCollector) -> TokenStream {
 		let atom_preloop = match self.shared_fields.as_slice() {
 			[] => TokenStream::new(),
-			[field] => field.atom_parse_if_peek(),
+			[field] => {
+				let inner = field.atom_parse_if_peek();
+				quote! { { let c = p.peek_n(1); #inner } }
+			}
 			_ => {
-				let atom = self.shared_atom().expect("shared_fields non-empty implies shared_atom");
 				let parse_steps: TokenStream = self.shared_fields.iter().map(|f| f.atom_match_arm()).collect();
-				emit_peek_loop(atom.binding_block(), parse_steps)
+				quote! {
+					loop {
+						let c = p.peek_n(1);
+						#parse_steps
+						break;
+					}
+				}
 			}
 		};
 
@@ -774,7 +788,13 @@ impl<'a> SharedAtomHoistPlan<'a> {
 				.iter()
 				.map(|f| f.parse_normal_tokens(FieldParseMode::OneMustOccur, wc))
 				.collect();
-			emit_peek_loop(TokenStream::new(), parse_steps)
+			quote! {
+				loop {
+					let c = p.peek_n(1);
+					#parse_steps
+					break;
+				}
+			}
 		};
 
 		quote! { #atom_preloop #type_preloop }
@@ -978,8 +998,6 @@ impl<'a> Plan for SharedAllMustOccurPlan<'a> {
 			}
 		};
 		let bindings: TokenStream = all_fields.iter().map(|(f, _)| f.binding()).collect();
-		let any_atom = all_fields.iter().find_map(|(f, _)| f.atom.as_ref());
-		let atom_binding = Atom::opt_binding_block(any_atom);
 		for (f, _) in all_fields.iter().filter(|(f, _)| f.atom.is_some()) {
 			wc.add(&f.ty.unpack_option());
 		}
@@ -991,8 +1009,9 @@ impl<'a> Plan for SharedAllMustOccurPlan<'a> {
 					let var = &f.var;
 					let ty = &f.ty.unpack_option();
 					let atom_path = atom.path();
+					let atom_set = atom.first_segment();
 					quote! {
-						if (#var.is_none() && _alternative == 0 && atom == #atom_path) {
+						if (#var.is_none() && _alternative == 0 && p.peek::<#ty>() && p.to_atom::<#atom_set>(c) == #atom_path) {
 							_alternative = #sentinel;
 							#var = Some(p.parse::<#ty>()?);
 							continue;
@@ -1006,7 +1025,6 @@ impl<'a> Plan for SharedAllMustOccurPlan<'a> {
 			})
 			.collect();
 
-		let peek_loop = emit_peek_loop(atom_binding, parse_steps);
 		let all_none_checks: Vec<TokenStream> = all_fields.iter().map(|(f, _)| f.none_check()).collect();
 		let nothing_parsed_check = quote! { #(#all_none_checks)&&* };
 		let match_arms: TokenStream = self
@@ -1065,7 +1083,11 @@ impl<'a> Plan for SharedAllMustOccurPlan<'a> {
 		quote! {
 			#bindings
 			let mut _alternative: usize = 0;
-			#peek_loop
+			loop {
+				let c = p.peek_n(1);
+				#parse_steps
+				break;
+			}
 			#trailing
 		}
 	}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_non_atom_only_input.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_non_atom_only_input.snap
@@ -23,12 +23,9 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         let mut length: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                p.to_atom::<FooAtoms>(c)
-            } else {
-                <FooAtoms>::default()
-            };
-            if auto.is_none() && atom == FooAtoms::Auto {
+            if auto.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::Auto
+            {
                 auto = Some(p.parse::<Ident>()?);
                 continue;
             }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_overlapping_lead_atoms.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_overlapping_lead_atoms.snap
@@ -15,21 +15,22 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         let mut _alternative: usize = 0;
         loop {
             let c = p.peek_n(1);
-            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                p.to_atom::<FooAtoms>(c)
-            } else {
-                <FooAtoms>::default()
-            };
-            if wrap.is_none() && atom == FooAtoms::Wrap {
+            if wrap.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::Wrap
+            {
                 wrap = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if (a.is_none() && _alternative == 0 && atom == FooAtoms::A) {
+            if (a.is_none() && _alternative == 0 && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::A)
+            {
                 _alternative = 1usize;
                 a = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if (b.is_none() && _alternative == 0 && atom == FooAtoms::B) {
+            if (b.is_none() && _alternative == 0 && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::B)
+            {
                 _alternative = 2usize;
                 b = Some(p.parse::<Ident>()?);
                 continue;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_non_ident_atom_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_non_ident_atom_field.snap
@@ -3,37 +3,37 @@ source: crates/csskit_derives/src/test/test_parse.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Parse<'a> for StableWithOptionalEdges {
+impl<'a> ::css_parse::Parse<'a> for VoiceVolume {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut stable: Option<Ident> = None;
-        let mut both_edges: Option<Ident> = None;
+        let mut soft: Option<Ident> = None;
+        let mut decibel: Option<Decibel> = None;
         loop {
             let c = p.peek_n(1);
-            if stable.is_none() && p.peek::<Ident>()
-                && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Stable
+            if soft.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::Soft
             {
-                stable = Some(p.parse::<Ident>()?);
+                soft = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if both_edges.is_none() && p.peek::<Ident>()
-                && p.to_atom::<CssAtomSet>(c) == CssAtomSet::BothEdges
+            if decibel.is_none() && p.peek::<Decibel>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::Db
             {
-                both_edges = Some(p.parse::<Ident>()?);
+                decibel = Some(p.parse::<Decibel>()?);
                 continue;
             }
             break;
         }
-        if stable.is_none() {
+        if soft.is_none() && decibel.is_none() {
             let c = p.peek_n(1);
             Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
         }
-        return Ok(Self {
-            stable: stable.unwrap(),
-            both_edges: both_edges,
+        return Ok(Self::Soft {
+            soft: soft,
+            decibel: decibel,
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_siblings_no_shared_atoms.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_siblings_no_shared_atoms.snap
@@ -19,24 +19,23 @@ impl<'a> ::css_parse::Parse<'a> for MarginTrim {
                 _ => {}
             }
         }
-        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::Block
-            || p.peek::<Ident>()
-                && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::Inline
+        let c = p.peek_n(1);
+        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::Block
+            || p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::Inline
         {
             let mut block: Option<Ident> = None;
             let mut inline: Option<Ident> = None;
             loop {
                 let c = p.peek_n(1);
-                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                    p.to_atom::<FooAtoms>(c)
-                } else {
-                    <FooAtoms>::default()
-                };
-                if block.is_none() && atom == FooAtoms::Block {
+                if block.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<FooAtoms>(c) == FooAtoms::Block
+                {
                     block = Some(p.parse::<Ident>()?);
                     continue;
                 }
-                if inline.is_none() && atom == FooAtoms::Inline {
+                if inline.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<FooAtoms>(c) == FooAtoms::Inline
+                {
                     inline = Some(p.parse::<Ident>()?);
                     continue;
                 }
@@ -51,25 +50,22 @@ impl<'a> ::css_parse::Parse<'a> for MarginTrim {
                 inline: inline,
             });
         }
-        if p.peek::<Ident>()
-            && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::BlockStart
-            || p.peek::<Ident>()
-                && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::BlockEnd
+        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockStart
+            || p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockEnd
         {
             let mut block_start: Option<Ident> = None;
             let mut block_end: Option<Ident> = None;
             loop {
                 let c = p.peek_n(1);
-                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                    p.to_atom::<FooAtoms>(c)
-                } else {
-                    <FooAtoms>::default()
-                };
-                if block_start.is_none() && atom == FooAtoms::BlockStart {
+                if block_start.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockStart
+                {
                     block_start = Some(p.parse::<Ident>()?);
                     continue;
                 }
-                if block_end.is_none() && atom == FooAtoms::BlockEnd {
+                if block_end.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockEnd
+                {
                     block_end = Some(p.parse::<Ident>()?);
                     continue;
                 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_variant_mixed_atom_and_type_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_variant_mixed_atom_and_type_fields.snap
@@ -23,17 +23,14 @@ impl<'a> ::css_parse::Parse<'a> for VerticalAlign {
             }
             break;
         }
-        if p.peek::<Ident>() && p.to_atom::<CssAtomSet>(p.peek_n(1)) == CssAtomSet::First
-        {
+        let c = p.peek_n(1);
+        if p.peek::<Ident>() && p.to_atom::<CssAtomSet>(c) == CssAtomSet::First {
             let mut first: Option<Ident> = None;
             loop {
                 let c = p.peek_n(1);
-                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                    p.to_atom::<CssAtomSet>(c)
-                } else {
-                    <CssAtomSet>::default()
-                };
-                if first.is_none() && atom == CssAtomSet::First {
+                if first.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<CssAtomSet>(c) == CssAtomSet::First
+                {
                     first = Some(p.parse::<Ident>()?);
                     continue;
                 }
@@ -59,17 +56,13 @@ impl<'a> ::css_parse::Parse<'a> for VerticalAlign {
                 baseline_shift: baseline_shift,
             });
         }
-        if p.peek::<Ident>() && p.to_atom::<CssAtomSet>(p.peek_n(1)) == CssAtomSet::Last
-        {
+        if p.peek::<Ident>() && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Last {
             let mut last: Option<Ident> = None;
             loop {
                 let c = p.peek_n(1);
-                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                    p.to_atom::<CssAtomSet>(c)
-                } else {
-                    <CssAtomSet>::default()
-                };
-                if last.is_none() && atom == CssAtomSet::Last {
+                if last.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Last
+                {
                     last = Some(p.parse::<Ident>()?);
                     continue;
                 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
@@ -23,16 +23,15 @@ impl<'a> ::css_parse::Parse<'a> for FlexWrap {
         let mut balance: Option<Ident> = None;
         loop {
             let c = p.peek_n(1);
-            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                p.to_atom::<FooAtoms>(c)
-            } else {
-                <FooAtoms>::default()
-            };
-            if wrap.is_none() && atom == FooAtoms::Wrap {
+            if wrap.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::Wrap
+            {
                 wrap = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if balance.is_none() && atom == FooAtoms::Balance {
+            if balance.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::Balance
+            {
                 balance = Some(p.parse::<Ident>()?);
                 continue;
             }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
@@ -20,25 +20,26 @@ impl<'a> ::css_parse::Parse<'a> for FlexWrap {
             }
         }
         let mut balance: Option<Ident> = None;
-        if p.peek::<::css_parse::token_macros::Ident>()
-            && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::Balance
         {
-            balance = Some(p.parse::<Ident>()?);
+            let c = p.peek_n(1);
+            if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::Balance {
+                balance = Some(p.parse::<Ident>()?);
+            }
         }
-        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::Wrap {
+        let c = p.peek_n(1);
+        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::Wrap {
             let mut wrap: Option<Ident> = None;
             loop {
                 let c = p.peek_n(1);
-                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                    p.to_atom::<FooAtoms>(c)
-                } else {
-                    <FooAtoms>::default()
-                };
-                if wrap.is_none() && atom == FooAtoms::Wrap {
+                if wrap.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<FooAtoms>(c) == FooAtoms::Wrap
+                {
                     wrap = Some(p.parse::<Ident>()?);
                     continue;
                 }
-                if balance.is_none() && atom == FooAtoms::Balance {
+                if balance.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<FooAtoms>(c) == FooAtoms::Balance
+                {
                     balance = Some(p.parse::<Ident>()?);
                     continue;
                 }
@@ -53,22 +54,19 @@ impl<'a> ::css_parse::Parse<'a> for FlexWrap {
                 balance: balance,
             });
         }
-        if p.peek::<Ident>()
-            && p.to_atom::<FooAtoms>(p.peek_n(1)) == FooAtoms::WrapReverse
-        {
+        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::WrapReverse {
             let mut wrap_reverse: Option<Ident> = None;
             loop {
                 let c = p.peek_n(1);
-                let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                    p.to_atom::<FooAtoms>(c)
-                } else {
-                    <FooAtoms>::default()
-                };
-                if wrap_reverse.is_none() && atom == FooAtoms::WrapReverse {
+                if wrap_reverse.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<FooAtoms>(c) == FooAtoms::WrapReverse
+                {
                     wrap_reverse = Some(p.parse::<Ident>()?);
                     continue;
                 }
-                if balance.is_none() && atom == FooAtoms::Balance {
+                if balance.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<FooAtoms>(c) == FooAtoms::Balance
+                {
                     balance = Some(p.parse::<Ident>()?);
                     continue;
                 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
@@ -18,16 +18,15 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurEnum {
                     let mut length: Option<Length> = None;
                     loop {
                         let c = p.peek_n(1);
-                        let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                            p.to_atom::<FooKeywords>(c)
-                        } else {
-                            <FooKeywords>::default()
-                        };
-                        if auto_field.is_none() && atom == FooKeywords::Auto {
+                        if auto_field.is_none() && p.peek::<AutoValue>()
+                            && p.to_atom::<FooKeywords>(c) == FooKeywords::Auto
+                        {
                             auto_field = Some(p.parse::<AutoValue>()?);
                             continue;
                         }
-                        if none_field.is_none() && atom == FooKeywords::None {
+                        if none_field.is_none() && p.peek::<NoneValue>()
+                            && p.to_atom::<FooKeywords>(c) == FooKeywords::None
+                        {
                             none_field = Some(p.parse::<NoneValue>()?);
                             continue;
                         }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_optional_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_optional_fields.snap
@@ -21,16 +21,15 @@ impl<'a> ::css_parse::Parse<'a> for ScrollbarGutter {
                     let mut both_edges: Option<Ident> = None;
                     loop {
                         let c = p.peek_n(1);
-                        let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                            p.to_atom::<CssAtomSet>(c)
-                        } else {
-                            <CssAtomSet>::default()
-                        };
-                        if stable.is_none() && atom == CssAtomSet::Stable {
+                        if stable.is_none() && p.peek::<Ident>()
+                            && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Stable
+                        {
                             stable = Some(p.parse::<Ident>()?);
                             continue;
                         }
-                        if both_edges.is_none() && atom == CssAtomSet::BothEdges {
+                        if both_edges.is_none() && p.peek::<Ident>()
+                            && p.to_atom::<CssAtomSet>(c) == CssAtomSet::BothEdges
+                        {
                             both_edges = Some(p.parse::<Ident>()?);
                             continue;
                         }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
@@ -14,16 +14,11 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurNewtypeTest {
         let mut length: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                p.to_atom::<Auto>(c)
-            } else {
-                <Auto>::default()
-            };
-            if auto_value.is_none() && atom == Auto {
+            if auto_value.is_none() && p.peek::<Auto>() && p.to_atom::<Auto>(c) == Auto {
                 auto_value = Some(p.parse::<Auto>()?);
                 continue;
             }
-            if none_value.is_none() && atom == None {
+            if none_value.is_none() && p.peek::<None>() && p.to_atom::<None>(c) == None {
                 none_value = Some(p.parse::<None>()?);
                 continue;
             }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
@@ -14,16 +14,15 @@ impl<'a> ::css_parse::Parse<'a> for SpecificKeywordTest {
         let mut length: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                p.to_atom::<FooKeywords>(c)
-            } else {
-                <FooKeywords>::default()
-            };
-            if auto_field.is_none() && atom == FooKeywords::Auto {
+            if auto_field.is_none() && p.peek::<AutoValue>()
+                && p.to_atom::<FooKeywords>(c) == FooKeywords::Auto
+            {
                 auto_field = Some(p.parse::<AutoValue>()?);
                 continue;
             }
-            if none_field.is_none() && atom == FooKeywords::None {
+            if none_field.is_none() && p.peek::<NoneValue>()
+                && p.to_atom::<FooKeywords>(c) == FooKeywords::None
+            {
                 none_field = Some(p.parse::<NoneValue>()?);
                 continue;
             }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
@@ -13,16 +13,15 @@ impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
         let mut none_value: Option<Ident> = None;
         loop {
             let c = p.peek_n(1);
-            let atom = if p.peek::<::css_parse::token_macros::Ident>() {
-                p.to_atom::<FooKeywords>(c)
-            } else {
-                <FooKeywords>::default()
-            };
-            if auto_value.is_none() && atom == FooKeywords::Auto {
+            if auto_value.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooKeywords>(c) == FooKeywords::Auto
+            {
                 auto_value = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if none_value.is_none() && atom == FooKeywords::None {
+            if none_value.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooKeywords>(c) == FooKeywords::None
+            {
                 none_value = Some(p.parse::<Ident>()?);
                 continue;
             }

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -604,6 +604,25 @@ fn parse_enum_all_must_occur_overlapping_lead_atoms() {
 	assert_parse_snapshot!(data, "parse_enum_all_must_occur_overlapping_lead_atoms");
 }
 
+/// Regression: atom_match_arm used the ident-based `atom` loop variable, which
+/// was always CssAtomSet::default() for non-Ident tokens (e.g. Dimension), so
+/// `soft 6db` would fail to parse the decibel field in the loop.
+#[test]
+fn parse_enum_one_must_occur_non_ident_atom_field() {
+	let data = to_deriveinput! {
+		enum VoiceVolume {
+			#[parse(one_must_occur)]
+			Soft {
+				#[atom(FooAtoms::Soft)]
+				soft: Option<Ident>,
+				#[atom(FooAtoms::Db)]
+				decibel: Option<Decibel>,
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_one_must_occur_non_ident_atom_field");
+}
+
 #[test]
 fn parse_enum_all_must_occur_non_atom_only_input() {
 	let data = to_deriveinput! {


### PR DESCRIPTION
Currently when going down the atom parse path we check for an Ident and extract
the atom for comparison, but that's rather limiting considering we could have a
function/dimension/at-keyword atom type. Those would fail as the Atom would be
the default atom.

This change switches the atom extraction stepps to grab the cursor and peek on
the inner type, instead. This will allow these other types to be used in
combination with atoms.