### PR TITLE
csskit_derives: Optimise Peek derive to use PEEK_KINDSET when possible

### DIFF
--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -4,10 +4,31 @@ use crate::{
 	ensure_lifetime_a,
 	field_view::option_inner,
 };
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
-use std::collections::HashMap;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Result, Type, parse_quote};
+use std::collections::{HashMap, hash_map::Entry};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Ident, Result, Type, parse_quote};
+
+/// Map indivudal type names to a Kind, if possible.
+fn map_type_to_kind(ty: &Type) -> Option<&'static str> {
+	if let Type::Path(path) = option_inner(ty).unwrap_or(ty)
+		&& let Some(seg) = path.path.segments.last()
+	{
+		match seg.ident.to_string().as_str() {
+			"Ident" => Some("Ident"),
+			"String" => Some("String"),
+			"Number" => Some("Number"),
+			"Dimension" => Some("Number"),
+			"Function" => Some("Function"),
+			"AtKeyword" => Some("AtKeyword"),
+			"Hash" => Some("Hash"),
+			"Delim" => Some("Delim"),
+			_ => None,
+		}
+	} else {
+		None
+	}
+}
 
 /// Build a peek check for a single type, optionally constrained to a set of atoms.
 /// `atoms` empty means unconstrained (just `peek`); non-empty means `peek && (atom || atom || ...)`.
@@ -31,6 +52,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let generic_with_a = ensure_lifetime_a(generics);
 	let (impl_generics, _, _) = generic_with_a.split_for_impl();
 	let (_, type_generics, _) = generics.split_for_impl();
+	let mut kinds = vec![];
 	let body = match input.data {
 		Data::Union(_) => return Err(Error::new(ident.span(), "Cannot derive Peek on a Union")),
 
@@ -41,7 +63,12 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 				let atom = extract_atom(&syn_field.attrs)?;
 				let atoms = atom.map(|a| vec![a]).unwrap_or_default();
 				let peek_ty = option_inner(view.ty).unwrap_or(view.ty);
-				checks.push(generate_type_peek(peek_ty, &atoms, &mut where_collector));
+				if let Some(kind) = map_type_to_kind(peek_ty) {
+					let ident = Ident::new(kind, Span::call_site());
+					kinds.push(quote! { ::css_lexer::Kind::#ident });
+				} else {
+					checks.push(generate_type_peek(peek_ty, &atoms, &mut where_collector));
+				}
 				if !parse_mode.any_field_can_start() && !view.is_option {
 					break;
 				}
@@ -55,12 +82,22 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 
 			let mut register = |peek_ty: &Type, atom: Option<Atom>| {
 				let key = peek_ty.to_token_stream().to_string();
+				if atom.is_none()
+					&& let Some(kind) = map_type_to_kind(peek_ty)
+				{
+					if !seen.contains(&kind.to_string()) {
+						seen.push(kind.to_string());
+						let ident = Ident::new(kind, Span::call_site());
+						kinds.push(quote! { ::css_lexer::Kind::#ident });
+					}
+					return;
+				}
 				match by_type.entry(key.clone()) {
-					std::collections::hash_map::Entry::Vacant(e) => {
+					Entry::Vacant(e) => {
 						seen.push(key);
 						e.insert(atom.map(|a| vec![a]));
 					}
-					std::collections::hash_map::Entry::Occupied(mut e) => match (e.get_mut(), atom) {
+					Entry::Occupied(mut e) => match (e.get_mut(), atom) {
 						(None, _) => {}
 						(slot @ Some(_), None) => *slot = None,
 						(Some(existing), Some(a)) => {
@@ -97,7 +134,9 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 
 			let mut type_checks: Vec<TokenStream> = vec![];
 			for key in &seen {
-				let entry = by_type.remove(key).unwrap();
+				let Some(entry) = by_type.remove(key) else {
+					continue;
+				};
 				let ty = variants
 					.iter()
 					.find_map(|v| {
@@ -116,17 +155,35 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 
 	let generics = input.generics.clone();
 	let where_clause = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::Peek<'a> });
+	let (peek_kindset, kindset_cond) = if kinds.is_empty() {
+		(None, None)
+	} else {
+		(
+			Some(quote! {
+			  const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(&[ #(#kinds),* ]);
+			}),
+			Some(quote! { c == Self::PEEK_KINDSET ||  }),
+		)
+	};
+	let peek_fn = if body.is_empty() {
+		None
+	} else {
+		Some(quote! {
+			fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
+			where
+				I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+				{
+				use ::css_parse::{Peek};
+				#kindset_cond #body
+			}
+		})
+	};
 
 	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics ::css_parse::Peek<'a> for #ident #type_generics #where_clause {
-			fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
-			where
-				I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
-			{
-				use ::css_parse::{Peek};
-				#body
-			}
+			#peek_kindset
+			#peek_fn
 		}
 	})
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_different_types.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_different_types.snap
@@ -1,14 +1,18 @@
 ---
 source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
+snapshot_kind: text
 ---
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Value {
+    const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(
+        &[::css_lexer::Kind::Ident],
+    );
     fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use ::css_parse::Peek;
-        <Ident>::peek(p, c) || <Length>::peek(p, c) || <Percentage>::peek(p, c)
+        c == Self::PEEK_KINDSET || <Length>::peek(p, c) || <Percentage>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_lifetime.snap
@@ -1,14 +1,18 @@
 ---
 source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
+snapshot_kind: text
 ---
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for CssValue<'a> {
+    const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(
+        &[::css_lexer::Kind::Ident, ::css_lexer::Kind::String],
+    );
     fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use ::css_parse::Peek;
-        <Ident>::peek(p, c) || <Length>::peek(p, c) || <String>::peek(p, c)
+        c == Self::PEEK_KINDSET || <Length>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_simple_enum.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_simple_enum.snap
@@ -1,14 +1,11 @@
 ---
 source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
+snapshot_kind: text
 ---
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Display {
-    fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
-    where
-        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
-    {
-        use ::css_parse::Peek;
-        <Ident>::peek(p, c)
-    }
+    const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(
+        &[::css_lexer::Kind::Ident],
+    );
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_simple_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_simple_struct.snap
@@ -1,14 +1,11 @@
 ---
 source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
+snapshot_kind: text
 ---
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Length {
-    fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
-    where
-        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
-    {
-        use ::css_parse::Peek;
-        <Number>::peek(p, c)
-    }
+    const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(
+        &[::css_lexer::Kind::Number],
+    );
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_all_must_occur.snap
@@ -1,14 +1,18 @@
 ---
 source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
+snapshot_kind: text
 ---
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Params {
+    const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(
+        &[::css_lexer::Kind::Ident],
+    );
     fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use ::css_parse::Peek;
-        <Ident>::peek(p, c) || <Percentage>::peek(p, c)
+        c == Self::PEEK_KINDSET || <Percentage>::peek(p, c)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_lifetime.snap
@@ -1,14 +1,11 @@
 ---
 source: crates/csskit_derives/src/test/test_peek.rs
 expression: pretty
+snapshot_kind: text
 ---
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Value<'a> {
-    fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
-    where
-        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
-    {
-        use ::css_parse::Peek;
-        <Ident>::peek(p, c)
-    }
+    const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(
+        &[::css_lexer::Kind::Ident],
+    );
 }


### PR DESCRIPTION
Right now we always derive a Peek function even when types are potential
trivial tokens that could use PEEK_KINDSET and the default impl.

This change does just that - it maps a set of simple type names to the KindSet
types to allow us to assign PEEK_KINDSET instead, only if the types are simple.
For more complex types we still use the function form.
