### PR TITLE
csskit_derives: Ensure peek checks enum variants after Option

### DIFF
--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -113,22 +113,17 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 			for variant in variants.iter() {
 				let views = variant.fields.views();
 				let parse_mode = extract_field_parse_mode(&variant.attrs)?;
-				if parse_mode.any_field_can_start() {
-					for (view, syn_field) in views.iter().zip(variant.fields.iter()) {
-						let atom = extract_atom(&syn_field.attrs)?;
-						let peek_ty = option_inner(view.ty).unwrap_or(view.ty);
-						register(peek_ty, atom);
-					}
-				} else {
-					let Some((view, syn_field)) = views.first().zip(variant.fields.iter().next()) else {
-						continue;
-					};
+				for (view, syn_field) in views.iter().zip(variant.fields.iter()) {
 					let atom = match extract_atom(&variant.attrs)? {
 						Some(a) => Some(a),
 						None => extract_atom(&syn_field.attrs)?,
 					};
-					let peek_ty = option_inner(view.ty).unwrap_or(view.ty);
+					let option = option_inner(view.ty);
+					let peek_ty = option.unwrap_or(view.ty);
 					register(peek_ty, atom);
+					if !parse_mode.any_field_can_start() && option.is_none() {
+						break;
+					}
 				}
 			}
 

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_option_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_with_option_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/csskit_derives/src/test/test_peek.rs
+expression: pretty
+snapshot_kind: text
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for Foo {
+    const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(
+        &[::css_lexer::Kind::Ident, ::css_lexer::Kind::Number],
+    );
+}

--- a/crates/csskit_derives/src/test/test_peek.rs
+++ b/crates/csskit_derives/src/test/test_peek.rs
@@ -187,3 +187,16 @@ fn peek_enum_with_multiple_identical_types() {
 	};
 	assert_peek_snapshot!(data, "peek_enum_with_multiple_identical_types");
 }
+
+#[test]
+fn peek_enum_with_option_variants() {
+	let data = to_deriveinput! {
+		enum Foo {
+			Element(
+				Option<Ident>,
+				Number,
+			),
+		}
+	};
+	assert_peek_snapshot!(data, "peek_enum_with_option_variants");
+}


### PR DESCRIPTION
Right now the Peek derive will accumulate all of the first field of every
variant, but not the subsequent fields, which is a problem if the first N fields
are Option types.

This change refactors the variant loop to ensure all fields are gathered up
until the first non-Optional type.
