### PR TITLE
css_parse: Add assert_peek_false helper

### DIFF
--- a/crates/css_lexer/src/kindset.rs
+++ b/crates/css_lexer/src/kindset.rs
@@ -69,6 +69,12 @@ impl KindSet {
 		Kind::RightCurly,
 	]);
 
+	/// A [KindSet] that matches either [Kind::LeftCurly], [Kind::LeftParen], [Kind::LeftSquare].
+	pub const PAIRWISE_START: KindSet = KindSet::new(&[Kind::LeftCurly, Kind::LeftParen, Kind::LeftSquare]);
+	///
+	/// A [KindSet] that matches either [Kind::RightCurly], [Kind::RightParen], [Kind::RightSquare].
+	pub const PAIRWISE_END: KindSet = KindSet::new(&[Kind::RightCurly, Kind::RightParen, Kind::RightSquare]);
+
 	/// A [KindSet] that matches _any_ token.
 	pub const ANY: KindSet = KindSet(u64::MAX);
 

--- a/crates/css_parse/src/syntax/comma_separated.rs
+++ b/crates/css_parse/src/syntax/comma_separated.rs
@@ -175,7 +175,6 @@ mod tests {
 		assert_parse!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, "foo");
 		assert_parse!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, "one,two");
 		assert_parse!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, "one,two,three");
-		assert_parse!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident], 0>, "");
 		assert_parse!(EmptyAtomSet::ATOMS, CommaSeparated<(T![Number], CommaSeparated<T![Ident]>)>, "1 foo, 2 bar");
 	}
 
@@ -200,9 +199,13 @@ mod tests {
 	}
 
 	#[test]
+	fn test_peek() {
+		assert_peek_false!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, "");
+		assert_peek_false!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, ",");
+	}
+
+	#[test]
 	fn test_errors() {
-		assert_parse_error!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, "");
-		assert_parse_error!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, ",");
 		assert_parse_error!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, "one,two,three,");
 		assert_parse_error!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident]>, "one two");
 		assert_parse_error!(EmptyAtomSet::ATOMS, CommaSeparated<T![Ident], 2>, "one");

--- a/crates/css_parse/src/syntax/simple_block.rs
+++ b/crates/css_parse/src/syntax/simple_block.rs
@@ -11,6 +11,10 @@ pub struct SimpleBlock<'a> {
 	pub close: Option<T![PairWiseEnd]>,
 }
 
+impl<'a> Peek<'a> for SimpleBlock<'a> {
+	const PEEK_KINDSET: KindSet = KindSet::PAIRWISE_START;
+}
+
 // https://drafts.csswg.org/css-syntax-3/#consume-a-simple-block
 impl<'a> Parse<'a> for SimpleBlock<'a> {
 	fn parse<Iter>(p: &mut Parser<'a, Iter>) -> ParserResult<Self>
@@ -79,7 +83,8 @@ mod tests {
 	}
 
 	#[test]
-	fn test_errors() {
-		assert_parse_error!(EmptyAtomSet::ATOMS, SimpleBlock, "foo");
+	fn test_peek() {
+		assert_peek_false!(EmptyAtomSet::ATOMS, SimpleBlock, "foo");
+		assert_peek_false!(EmptyAtomSet::ATOMS, SimpleBlock, "");
 	}
 }

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -98,6 +98,43 @@ macro_rules! assert_parse_error {
 #[cfg(test)]
 pub(crate) use assert_parse_error;
 
+/// (Requires feature "testing") Given a Node, and a string, this will expand to code that sets up a parser, and checks
+/// that the Node returns false when Peeking on the node. It _also_ parses using the node, to ensure that the Parse
+/// causes an error, confirming that Peek doesn't contradict Parse. If the parse succeeded this macro will [panic] with
+/// a readable failure.
+///
+/// ```
+/// use css_parse::*;
+/// assert_peek_false!(EmptyAtomSet::ATOMS, T![Ident], "1");
+/// ```
+#[macro_export]
+macro_rules! assert_peek_false {
+	($atomset: path, $ty: ty, $str: literal) => {
+		let source_text = $str;
+		let bump = ::bumpalo::Bump::default();
+		let lexer = css_lexer::Lexer::new(&$atomset, source_text);
+		let mut parser = $crate::Parser::new(&bump, source_text, lexer);
+		if parser.peek::<$ty>() {
+			panic!("\n\n.\n\nPeek returned true! You might want `assert_parse_error` instead: {:?}", source_text);
+		}
+		let result = parser.parse::<$ty>();
+		if parser.at_end() {
+			if let Ok(result) = result {
+				let mut actual = ::bumpalo::collections::String::new_in(&bump);
+				{
+					let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
+					let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+					use $crate::ToCursors;
+					result.to_cursors(&mut ordered_sink);
+				}
+				panic!("\n\nExpected errors but it passed without error.\n\n   parser input: {:?}\n  parser output: {:?}\n       expected: (Error)", source_text, actual);
+			}
+		}
+	};
+}
+#[cfg(test)]
+pub(crate) use assert_peek_false;
+
 /// (Requires feature "testing") Given a Node, and a multiline string, this will expand to code that sets up a parser,
 /// and parses the first line of the given string with the parser. It will then create a second string based on the span
 /// data and append it to the first line of the string, showing what was parsed and where the span rests.


### PR DESCRIPTION
This change adds a new helper to assert than a Peek impl returns false. This
also checks that _if_ it returns false, a Parse call would result in an error.
This helps check that Peek is working properly.

We could add this to assert_parse_error, but it is not invariant that a false
peek is a good parse!
