### PR TITLE
csskit_proc_macro: Wrap Zero-Or-More vecs in Option<>

### DIFF
--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -2566,7 +2567,7 @@ StyleSheet(
                 offset: SourceOffset(2201),
                 len: 1,
               )),
-              value: CursorStyleValue([], Help(Ident(Cursor(
+              value: CursorStyleValue(None, Help(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(2203),
                 len: 4,
@@ -5405,7 +5406,7 @@ StyleSheet(
                 offset: SourceOffset(4136),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(4138),
                 len: 7,
@@ -5888,7 +5889,7 @@ StyleSheet(
                 offset: SourceOffset(4402),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(4404),
                 len: 7,
@@ -7292,7 +7293,7 @@ StyleSheet(
                 offset: SourceOffset(5442),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(5444),
                 len: 7,
@@ -64925,7 +64926,7 @@ StyleSheet(
                 offset: SourceOffset(47054),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(47056),
                 len: 7,
@@ -115899,7 +115900,7 @@ StyleSheet(
                 offset: SourceOffset(84536),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(84538),
                 len: 7,
@@ -116787,7 +116788,7 @@ StyleSheet(
                 offset: SourceOffset(85342),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(85344),
                 len: 7,
@@ -117712,7 +117713,7 @@ StyleSheet(
                 offset: SourceOffset(86157),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(86159),
                 len: 7,
@@ -118161,7 +118162,7 @@ StyleSheet(
                 offset: SourceOffset(86596),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(86598),
                 len: 7,
@@ -118321,7 +118322,7 @@ StyleSheet(
                 offset: SourceOffset(86736),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(86738),
                 len: 7,
@@ -119256,7 +119257,7 @@ StyleSheet(
                 offset: SourceOffset(87489),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(87491),
                 len: 7,
@@ -142802,7 +142803,7 @@ StyleSheet(
                 offset: SourceOffset(105880),
                 len: 1,
               )),
-              value: CursorStyleValue([], Auto(Ident(Cursor(
+              value: CursorStyleValue(None, Auto(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(105882),
                 len: 4,
@@ -181181,7 +181182,7 @@ StyleSheet(
                 offset: SourceOffset(136833),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(136835),
                 len: 7,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.min.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.min.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -8470,7 +8471,7 @@ StyleSheet(
                 offset: SourceOffset(6496),
                 len: 1,
               )),
-              value: CursorStyleValue([], Help(Ident(Cursor(
+              value: CursorStyleValue(None, Help(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(6497),
                 len: 4,
@@ -11818,7 +11819,7 @@ StyleSheet(
                 offset: SourceOffset(8352),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(8353),
                 len: 7,
@@ -12682,7 +12683,7 @@ StyleSheet(
                 offset: SourceOffset(8760),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(8761),
                 len: 7,
@@ -14039,7 +14040,7 @@ StyleSheet(
                 offset: SourceOffset(9722),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(9723),
                 len: 7,
@@ -48021,7 +48022,7 @@ StyleSheet(
                 offset: SourceOffset(29030),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(29031),
                 len: 7,
@@ -52930,7 +52931,7 @@ StyleSheet(
                 offset: SourceOffset(32660),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(32661),
                 len: 7,
@@ -57578,7 +57579,7 @@ StyleSheet(
                 offset: SourceOffset(36926),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(36927),
                 len: 7,
@@ -60590,7 +60591,7 @@ StyleSheet(
                 offset: SourceOffset(39516),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(39517),
                 len: 7,
@@ -61452,7 +61453,7 @@ StyleSheet(
                 offset: SourceOffset(40202),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(40203),
                 len: 7,
@@ -78665,7 +78666,7 @@ StyleSheet(
                 offset: SourceOffset(53563),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(53564),
                 len: 7,
@@ -104111,7 +104112,7 @@ StyleSheet(
                 offset: SourceOffset(73577),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(73578),
                 len: 7,
@@ -176492,7 +176493,7 @@ StyleSheet(
                 offset: SourceOffset(137558),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(137559),
                 len: 7,
@@ -194744,7 +194745,7 @@ StyleSheet(
                 offset: SourceOffset(150996),
                 len: 1,
               )),
-              value: CursorStyleValue([], Wait(Ident(Cursor(
+              value: CursorStyleValue(None, Wait(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(150997),
                 len: 4,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -10063,7 +10064,7 @@ StyleSheet(
                 offset: SourceOffset(7808),
                 len: 1,
               )),
-              value: CursorStyleValue([], Help(Ident(Cursor(
+              value: CursorStyleValue(None, Help(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(7810),
                 len: 4,
@@ -13611,7 +13612,7 @@ StyleSheet(
                 offset: SourceOffset(10162),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(10164),
                 len: 7,
@@ -14495,7 +14496,7 @@ StyleSheet(
                 offset: SourceOffset(10620),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(10622),
                 len: 7,
@@ -15921,7 +15922,7 @@ StyleSheet(
                 offset: SourceOffset(11894),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(11896),
                 len: 7,
@@ -52578,7 +52579,7 @@ StyleSheet(
                 offset: SourceOffset(37720),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(37722),
                 len: 7,
@@ -57796,7 +57797,7 @@ StyleSheet(
                 offset: SourceOffset(41927),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(41929),
                 len: 7,
@@ -62796,7 +62797,7 @@ StyleSheet(
                 offset: SourceOffset(46739),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(46741),
                 len: 7,
@@ -66033,7 +66034,7 @@ StyleSheet(
                 offset: SourceOffset(49708),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(49710),
                 len: 7,
@@ -66946,7 +66947,7 @@ StyleSheet(
                 offset: SourceOffset(50516),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(50518),
                 len: 7,
@@ -85306,7 +85307,7 @@ StyleSheet(
                 offset: SourceOffset(65497),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(65499),
                 len: 7,
@@ -113668,7 +113669,7 @@ StyleSheet(
                 offset: SourceOffset(88789),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(88791),
                 len: 7,
@@ -192968,7 +192969,7 @@ StyleSheet(
                 offset: SourceOffset(162240),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(162242),
                 len: 7,
@@ -212510,7 +212511,7 @@ StyleSheet(
                 offset: SourceOffset(178599),
                 len: 1,
               )),
-              value: CursorStyleValue([], Wait(Ident(Cursor(
+              value: CursorStyleValue(None, Wait(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(178601),
                 len: 4,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.min.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.min.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -5176,7 +5177,7 @@ StyleSheet(
                 offset: SourceOffset(3283),
                 len: 1,
               )),
-              value: CursorStyleValue([], Auto(Ident(Cursor(
+              value: CursorStyleValue(None, Auto(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(3284),
                 len: 4,
@@ -82977,7 +82978,7 @@ StyleSheet(
                 offset: SourceOffset(48762),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(48763),
                 len: 7,
@@ -84229,7 +84230,7 @@ StyleSheet(
                 offset: SourceOffset(49435),
                 len: 1,
               )),
-              value: CursorStyleValue([], Help(Ident(Cursor(
+              value: CursorStyleValue(None, Help(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(49436),
                 len: 4,
@@ -88920,7 +88921,7 @@ StyleSheet(
                 offset: SourceOffset(52368),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(52369),
                 len: 7,
@@ -100943,7 +100944,7 @@ StyleSheet(
                 offset: SourceOffset(58979),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(58980),
                 len: 11,
@@ -105362,7 +105363,7 @@ StyleSheet(
                 offset: SourceOffset(61740),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(61741),
                 len: 11,
@@ -106454,7 +106455,7 @@ StyleSheet(
                 offset: SourceOffset(62379),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(62380),
                 len: 7,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -5467,7 +5468,7 @@ StyleSheet(
                 offset: SourceOffset(4243),
                 len: 1,
               )),
-              value: CursorStyleValue([], Auto(Ident(Cursor(
+              value: CursorStyleValue(None, Auto(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(4245),
                 len: 4,
@@ -88503,7 +88504,7 @@ StyleSheet(
                 offset: SourceOffset(63683),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(63685),
                 len: 7,
@@ -89807,7 +89808,7 @@ StyleSheet(
                 offset: SourceOffset(64566),
                 len: 1,
               )),
-              value: CursorStyleValue([], Help(Ident(Cursor(
+              value: CursorStyleValue(None, Help(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(64568),
                 len: 4,
@@ -94752,7 +94753,7 @@ StyleSheet(
                 offset: SourceOffset(68329),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(68331),
                 len: 7,
@@ -106991,7 +106992,7 @@ StyleSheet(
                 offset: SourceOffset(75807),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(75809),
                 len: 11,
@@ -111536,7 +111537,7 @@ StyleSheet(
                 offset: SourceOffset(79069),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(79071),
                 len: 11,
@@ -112678,7 +112679,7 @@ StyleSheet(
                 offset: SourceOffset(79868),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(79870),
                 len: 7,
@@ -117714,7 +117715,7 @@ StyleSheet(
                 offset: SourceOffset(84637),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(84639),
                 len: 11,
@@ -119122,7 +119123,7 @@ StyleSheet(
                 offset: SourceOffset(85676),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(85678),
                 len: 11,
@@ -122262,7 +122263,7 @@ StyleSheet(
                 offset: SourceOffset(88193),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(88195),
                 len: 7,
@@ -124698,7 +124699,7 @@ StyleSheet(
                 offset: SourceOffset(89982),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(89984),
                 len: 7,
@@ -125194,7 +125195,7 @@ StyleSheet(
                 offset: SourceOffset(90346),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(90348),
                 len: 11,
@@ -153225,7 +153226,7 @@ StyleSheet(
                 offset: SourceOffset(109402),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(109404),
                 len: 7,
@@ -165831,7 +165832,7 @@ StyleSheet(
                 offset: SourceOffset(118793),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(118795),
                 len: 7,
@@ -166787,7 +166788,7 @@ StyleSheet(
                 offset: SourceOffset(119397),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(119399),
                 len: 7,
@@ -181343,7 +181344,7 @@ StyleSheet(
                 offset: SourceOffset(130476),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(130478),
                 len: 7,
@@ -184138,7 +184139,7 @@ StyleSheet(
                 offset: SourceOffset(132653),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(132655),
                 len: 7,
@@ -202686,7 +202687,7 @@ StyleSheet(
                 offset: SourceOffset(148546),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(148548),
                 len: 7,
@@ -202811,7 +202812,7 @@ StyleSheet(
                 offset: SourceOffset(148648),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(148650),
                 len: 11,
@@ -207503,7 +207504,7 @@ StyleSheet(
                 offset: SourceOffset(152203),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(152205),
                 len: 7,
@@ -208398,7 +208399,7 @@ StyleSheet(
                 offset: SourceOffset(152943),
                 len: 1,
               )),
-              value: CursorStyleValue([], Grab(Ident(Cursor(
+              value: CursorStyleValue(None, Grab(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(152945),
                 len: 4,
@@ -208998,7 +208999,7 @@ StyleSheet(
                 offset: SourceOffset(153471),
                 len: 1,
               )),
-              value: CursorStyleValue([], Grabbing(Ident(Cursor(
+              value: CursorStyleValue(None, Grabbing(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(153473),
                 len: 8,
@@ -209130,7 +209131,7 @@ StyleSheet(
                 offset: SourceOffset(153549),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(153551),
                 len: 11,
@@ -211353,7 +211354,7 @@ StyleSheet(
                 offset: SourceOffset(155190),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(155192),
                 len: 7,
@@ -212131,7 +212132,7 @@ StyleSheet(
                 offset: SourceOffset(155804),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(155806),
                 len: 11,
@@ -220961,7 +220962,7 @@ StyleSheet(
                 offset: SourceOffset(162010),
                 len: 1,
               )),
-              value: CursorStyleValue([], Help(Ident(Cursor(
+              value: CursorStyleValue(None, Help(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(162012),
                 len: 4,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__inuitcss.6.0.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__inuitcss.6.0.0.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -2585,7 +2586,7 @@ StyleSheet(
                 offset: SourceOffset(16252),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(16254),
                 len: 7,
@@ -2699,7 +2700,7 @@ StyleSheet(
                 offset: SourceOffset(16380),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(16382),
                 len: 7,
@@ -4039,7 +4040,7 @@ StyleSheet(
                 offset: SourceOffset(18515),
                 len: 1,
               )),
-              value: CursorStyleValue([], Help(Ident(Cursor(
+              value: CursorStyleValue(None, Help(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(18517),
                 len: 4,
@@ -4322,7 +4323,7 @@ StyleSheet(
                 offset: SourceOffset(18940),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(18942),
                 len: 7,
@@ -4456,7 +4457,7 @@ StyleSheet(
                 offset: SourceOffset(19035),
                 len: 1,
               )),
-              value: CursorStyleValue([], Text(Ident(Cursor(
+              value: CursorStyleValue(None, Text(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(19037),
                 len: 4,
@@ -29094,7 +29095,7 @@ StyleSheet(
                 offset: SourceOffset(50021),
                 len: 1,
               )),
-              value: CursorStyleValue([], Help(Ident(Cursor(
+              value: CursorStyleValue(None, Help(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(50023),
                 len: 4,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -25415,7 +25416,7 @@ StyleSheet(
                 offset: SourceOffset(17976),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(17978),
                 len: 7,
@@ -26747,7 +26748,7 @@ StyleSheet(
                 offset: SourceOffset(18778),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(18780),
                 len: 11,
@@ -39352,7 +39353,7 @@ StyleSheet(
                 offset: SourceOffset(27263),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(27265),
                 len: 7,
@@ -53375,7 +53376,7 @@ StyleSheet(
                 offset: SourceOffset(36902),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(36904),
                 len: 7,
@@ -55442,7 +55443,7 @@ StyleSheet(
                 offset: SourceOffset(38367),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(38369),
                 len: 7,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -252,7 +253,7 @@ StyleSheet(
                 offset: SourceOffset(204),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(206),
                 len: 7,
@@ -2314,7 +2315,7 @@ StyleSheet(
                 offset: SourceOffset(1636),
                 len: 1,
               )),
-              value: CursorStyleValue([], Progress(Ident(Cursor(
+              value: CursorStyleValue(None, Progress(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(1638),
                 len: 8,
@@ -2416,7 +2417,7 @@ StyleSheet(
                 offset: SourceOffset(1693),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(1695),
                 len: 11,
@@ -18616,7 +18617,7 @@ StyleSheet(
                         offset: SourceOffset(12523),
                         len: 1,
                       )),
-                      value: CursorStyleValue([], Pointer(Ident(Cursor(
+                      value: CursorStyleValue(None, Pointer(Ident(Cursor(
                         kind: "Ident",
                         offset: SourceOffset(12525),
                         len: 7,
@@ -23727,7 +23728,7 @@ StyleSheet(
                 offset: SourceOffset(16059),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(16061),
                 len: 7,
@@ -24933,7 +24934,7 @@ StyleSheet(
                         offset: SourceOffset(16834),
                         len: 1,
                       )),
-                      value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+                      value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                         kind: "Ident",
                         offset: SourceOffset(16836),
                         len: 11,
@@ -25506,7 +25507,7 @@ StyleSheet(
                 offset: SourceOffset(17162),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(17164),
                 len: 7,
@@ -28098,7 +28099,7 @@ StyleSheet(
                 offset: SourceOffset(18879),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(18881),
                 len: 11,
@@ -37903,7 +37904,7 @@ StyleSheet(
                 offset: SourceOffset(26035),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(26037),
                 len: 7,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__pure.2.0.3.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__pure.2.0.3.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -7571,7 +7572,7 @@ StyleSheet(
                 offset: SourceOffset(11626),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(11628),
                 len: 7,
@@ -9946,7 +9947,7 @@ StyleSheet(
                 offset: SourceOffset(13501),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(13503),
                 len: 11,
@@ -15255,7 +15256,7 @@ StyleSheet(
                 offset: SourceOffset(17819),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(17821),
                 len: 11,
@@ -15432,7 +15433,7 @@ StyleSheet(
                 offset: SourceOffset(18084),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(18086),
                 len: 11,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__sakura.1.5.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__sakura.1.5.1.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -3626,7 +3627,7 @@ StyleSheet(
                 offset: SourceOffset(2899),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(2901),
                 len: 7,
@@ -4350,7 +4351,7 @@ StyleSheet(
                 offset: SourceOffset(3318),
                 len: 1,
               )),
-              value: CursorStyleValue([], Default(Ident(Cursor(
+              value: CursorStyleValue(None, Default(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(3320),
                 len: 7,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__water.2.1.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__water.2.1.1.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -10619,7 +10620,7 @@ StyleSheet(
                 offset: SourceOffset(9336),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(9338),
                 len: 7,
@@ -16217,7 +16218,7 @@ StyleSheet(
                 offset: SourceOffset(13515),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(13517),
                 len: 7,
@@ -21480,7 +21481,7 @@ StyleSheet(
                 offset: SourceOffset(18843),
                 len: 1,
               )),
-              value: CursorStyleValue([], NotAllowed(Ident(Cursor(
+              value: CursorStyleValue(None, NotAllowed(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(18845),
                 len: 11,
@@ -36913,7 +36914,7 @@ StyleSheet(
                 offset: SourceOffset(29723),
                 len: 1,
               )),
-              value: CursorStyleValue([], Pointer(Ident(Cursor(
+              value: CursorStyleValue(None, Pointer(Ident(Cursor(
                 kind: "Ident",
                 offset: SourceOffset(29725),
                 len: 7,

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -216,9 +216,16 @@ impl ToType for Def {
 				};
 				vec![quote! { ::css_parse::CommaSeparated<'a, #ty, #min> }]
 			}
-			Self::Multiplier(def, DefMultiplierSeparator::None, _) => {
+			Self::Multiplier(def, DefMultiplierSeparator::None, range) => {
 				let ty = def.deref().to_type();
-				vec![quote! { ::bumpalo::collections::Vec<'a, #ty> }]
+				match range {
+					DefRange::RangeFrom(f) if *f == 0.0 => {
+						vec![quote! { Option<::bumpalo::collections::Vec<'a, #ty>> }]
+					}
+					_ => {
+						vec![quote! { ::bumpalo::collections::Vec<'a, #ty> }]
+					}
+				}
 			}
 			Self::IntLiteral(value) => {
 				let val = *value;
@@ -748,9 +755,15 @@ impl GenerateDefinition for Def {
 									};
 									vec![quote! { ::css_parse::CommaSeparated<'a, #inner_type_ref, #min> }]
 								}
-								DefMultiplierSeparator::None => {
-									vec![quote! { ::bumpalo::collections::Vec<'a, #inner_type_ref> }]
-								}
+								DefMultiplierSeparator::None => match range {
+									DefRange::Range(Range { start, .. }) if *start == 0.0 => {
+										vec![quote! { Option<::bumpalo::collections::Vec<'a, #inner_type_ref>> }]
+									}
+									_ => {
+										dbg!(range);
+										vec![quote! { Option<::bumpalo::collections::Vec<'a, #inner_type_ref> }]
+									}
+								},
 							};
 							quote! { ( #(pub #ty),* ); }
 						}

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_list.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_list.snap
@@ -1,0 +1,31 @@
+---
+source: crates/csskit_proc_macro/src/test/test_generate.rs
+expression: pretty
+snapshot_kind: text
+---
+#[derive(
+    ::csskit_derives::Parse,
+    ::csskit_derives::Peek,
+    ::csskit_derives::ToCursors,
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::SemanticEq,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(skip))]
+pub enum FooKeywords {}
+#[derive(Parse)]
+struct Foo<'a>(
+    pub Option<
+        ::bumpalo::collections::Vec<'a, (::css_parse::T![Ident], ::css_parse::T![,])>,
+    >,
+    #[atom(CssAtomSet::Bar)]
+    pub FooKeywords,
+);

--- a/crates/csskit_proc_macro/src/test/test_generate.rs
+++ b/crates/csskit_proc_macro/src/test/test_generate.rs
@@ -461,7 +461,6 @@ fn enum_with_ordered_punct() {
 
 #[test]
 fn enum_with_keyword_options() {
-	// 4 alternatives stays as enum (not folded to NoneOr)
 	let syntax =
 		to_valuedef! { none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error };
 	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
@@ -470,7 +469,6 @@ fn enum_with_keyword_options() {
 
 #[test]
 fn enum_with_mixed_options() {
-	// 3 alternatives: keyword, type-only options, mixed options
 	let syntax = to_valuedef! { none | [ <angle> || flip ] | <length> };
 	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
 	assert_snapshot!(syntax, data, "enum_with_mixed_options");
@@ -478,7 +476,6 @@ fn enum_with_mixed_options() {
 
 #[test]
 fn enum_with_type_only_options() {
-	// type-only options use Optionals! directly (no helper struct needed)
 	let syntax = to_valuedef! { none | [ <angle> || <percentage> ] | <length> };
 	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
 	assert_snapshot!(syntax, data, "enum_with_type_only_options");
@@ -486,7 +483,6 @@ fn enum_with_type_only_options() {
 
 #[test]
 fn struct_nonor_keyword_options() {
-	// NoneOr wrapping Options-with-keywords generates helper struct
 	let syntax = to_valuedef! { none | [ weight || style || small-caps || position ] };
 	let data = to_deriveinput! { #[derive(Parse)] struct Foo; };
 	assert_snapshot!(syntax, data, "struct_nonor_keyword_options");
@@ -494,10 +490,6 @@ fn struct_nonor_keyword_options() {
 
 #[test]
 fn enum_with_keyword_group_in_options() {
-	// Upcoming flex-wrap grammar: `nowrap | [ wrap | wrap-reverse ] || balance`.
-	// The `||` operand `[ wrap | wrap-reverse ]` is a keyword-only alternation
-	// group. Codegen should mint an inline keyword enum so the Options helper
-	// struct's field can hold it.
 	let syntax = to_valuedef! { nowrap | [ wrap | wrap-reverse ] || balance };
 	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
 	assert_snapshot!(syntax, data, "enum_with_keyword_group_in_options");
@@ -505,9 +497,6 @@ fn enum_with_keyword_group_in_options() {
 
 #[test]
 fn keyword_only_alternation_group_in_options() {
-	// Isolated form: `||` over a keyword-only alternation group plus a plain
-	// keyword. The optimiser distributes the inner alternation over `||`,
-	// producing a top-level alternation that requires an enum.
 	let syntax = to_valuedef! { [ wrap | wrap-reverse ] || balance };
 	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
 	assert_snapshot!(syntax, data, "keyword_only_alternation_group_in_options");
@@ -525,4 +514,11 @@ fn enum_keyword_group_with_nested_options() {
 	let syntax = to_valuedef!(" [ foo | bar ] || [ baz || qux ] ");
 	let data = to_deriveinput! { #[derive(Parse)] enum Foo<'a> {} };
 	assert_snapshot!(syntax, data, "enum_keyword_group_with_nested_options");
+}
+
+#[test]
+fn struct_keyword_group_list() {
+	let syntax = to_valuedef!(" [ foo,]* bar ");
+	let data = to_deriveinput! { #[derive(Parse)] struct Foo<'a> {} };
+	assert_snapshot!(syntax, data, "enum_keyword_group_list");
 }


### PR DESCRIPTION
Groups with zero-or-more such as `[ foo, ]*` currently use a Vec, with no extra
validation to indicate that they're zero-or-more. This is problematic because we
lose the information that this group is optional, which means Peek derives
assume it's required.

This change wraps such syntax in an Option, which allows Peek impls to skip it.
We could add some additional attributes for Peek to handle but this feels much
simpler and is truer to the intent.
