### PR TITLE
css_parse: Add peek_n_including_whitespace

### DIFF
--- a/crates/css_parse/src/macros/pseudo_class.rs
+++ b/crates/css_parse/src/macros/pseudo_class.rs
@@ -63,7 +63,7 @@ macro_rules! pseudo_class {
 			where
 				I: Iterator<Item = $crate::Cursor> + Clone,
 			{
-				let c2 = p.peek_n(2);
+				let c2 = p.peek_n_including_whitespace(2);
 				c == $crate::Kind::Colon &&
 				c2 == $crate::Kind::Ident &&
 				matches!(p.to_atom::<$atoms>(c2), $atoms::$first $(| $variant_pat)*)

--- a/crates/css_parse/src/macros/pseudo_element.rs
+++ b/crates/css_parse/src/macros/pseudo_element.rs
@@ -57,8 +57,8 @@ macro_rules! pseudo_element {
 			where
 				I: Iterator<Item = $crate::Cursor> + Clone,
 			{
-				let c2 = p.peek_n(2);
-				let c3 = p.peek_n(3);
+				let c2 = p.peek_n_including_whitespace(2);
+				let c3 = p.peek_n_including_whitespace(3);
 				c == $crate::Kind::Colon
 				&& c2 == $crate::Kind::Colon
 				&& c3 == $crate::Kind::Ident

--- a/crates/css_parse/src/parser.rs
+++ b/crates/css_parse/src/parser.rs
@@ -323,6 +323,11 @@ where
 		self.peek_n_with_skip(n, self.skip)
 	}
 
+	#[inline]
+	pub fn peek_n_including_whitespace(&self, n: u8) -> Cursor {
+		self.peek_n_with_skip(n, self.skip.remove(Kind::Whitespace))
+	}
+
 	pub fn to_source_cursor(&self, cursor: Cursor) -> SourceCursor<'a> {
 		SourceCursor::from(cursor, cursor.str_slice(self.source_text))
 	}


### PR DESCRIPTION
This change adds a new peek method to specifically peek with Whitespace,
allowing Peek impls like the PsuedoClass/PseudoElement impls to trivially avoid
peeking on code like `:: foo`, knowing it'll fail parse.
