### PR TITLE
chromashift/csskit_transform: Round fractional colour channels to perceptually safe values

### DIFF
--- a/crates/chromashift/src/conversion.rs
+++ b/crates/chromashift/src/conversion.rs
@@ -213,8 +213,8 @@ simple_from!(XyzD65 to Lch, via Srgb);
 
 simple_from!(Lch to Oklab, via Srgb);
 simple_from!(Lch to Oklch, via Srgb);
-simple_from!(Lch to XyzD50, via Srgb);
-simple_from!(Lch to XyzD65, via Srgb);
+simple_from!(Lch to XyzD50, via Lab);
+simple_from!(Lch to XyzD65, via Lab);
 
 simple_from!(Hsv to LinearRgb, via Srgb);
 simple_from!(Lab to LinearRgb, via XyzD50);

--- a/crates/chromashift/src/lib.rs
+++ b/crates/chromashift/src/lib.rs
@@ -21,6 +21,7 @@ mod oklab;
 mod oklch;
 mod prophoto_rgb;
 mod rec2020;
+mod round;
 mod srgb;
 #[cfg(test)]
 mod tests;
@@ -47,6 +48,7 @@ pub use oklab::Oklab;
 pub use oklch::Oklch;
 pub use prophoto_rgb::ProphotoRgb;
 pub use rec2020::Rec2020;
+pub use round::PerceptualRound;
 pub use srgb::Srgb;
 pub use wcag::{WcagColorContrast, WcagLevel};
 pub use xyzd50::XyzD50;
@@ -228,7 +230,7 @@ impl From<Color> for XyzD65 {
 
 pub const COLOR_EPSILON: f64 = 0.0072;
 
-pub(crate) fn round_dp(f: f64, d: u32) -> f64 {
+pub fn round_dp(f: f64, d: u32) -> f64 {
 	let factor = 10u32.pow(d) as f64;
 	(f * factor).round() / factor
 }

--- a/crates/chromashift/src/round.rs
+++ b/crates/chromashift/src/round.rs
@@ -1,0 +1,170 @@
+use crate::*;
+
+/// Rounds a colour's channels to perceptually safe precision.
+///
+/// The number of decimal places per channel is determined by the channel's value range, so that each rounding step
+/// represents roughly the same fraction of the perceptual range. Small-range channels (e.g. OKLab 0–1) keep more
+/// decimal places, while large-range channels (e.g. hue 0–360, Lab L 0–100) need fewer.
+///
+/// The precisions used are chosen to be well below the Just Noticeable Difference (JND) while still surviving chained
+/// colour operations like `color-mix()` and relative colour syntax without accumulating visible error.
+///
+/// See: <https://keithcirkel.co.uk/too-much-color/>
+pub trait PerceptualRound: Sized {
+	fn round(self) -> Self;
+}
+
+macro_rules! impl_perceptual_round {
+	($ty:ident, $c1:ident: $dp1:expr, $c2:ident: $dp2:expr, $c3:ident: $dp3:expr) => {
+		impl PerceptualRound for $ty {
+			fn round(self) -> Self {
+				$ty::new(
+					round_dp(self.$c1 as f64, $dp1) as _,
+					round_dp(self.$c2 as f64, $dp2) as _,
+					round_dp(self.$c3 as f64, $dp3) as _,
+					round_dp(self.alpha as f64, 2) as f32,
+				)
+			}
+		}
+	};
+}
+
+// oklch/oklab: 3dp for 0–1 range channels, 1dp for hue (0–360 range).
+impl_perceptual_round!(Oklch, lightness: 3, chroma: 3, hue: 1);
+impl_perceptual_round!(Oklab, lightness: 3, a: 3, b: 3);
+
+// lab/lch: 1dp for all channels (0–100/±128/0–150/0–360 ranges).
+impl_perceptual_round!(Lab, lightness: 1, a: 1, b: 1);
+impl_perceptual_round!(Lch, lightness: 1, chroma: 1, hue: 1);
+
+// RGB 0–1 types: 3dp (4dp for srgb-linear due to near-black divergence at 3dp).
+impl_perceptual_round!(LinearRgb, red: 4, green: 4, blue: 4);
+impl_perceptual_round!(DisplayP3, red: 3, green: 3, blue: 3);
+impl_perceptual_round!(A98Rgb, red: 3, green: 3, blue: 3);
+impl_perceptual_round!(ProphotoRgb, red: 3, green: 3, blue: 3);
+impl_perceptual_round!(Rec2020, red: 3, green: 3, blue: 3);
+
+// XYZ 0–100 types: 2dp (4dp in CSS 0–1 scale, matching srgb-linear).
+impl_perceptual_round!(XyzD50, x: 2, y: 2, z: 2);
+impl_perceptual_round!(XyzD65, x: 2, y: 2, z: 2);
+
+// HSL/HWB: 1dp for hue (0–360), 1dp for percentage channels (0–100).
+impl_perceptual_round!(Hsl, hue: 1, saturation: 1, lightness: 1);
+impl_perceptual_round!(Hwb, hue: 1, whiteness: 1, blackness: 1);
+
+macro_rules! impl_perceptual_round_noop {
+	($($ty:ident),+) => {
+		$(impl PerceptualRound for $ty {
+			fn round(self) -> Self { self }
+		})+
+	};
+}
+
+impl_perceptual_round_noop!(Srgb, Hex, Named, Hsv);
+
+impl PerceptualRound for Color {
+	fn round(self) -> Self {
+		match self {
+			Color::A98Rgb(c) => Color::A98Rgb(c.round()),
+			Color::DisplayP3(c) => Color::DisplayP3(c.round()),
+			Color::Hex(c) => Color::Hex(c.round()),
+			Color::Hsv(c) => Color::Hsv(c.round()),
+			Color::Hsl(c) => Color::Hsl(c.round()),
+			Color::Hwb(c) => Color::Hwb(c.round()),
+			Color::Lab(c) => Color::Lab(c.round()),
+			Color::Lch(c) => Color::Lch(c.round()),
+			Color::LinearRgb(c) => Color::LinearRgb(c.round()),
+			Color::Named(n) => Color::Named(n.round()),
+			Color::Oklab(c) => Color::Oklab(c.round()),
+			Color::Oklch(c) => Color::Oklch(c.round()),
+			Color::ProphotoRgb(c) => Color::ProphotoRgb(c.round()),
+			Color::Rec2020(c) => Color::Rec2020(c.round()),
+			Color::Srgb(c) => Color::Srgb(c.round()),
+			Color::XyzD50(c) => Color::XyzD50(c.round()),
+			Color::XyzD65(c) => Color::XyzD65(c.round()),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn oklch_round() {
+		// 3dp L/C, 1dp hue
+		let rounded = Oklch::new(0.6593827, 0.30412345, 203.27412, 100.0).round();
+		assert_eq!(rounded, Oklch::new(0.659, 0.304, 203.3, 100.0));
+	}
+
+	#[test]
+	fn oklab_round() {
+		let rounded = Oklab::new(0.44027179, 0.08817676, -0.13386435, 100.0).round();
+		assert_eq!(rounded, Oklab::new(0.44, 0.088, -0.134, 100.0));
+	}
+
+	#[test]
+	fn lab_round() {
+		// 1dp for all channels
+		let rounded = Lab::new(32.39271642, 38.42945581, -47.68554267, 100.0).round();
+		assert_eq!(rounded, Lab::new(32.4, 38.4, -47.7, 100.0));
+	}
+
+	#[test]
+	fn lch_round() {
+		let rounded = Lch::new(61.23323694, 50.27335275, 273.48455139, 100.0).round();
+		assert_eq!(rounded, Lch::new(61.2, 50.3, 273.5, 100.0));
+	}
+
+	#[test]
+	fn hsl_round() {
+		let rounded = Hsl::new(218.54015, 79.19075, 66.07843, 100.0).round();
+		assert_eq!(rounded, Hsl::new(218.5, 79.2, 66.1, 100.0));
+	}
+
+	#[test]
+	fn display_p3_round() {
+		let rounded = DisplayP3::new(0.39189772, 0.57889666, 0.92721090, 100.0).round();
+		assert_eq!(rounded, DisplayP3::new(0.392, 0.579, 0.927, 100.0));
+	}
+
+	#[test]
+	fn already_clean_values_unchanged() {
+		let clean = Oklch::new(0.5, 0.2, 180.0, 100.0);
+		assert_eq!(clean.round(), clean);
+	}
+
+	#[test]
+	fn noop_types() {
+		assert_eq!(Srgb::new(102, 51, 153, 100.0).round(), Srgb::new(102, 51, 153, 100.0));
+		assert_eq!(Hex::new(0x663399FF).round(), Hex::new(0x663399FF));
+		assert_eq!(Named::Rebeccapurple.round(), Named::Rebeccapurple);
+	}
+
+	#[test]
+	fn alpha_is_rounded() {
+		assert_eq!(Oklch::new(0.5, 0.2, 180.0, 75.555).round().alpha, 75.56);
+	}
+
+	#[test]
+	fn color_enum_round() {
+		let rounded = Color::Oklch(Oklch::new(0.6593827, 0.30412345, 203.27412, 100.0)).round();
+		assert_eq!(rounded, Color::Oklch(Oklch::new(0.659, 0.304, 203.3, 100.0)));
+	}
+
+	#[test]
+	fn round_stays_perceptually_close() {
+		let colors = [
+			Color::Oklch(Oklch::new(0.659, 0.304, 203.274, 100.0)),
+			Color::Lab(Lab::new(50.0, 30.5, -20.123, 80.0)),
+			Color::Hsl(Hsl::new(218.54015, 79.19075, 66.07843, 100.0)),
+			Color::DisplayP3(DisplayP3::new(0.39189772, 0.57889666, 0.92721090, 100.0)),
+			Color::Oklab(Oklab::new(0.44027179, 0.08817676, -0.13386435, 100.0)),
+			Color::Lch(Lch::new(61.23323694, 50.27335275, 273.48455139, 100.0)),
+		];
+		for color in &colors {
+			let rounded = color.round();
+			assert!(color.close_to(rounded, 1.0), "ΔE = {} for {color:?}", color.delta_e(rounded));
+		}
+	}
+}

--- a/crates/css_ast/src/functions/color_function.rs
+++ b/crates/css_ast/src/functions/color_function.rs
@@ -139,9 +139,9 @@ impl crate::ToChromashift for ColorFunctionColor {
 
 		match space {
 			ColorSpace::Srgb(_) => {
-				let r = (channel_unit(c1)? * 255.0) as u8;
-				let g = (channel_unit(c2)? * 255.0) as u8;
-				let b = (channel_unit(c3)? * 255.0) as u8;
+				let r = (channel_unit(c1)? * 255.0).round() as u8;
+				let g = (channel_unit(c2)? * 255.0).round() as u8;
+				let b = (channel_unit(c3)? * 255.0).round() as u8;
 				Some(chromashift::Color::Srgb(Srgb::new(r, g, b, alpha)))
 			}
 			ColorSpace::SrgbLinear(_) => {
@@ -280,27 +280,30 @@ impl crate::ToChromashift for RgbFunctionParams {
 			Some(NoneOr::Some(NumberOrPercentage::Percentage(t))) => t.value(),
 			None => 100.0,
 		};
-		let red = match red {
+		let red = (match red {
 			NoneOr::None(_) => {
 				return None;
 			}
 			NoneOr::Some(NumberOrPercentage::Number(red)) => red.value(),
 			NoneOr::Some(NumberOrPercentage::Percentage(red)) => red.value() / 100.0 * 255.0,
-		} as u8;
-		let green = match green {
+		})
+		.round() as u8;
+		let green = (match green {
 			NoneOr::None(_) => {
 				return None;
 			}
 			NoneOr::Some(NumberOrPercentage::Number(green)) => green.value(),
 			NoneOr::Some(NumberOrPercentage::Percentage(green)) => green.value() / 100.0 * 255.0,
-		} as u8;
-		let blue = match blue {
+		})
+		.round() as u8;
+		let blue = (match blue {
 			NoneOr::None(_) => {
 				return None;
 			}
 			NoneOr::Some(NumberOrPercentage::Number(blue)) => blue.value(),
 			NoneOr::Some(NumberOrPercentage::Percentage(blue)) => blue.value() / 100.0 * 255.0,
-		} as u8;
+		})
+		.round() as u8;
 		Some(chromashift::Color::Srgb(Srgb::new(red, green, blue, alpha)))
 	}
 }

--- a/crates/csskit_transform/src/reduce_colors.rs
+++ b/crates/csskit_transform/src/reduce_colors.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use chromashift::{COLOR_EPSILON, ColorDistance, ColorSpace, Hex, Named, Srgb, ToAlpha};
+use chromashift::{COLOR_EPSILON, ColorDistance, ColorSpace, Hex, Named, PerceptualRound, Srgb, ToAlpha, round_dp};
 use css_ast::{
 	Color, ColorFunction, ColorMixFunction, HueInterpolationDirection, InterpolationColorSpace, ToChromashift,
 	Visitable,
@@ -34,11 +34,137 @@ impl Shortest for chromashift::Color {
 		[
 			Some(Hex::from(*self).to_string()),
 			Named::try_from(*self).ok().map(|named| named.to_string()),
-			Some(Srgb::from(*self).to_string()),
+			Some(Srgb::from(*self).round().to_string()),
 		]
 		.into_iter()
 		.flatten()
 		.min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)))
+	}
+}
+
+/// Formats a CSS alpha value (0–1) from chromashift's internal 0–100 representation.
+/// Returns `None` when the alpha is fully opaque (100.0).
+fn css_alpha(alpha: f32) -> Option<String> {
+	if alpha >= 100.0 {
+		return None;
+	}
+	Some(format!("{}", round_dp(alpha as f64 / 100.0, 3)))
+}
+
+/// Serialises a chromashift colour into valid CSS function syntax.
+///
+/// This produces the native-space representation (e.g. `lch(54.3 43.8 274.5 / 0.746)`) which the
+/// compact writer will then minify (removing leading zeros, collapsing whitespace around `/`, etc.).
+///
+/// Returns `None` for colour types that don't have a non-sRGB CSS function syntax (Hex, Named, Srgb, Hsv).
+trait ToCss {
+	fn to_css(&self) -> Option<String>;
+}
+
+macro_rules! impl_to_css_3ch {
+	($ty:ident, $name:literal, $c1:ident, $c2:ident, $c3:ident) => {
+		impl ToCss for chromashift::$ty {
+			fn to_css(&self) -> Option<String> {
+				let alpha = css_alpha(self.alpha);
+				if let Some(a) = alpha {
+					Some(format!(concat!($name, "({} {} {} / {})"), self.$c1, self.$c2, self.$c3, a))
+				} else {
+					Some(format!(concat!($name, "({} {} {})"), self.$c1, self.$c2, self.$c3))
+				}
+			}
+		}
+	};
+	($ty:ident, $name:literal, $c1:ident, $c2:ident: $suf2:literal, $c3:ident: $suf3:literal) => {
+		impl ToCss for chromashift::$ty {
+			fn to_css(&self) -> Option<String> {
+				let alpha = css_alpha(self.alpha);
+				if let Some(a) = alpha {
+					Some(format!(
+						concat!($name, "({} {}", $suf2, " {}", $suf3, " / {})"),
+						self.$c1, self.$c2, self.$c3, a
+					))
+				} else {
+					Some(format!(concat!($name, "({} {}", $suf2, " {}", $suf3, ")"), self.$c1, self.$c2, self.$c3))
+				}
+			}
+		}
+	};
+}
+
+macro_rules! impl_to_css_color_fn {
+	($ty:ident, $space:literal) => {
+		impl ToCss for chromashift::$ty {
+			fn to_css(&self) -> Option<String> {
+				let alpha = css_alpha(self.alpha);
+				if let Some(a) = alpha {
+					Some(format!(concat!("color(", $space, " {} {} {} / {})"), self.red, self.green, self.blue, a))
+				} else {
+					Some(format!(concat!("color(", $space, " {} {} {})"), self.red, self.green, self.blue))
+				}
+			}
+		}
+	};
+}
+
+macro_rules! impl_to_css_xyz {
+	($ty:ident, $space:literal) => {
+		impl ToCss for chromashift::$ty {
+			fn to_css(&self) -> Option<String> {
+				let alpha = css_alpha(self.alpha);
+				// CSS color(xyz-*) uses 0–1 scale; chromashift stores 0–100 internally.
+				// After dividing, re-apply round_dp(4) to eliminate float display artifacts
+				// (e.g. 18.76 / 100.0 = 0.18760000000000002 without this).
+				let x = round_dp(self.x / 100.0, 4);
+				let y = round_dp(self.y / 100.0, 4);
+				let z = round_dp(self.z / 100.0, 4);
+				if let Some(a) = alpha {
+					Some(format!(concat!("color(", $space, " {} {} {} / {})"), x, y, z, a))
+				} else {
+					Some(format!(concat!("color(", $space, " {} {} {})"), x, y, z))
+				}
+			}
+		}
+	};
+}
+
+impl_to_css_3ch!(Lab, "lab", lightness, a, b);
+impl_to_css_3ch!(Lch, "lch", lightness, chroma, hue);
+impl_to_css_3ch!(Oklab, "oklab", lightness, a, b);
+impl_to_css_3ch!(Oklch, "oklch", lightness, chroma, hue);
+impl_to_css_3ch!(Hsl, "hsl", hue, saturation: "%", lightness: "%");
+impl_to_css_3ch!(Hwb, "hwb", hue, whiteness: "%", blackness: "%");
+
+impl_to_css_color_fn!(DisplayP3, "display-p3");
+impl_to_css_color_fn!(LinearRgb, "srgb-linear");
+impl_to_css_color_fn!(A98Rgb, "a98-rgb");
+impl_to_css_color_fn!(ProphotoRgb, "prophoto-rgb");
+impl_to_css_color_fn!(Rec2020, "rec2020");
+
+impl_to_css_xyz!(XyzD50, "xyz-d50");
+impl_to_css_xyz!(XyzD65, "xyz-d65");
+
+impl ToCss for chromashift::Color {
+	fn to_css(&self) -> Option<String> {
+		match self {
+			chromashift::Color::Lab(c) => c.to_css(),
+			chromashift::Color::Lch(c) => c.to_css(),
+			chromashift::Color::Oklab(c) => c.to_css(),
+			chromashift::Color::Oklch(c) => c.to_css(),
+			chromashift::Color::Hsl(c) => c.to_css(),
+			chromashift::Color::Hwb(c) => c.to_css(),
+			chromashift::Color::DisplayP3(c) => c.to_css(),
+			chromashift::Color::LinearRgb(c) => c.to_css(),
+			chromashift::Color::A98Rgb(c) => c.to_css(),
+			chromashift::Color::ProphotoRgb(c) => c.to_css(),
+			chromashift::Color::Rec2020(c) => c.to_css(),
+			chromashift::Color::XyzD50(c) => c.to_css(),
+			chromashift::Color::XyzD65(c) => c.to_css(),
+			// sRGB types don't need native-space CSS — they use Shortest
+			chromashift::Color::Hex(_)
+			| chromashift::Color::Named(_)
+			| chromashift::Color::Srgb(_)
+			| chromashift::Color::Hsv(_) => None,
+		}
 	}
 }
 
@@ -61,19 +187,21 @@ where
 		};
 		let len = color.to_span().len() as usize;
 
-		// Only generate sRGB-based candidates if the colour is within the sRGB gamut.
-		// Converting an out-of-gamut colour (e.g. display-p3 1 0 0) to sRGB would silently
-		// clamp the values, changing the actual colour.
-		if !chroma_color.in_gamut_of(ColorSpace::Srgb) {
+		if chroma_color.in_gamut_of(ColorSpace::Srgb)
+			&& let Some(candidate) = chroma_color.shortest()
+			&& candidate.len() < len
+		{
+			self.transformer.replace_parsed::<Color>(color.to_span(), &candidate);
 			return;
 		}
 
-		let Some(candidate) = chroma_color.shortest() else {
-			return;
-		};
-
-		if candidate.len() < len {
-			self.transformer.replace_parsed::<Color>(color.to_span(), &candidate);
+		// Try the native-space rounded form. This preserves the original colour space
+		// while reducing precision to perceptually safe levels.
+		let rounded = chroma_color.round();
+		if let Some(css) = rounded.to_css()
+			&& css.len() < len
+		{
+			self.transformer.replace_parsed::<Color>(color.to_span(), &css);
 		}
 	}
 
@@ -153,19 +281,18 @@ where
 			let mixed_alpha = (mixed.to_alpha() as f64 / 100.0 * alpha_mult * 100.0) as f32;
 			let mixed = mixed.with_alpha(mixed_alpha);
 
-			// Only convert to sRGB hex/named if the result is in sRGB gamut.
-			// Converting out-of-gamut colors to hex silently clamps, changing the color.
-			let candidate = if mixed.in_gamut_of(ColorSpace::Srgb) {
-				mixed.shortest()
-			} else {
-				// Out of sRGB gamut — output in the native interpolation color space
-				Some(mixed.to_string())
-			};
+			// Try the perceptually-rounded native-space form first, then sRGB
+			// candidates if the result is in gamut.
+			let rounded = mixed.round();
+			let native_css = rounded.to_css();
+			let srgb_css = if mixed.in_gamut_of(ColorSpace::Srgb) { mixed.shortest() } else { None };
+			let candidate =
+				native_css.into_iter().chain(srgb_css).min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
 
-			if let Some(candidate) = candidate
+			if let Some(ref candidate) = candidate
 				&& candidate.len() < outer_len
 			{
-				self.transformer.replace_parsed::<Color>(outer_span, &candidate);
+				self.transformer.replace_parsed::<Color>(outer_span, candidate);
 				self.replacing_outer = true;
 				return;
 			}
@@ -272,7 +399,7 @@ mod tests {
 	}
 
 	#[test]
-	fn reduces_color_display_p3() {
+	fn reduces_in_gamut_display_p3_to_shortest() {
 		assert_transform!(
 			CssMinifierFeature::ReduceColors,
 			CssAtomSet,
@@ -449,13 +576,14 @@ mod tests {
 
 	#[test]
 	fn color_mix_oklch_out_of_gamut_uses_native_space() {
-		// oklch mix of lime+blue is out of sRGB gamut — resolved to oklch(), not hex
+		// oklch mix of lime+blue is out of sRGB gamut — resolved to oklch(), not hex.
+		// Perceptual rounding: L/C at 3dp, hue at 1dp.
 		assert_transform!(
 			CssMinifierFeature::ReduceColors,
 			CssAtomSet,
 			StyleSheet,
 			"a { color: color-mix(in oklch, lime, blue); }",
-			"a { color: oklch(0.66 0.304 203.27); }"
+			"a { color: oklch(0.659 0.304 203.3); }"
 		);
 	}
 }

--- a/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
+++ b/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
@@ -41,14 +41,6 @@ FAIL colors/0024
 -a{color:color-mix(in srgb,rgb(none 0 0),#c80000)}
 +a{color:#c80000}
 
-FAIL colors/0027
--a{color:#3c740a}
-+a{color:oklab(.5 -.1 .1)}
-
-FAIL colors/0029
--a{color:oklch(.54 .2854 326.64)}
-+a{color:oklch(54% .285 326.6)}
-
 FAIL colors/0031
 -a{color:color-mix(in oklch,rgba(255,255,255,1),var(--foo))}
 +a{color:color-mix(in oklch,#fff,var(--foo))}
@@ -68,22 +60,6 @@ FAIL colors/0034
 FAIL colors/0035
 -a{color:color(display-p3 1.2 -.3 .5)}
 +a{color:color(display-p3 1.2-.3 .5)}
-
-FAIL colors/0044
--a{color:oklch(.66 .304 203.27)}
-+a{color:oklch(.659 .304 203.3)}
-
-FAIL colors/0045
--a{color:#7f40bf}
-+a{color:#8040c0}
-
-FAIL colors/0046
--a{color:oklch(.55432 .12276 180.4567/.74567);background-color:#52a746}
-+a{color:oklch(.554 .123 180.5/.746);background-color:oklab(.654 -.123 .099)}
-
-FAIL colors/0047
--a{color:#5d82cebd;background-color:#6b8b4a}
-+a{color:lch(54.3 43.8 274.5/.746);background-color:lab(54.3 -20.5 30.8)}
 
 FAIL comments/0003
 -a{color:red}


### PR DESCRIPTION
This change rounds colours to a fixed number of decimal places in a way which
preserves perceptual similarity using the minimal number of decimal places.
