### PR TITLE
csskit_arena/css_parse/css_lexer/css_ast: Implement chunk based allocations, drop bumpalo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.21"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
 
 [[package]]
 name = "android_system_properties"
@@ -323,10 +323,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-dependencies = [
- "allocator-api2",
- "serde",
-]
 
 [[package]]
 name = "bytemuck"
@@ -692,7 +688,6 @@ version = "0.0.28"
 dependencies = [
  "allocator-api2",
  "bitmask-enum",
- "bumpalo",
  "console",
  "criterion",
  "derive_atom_set",
@@ -714,7 +709,6 @@ version = "0.0.28"
 dependencies = [
  "allocator-api2",
  "bitmask-enum",
- "bumpalo",
  "css_lexer",
  "csskit_arena",
  "csskit_derives",
@@ -1168,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1756,7 +1750,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2433,7 +2427,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2665,7 +2659,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2722,7 +2716,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2999,7 +2993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3220,7 +3214,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3840,7 +3834,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,7 @@ stable_type_layout_derive = { package = "stable-type-layout-derive", path = "cra
 visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.28" }  # @release
 
 # Memory
-allocator-api2 = { version = "0.2.21" }  # Held back for bumpalo (https://github.com/fitzgen/bumpalo/pull/288)
-bumpalo = { version = "3.20.3" }
+allocator-api2 = { version = "0.4.0" }
 inventory = { version = "0.3.24" }
 libc = { version = "0.2.186" }
 windows-sys = { version = "0.61.0" }

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -56,8 +56,6 @@ pprof = { workspace = true, features = ["flamegraph", "criterion"] }
 
 [features]
 default = []
-# Use bumpalo instead of the default csskit_arena allocator.
-bumpalo = ["css_parse/bumpalo"]
 visitable = []
 serde = ["dep:serde", "dep:serde_json", "css_parse/serde", "smallvec/serde"]
 miette = ["css_parse/miette"]

--- a/crates/css_ast/tests/allocations.rs
+++ b/crates/css_ast/tests/allocations.rs
@@ -60,16 +60,7 @@ fn allocation_test() {
 	}
 
 	// XXX: If these fail because the numbers go down, great! If they go up, investigate why.
-	#[cfg(not(feature = "bumpalo"))]
-	{
-		assert_eq!(simple_alloc.used_bytes(), 1136);
-		assert_eq!(escaped_alloc.used_bytes(), 6384);
-		assert_eq!(big_alloc.used_bytes(), 109_831_608);
-	}
-	#[cfg(feature = "bumpalo")]
-	{
-		assert_eq!(simple_alloc.allocated_bytes(), simple_alloc_size);
-		assert_eq!(escaped_alloc.allocated_bytes(), escaped_alloc_size);
-		assert_eq!(big_alloc.allocated_bytes(), big_alloc_size);
-	}
+	assert_eq!(simple_alloc.used_bytes(), 1136);
+	assert_eq!(escaped_alloc.used_bytes(), 6384);
+	assert_eq!(big_alloc.used_bytes(), 109_831_608);
 }

--- a/crates/css_lexer/Cargo.toml
+++ b/crates/css_lexer/Cargo.toml
@@ -15,11 +15,6 @@ bench = false
 
 [dependencies]
 allocator-api2 = { workspace = true }
-bumpalo = { workspace = true, features = [
-	"boxed",
-	"collections",
-	"allocator-api2",
-], optional = true }
 bitmask-enum = { workspace = true }
 derive_atom_set = { workspace = true } # @release
 fearless_simd = { workspace = true }
@@ -48,9 +43,7 @@ default = []
 egg = []
 # Provides `From<>` implementations for the [SourceSpan] into [miette::SourceSpan] and [Span] into [miette::Span]
 miette = ["dep:miette"]
-# Provides `From<>` implementations for [Vec]
-bumpalo = ["dep:bumpalo"]
-serde = ["dep:serde", "dep:serde_json", "bumpalo/serde", "miette/serde"]
+serde = ["dep:serde", "dep:serde_json", "miette/serde"]
 # Enables dynamic atom interning via DynAtomRegistry
 dynamic-atoms = ["dep:fnv"]
 # Test only features

--- a/crates/css_lexer/README.md
+++ b/crates/css_lexer/README.md
@@ -14,7 +14,6 @@ A spec-compliant CSS tokenizer with zero-copy cursors and optional feature gates
 ## Optional Features
 
 - `miette` - Enables `From<>` implementations for miette span types
-- `bumpalo` - Enables `From<>` implementations for bumpalo Vec
 - `serde` - Enables serialization/deserialization support
 
 ## Part of csskit

--- a/crates/css_lexer/src/source_cursor.rs
+++ b/crates/css_lexer/src/source_cursor.rs
@@ -824,29 +824,6 @@ mod test {
 	}
 
 	#[test]
-	#[cfg(feature = "bumpalo")]
-	fn test_bumpalo_compatibility() {
-		use bumpalo::Bump;
-
-		// Test that Bumpalo's Bump can be used as an allocator
-		let bump = Bump::new();
-		let c = Cursor::new(SourceOffset(0), Token::new_ident(true, false, false, 0, 3));
-
-		// Test that the old interface still works
-		assert_eq!(SourceCursor::from(c, "FoO").parse(&bump), "FoO");
-		assert_eq!(SourceCursor::from(c, "FoO").parse_ascii_lower(&bump), "foo");
-
-		// Test that the new interface works with Bumpalo too
-		assert_eq!(&*SourceCursor::from(c, "FoO").parse(&bump), "FoO");
-		assert_eq!(&*SourceCursor::from(c, "FoO").parse_ascii_lower(&bump), "foo");
-
-		// Test with escape sequences
-		let c = Cursor::new(SourceOffset(0), Token::new_ident(false, false, true, 0, 7));
-		assert_eq!(SourceCursor::from(c, "b\\61\\72").parse(&bump), "bar");
-		assert_eq!(&*SourceCursor::from(c, "b\\61\\72").parse(&bump), "bar");
-	}
-
-	#[test]
 	fn test_compact_ident_with_escapes() {
 		let c = Cursor::new(SourceOffset(0), Token::new_ident(false, false, true, 0, 5));
 		let sc = SourceCursor::from(c, r"\66oo");

--- a/crates/css_lexer/src/span.rs
+++ b/crates/css_lexer/src/span.rs
@@ -196,21 +196,6 @@ impl<T: ToSpan, A: allocator_api2::alloc::Allocator> ToSpan for allocator_api2::
 	}
 }
 
-#[cfg(feature = "bumpalo")]
-impl<'a, T: ToSpan> ToSpan for bumpalo::collections::Vec<'a, T> {
-	fn to_span(&self) -> Span {
-		let mut span = Span::ZERO;
-		for item in self {
-			if span == Span::ZERO {
-				span = item.to_span();
-			} else {
-				span = span + item.to_span()
-			}
-		}
-		span
-	}
-}
-
 macro_rules! impl_tuple {
     ($len:tt: $($name:ident),+) => {
         impl<$($name: ToSpan),+> ToSpan for ($($name),+) {

--- a/crates/css_parse/Cargo.toml
+++ b/crates/css_parse/Cargo.toml
@@ -16,13 +16,9 @@ bench = false
 [dependencies]
 csskit_proc_macro = { workspace = true } # @release
 css_lexer = { workspace = true } # @release
+csskit_arena = { workspace = true } # @release
 
 allocator-api2 = { workspace = true }
-bumpalo = { workspace = true, features = [
-	"boxed",
-	"collections",
-	"allocator-api2",
-], optional = true }
 smallvec = { workspace = true }
 
 miette = { workspace = true, features = ["derive"], optional = true }
@@ -30,11 +26,6 @@ thiserror = { workspace = true, optional = true }
 bitmask-enum = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-
-# The default allocator backend. Only pulled in where its virtual memory APIs exist; elsewhere
-# (e.g. wasm32) the `bumpalo` feature is mandatory.
-[target.'cfg(any(unix, windows))'.dependencies]
-csskit_arena = { workspace = true } # @release
 
 [dev-dependencies]
 csskit_derives = { workspace = true }  # @release
@@ -47,12 +38,10 @@ stable_type_layout = { workspace = true }  # @release
 [features]
 default = []
 testing = []
-# Allocator backend override: use bumpalo instead of the default csskit_arena.
-bumpalo = ["dep:bumpalo", "css_lexer/bumpalo"]
 # Easter egg feature for CSS expansion (opposite of minification)
 egg = ["css_lexer/egg"]
 miette = ["dep:miette", "dep:thiserror", "css_lexer/miette"]
-serde = ["dep:serde", "dep:serde_json", "css_lexer/serde", "bumpalo?/serde"]
+serde = ["dep:serde", "dep:serde_json", "css_lexer/serde"]
 fancy = ["miette", "miette/fancy-no-backtrace"]
 # Test only features
 _dhat-heap-testing = []

--- a/crates/css_parse/src/arena_box.rs
+++ b/crates/css_parse/src/arena_box.rs
@@ -11,10 +11,6 @@ use std::{
 
 /// An arena-allocated box that retains a reference to its allocator, enabling [`Clone`] support.
 ///
-/// Unlike [`bumpalo::boxed::Box`], which only stores a mutable reference to the allocated value (and thus cannot
-/// implement [`Clone`] without the allocator), `Box` stores both the allocator reference and the value pointer.
-/// This allows it to allocate a new copy during [`Clone::clone`].
-///
 /// This type is intended for recursive AST nodes (e.g. `color-mix()` containing nested `<color>` values) where
 /// indirection is required to break the cycle, but the allocation should still live in the parsing arena.
 #[repr(C)]

--- a/crates/css_parse/src/arena_vec.rs
+++ b/crates/css_parse/src/arena_vec.rs
@@ -506,12 +506,8 @@ impl<'a, T: serde::Serialize, A: Allocator> serde::Serialize for Vec<'a, T, A> {
 
 #[cfg(test)]
 mod test {
-	#[cfg(feature = "bumpalo")]
-	use super::super::arena_box::Box;
 	use super::Vec;
 	use crate::Arena;
-	#[cfg(feature = "bumpalo")]
-	use bumpalo::Bump;
 	use std::cell::Cell;
 	use std::panic::{AssertUnwindSafe, catch_unwind};
 	use std::rc::Rc;
@@ -1062,43 +1058,6 @@ mod test {
 		assert_eq!(v.pop(), None);
 	}
 
-	#[cfg(feature = "bumpalo")]
-	#[test]
-	fn footprint_matches_bumpalo_vec() {
-		let a = Bump::new();
-		{
-			let mut outer: Vec<u32, &Bump> = Vec::new_in(&a);
-			for i in 0..5u32 {
-				let mut inner: Vec<u32, &Bump> = Vec::new_in(&a);
-				for j in 0..7u32 {
-					inner.push(j);
-				}
-				let _b = Box::new_in(&a, inner);
-				outer.push(i);
-			}
-		}
-		let b = Bump::new();
-		{
-			let mut outer: bumpalo::collections::Vec<u32> = bumpalo::collections::Vec::new_in(&b);
-			for i in 0..5u32 {
-				let mut inner: bumpalo::collections::Vec<u32> = bumpalo::collections::Vec::new_in(&b);
-				for j in 0..7u32 {
-					inner.push(j);
-				}
-				let _b = bumpalo::boxed::Box::new_in(inner, &b);
-				outer.push(i);
-			}
-		}
-		assert_eq!(
-			a.allocated_bytes(),
-			b.allocated_bytes(),
-			"arena_vec={} bumpalo::collections::Vec={}",
-			a.allocated_bytes(),
-			b.allocated_bytes()
-		);
-	}
-
-	#[cfg(not(feature = "bumpalo"))]
 	#[test]
 	fn parsing_beyond_default_arena_capacity_does_not_panic() {
 		use crate::{ComponentValues, EmptyAtomSet, Parser};

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -316,13 +316,6 @@ mod traits;
 
 pub type Result<T> = std::result::Result<T, diagnostics::Diagnostic>;
 
-#[cfg(all(not(feature = "bumpalo"), not(any(unix, windows))))]
-compile_error!("the `bumpalo` feature is required on targets csskit_arena cannot support");
-
-#[cfg(feature = "bumpalo")]
-pub type Arena = bumpalo::Bump;
-
-#[cfg(not(feature = "bumpalo"))]
 pub type Arena = csskit_arena::Arena;
 
 pub use arena_box::*;

--- a/crates/css_parse/tests/allocations.rs
+++ b/crates/css_parse/tests/allocations.rs
@@ -59,16 +59,7 @@ fn allocation_test() {
 	}
 
 	// XXX: If these fail because the numbers go down, great! If they go up, investigate why.
-	#[cfg(not(feature = "bumpalo"))]
-	{
-		assert_eq!(simple_alloc.used_bytes(), 448);
-		assert_eq!(escaped_alloc.used_bytes(), 704);
-		assert_eq!(big_alloc.used_bytes(), 59_355_416);
-	}
-	#[cfg(feature = "bumpalo")]
-	{
-		assert_eq!(simple_alloc.allocated_bytes(), simple_alloc_size);
-		assert_eq!(escaped_alloc.allocated_bytes(), escaped_alloc_size);
-		assert_eq!(big_alloc.allocated_bytes(), big_alloc_size);
-	}
+	assert_eq!(simple_alloc.used_bytes(), 448);
+	assert_eq!(escaped_alloc.used_bytes(), 704);
+	assert_eq!(big_alloc.used_bytes(), 59_355_416);
 }

--- a/crates/csskit_arena/Cargo.toml
+++ b/crates/csskit_arena/Cargo.toml
@@ -15,8 +15,8 @@ bench = false
 [dependencies]
 allocator-api2 = { workspace = true }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(all(unix, target_pointer_width = "64"))'.dependencies]
 libc = { workspace = true }
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(all(windows, target_pointer_width = "64"))'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Memory"] }

--- a/crates/csskit_arena/src/lib.rs
+++ b/crates/csskit_arena/src/lib.rs
@@ -12,15 +12,18 @@
 //! [oxc_allocator](https://github.com/oxc-project/oxc/tree/main/crates/oxc_allocator) which introduces this concept for
 //! their JS parser. Credit to the oxc project for this technique.
 //!
-//! [`Arena`] is a single-chunk bump allocator that satisfies both constraints. It never grows or relocates.
+//! [`Arena`] can be used in several modes, predominantly as a single-chunk bump allocator that satisfies both
+//! constraints. In this mode it never grows or relocates. For systems without virtual memory, or for 32-bit systems, it
+//! can devolve into a chunk based allocator, or can borrow a block of memory to allocate into.
 //!
 //! # Ownership modes
 //!
-//! - [`Arena::new`] / [`Arena::default`]: self-allocated, full 2 GiB reservation.
-//! - [`Arena::with_capacity`]: self-allocated, reserving a given size, useful for tests.
+//! - [`Arena::new`] / [`Arena::default`]: self-allocated, as large a first chunk as the target allows.
+//! - [`Arena::with_capacity`]: self-allocated, exactly the given size, never grows. Useful for tests.
 //! - [`Arena::from_raw_parts`]: borrows caller-owned memory (useful for e.g. NAPI where V8 owns the `ArrayBuffer`).
 //!
-//! All modes yield the same [`Arena`] type with identical layout and offset semantics.
+//! All modes yield the same [`Arena`] type; they differ only in where the first chunk comes from and whether the arena
+//! may add another.
 use allocator_api2::alloc::{AllocError, Allocator};
 use std::alloc::Layout;
 use std::cell::Cell;
@@ -28,76 +31,132 @@ use std::ptr::NonNull;
 
 mod vm;
 
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("csskit_arena requires a 64 bit target, as BLOCK_ALIGN does not fit in a smaller pointer");
-
-#[cfg(not(any(unix, windows)))]
-compile_error!("csskit_arena requires the virtual memory APIs of unix or windows");
-
 /// Required alignment of the arena region (4 GiB), so that `ptr as u32` equals the byte offset
-/// within the region.
+/// within the region. Where nothing is reserved or 32-bit targets that already express 4gb, this is `1`.
+#[cfg(all(target_pointer_width = "64", any(unix, windows)))]
 pub const BLOCK_ALIGN: usize = 4 * 1024 * 1024 * 1024;
+#[cfg(not(all(target_pointer_width = "64", any(unix, windows))))]
+pub const BLOCK_ALIGN: usize = 1;
 
 /// Maximum usable size of the arena region (just under 2 GiB), so that no allocation crosses a
 /// 4 GiB boundary and every offset fits in a `u32`.
 pub const MAX_BLOCK_SIZE: usize = 2 * 1024 * 1024 * 1024 - 16;
 
-/// Bytes committed the first time a Windows arena is written to; growth doubles from there.
-#[cfg(any(test, windows))]
+/// Smallest step the arena takes when it needs more room: bytes committed the first time a Windows arena is written
+/// to, and the size of the first chunk where nothing can be reserved. Growth doubles from there.
 const INITIAL_COMMIT: usize = 64 * 1024;
 
-/// How the arena's backing memory was obtained, which determines what (if anything) happens on drop.
+/// Alignment of a chunk from the global allocator: enough for any fundamental type, and raised to the requested
+/// alignment when a single allocation needs more.
+const CHUNK_ALIGN: usize = 16;
+
+/// How a chunk's memory was obtained, which determines what (if anything) happens on drop.
+#[derive(Clone, Copy)]
 enum Backing {
 	/// Address space reserved by this crate. `reservation` and `reserved` are the base and length of the whole
 	/// reservation, both of which are needed to release it.
 	Owned { reservation: NonNull<u8>, reserved: usize },
+	/// A block from the global allocator, for targets that cannot reserve address space lazily.
+	Heap(Layout),
 	/// Memory owned by the caller (e.g. a V8 `ArrayBuffer`). Never freed by the arena.
 	Borrowed,
 }
 
-/// A single-chunk Allocator.
-///
-/// The region begins at a 4 GiB-aligned address and is at most [`MAX_BLOCK_SIZE`] bytes, so the low 32 bits of any
-/// interior pointer equal its byte offset within the region. Allocation is a pointer bump; deallocation of individual
-/// items is a no-op (the whole region is freed at once on drop; or never if using borrowed memory).
-pub struct Arena {
-	/// Base of the usable, 4 GiB-aligned region.
+/// A chunk the arena has bumped past, kept in a chain so every chunk is released when the arena is.
+struct Chunk {
 	base: NonNull<u8>,
-	/// Usable size of the region in bytes.
 	size: usize,
-	/// Bump cursor: byte offset of the next free position within the region.
+	backing: Backing,
+	prev: Option<NonNull<Chunk>>,
+}
+
+/// Where the target allows it the region begins at a 4 GiB-aligned address and is at most [`MAX_BLOCK_SIZE`] bytes, so
+/// the low 32 bits of any interior pointer equal its byte offset within the region. Allocation is a pointer bump;
+/// deallocation of individual items is a no-op (every chunk is freed at once on drop; or never if using borrowed
+/// memory).
+pub struct Arena {
+	/// Base of the usable region of the chunk being bumped from.
+	base: Cell<NonNull<u8>>,
+	/// Usable size of that chunk in bytes.
+	size: Cell<usize>,
+	/// Bump cursor: byte offset of the next free position within the chunk.
 	cursor: Cell<usize>,
-	/// Bytes of the region backed by physical memory. Windows has no lazy commit, so the arena commits as it bumps.
+	/// Bytes of the chunk backed by physical memory. Windows has no lazy commit, so the arena commits as it bumps.
 	#[cfg(windows)]
 	committed: Cell<usize>,
-	backing: Backing,
+	backing: Cell<Backing>,
+	/// Chunks the arena has bumped past. `None` unless it ran out of room and had to add one.
+	prev: Cell<Option<NonNull<Chunk>>>,
+	/// Bytes handed out from, and total usable size of, the chunks in `prev`.
+	prev_used: Cell<usize>,
+	prev_size: Cell<usize>,
+	/// Whether a full chunk may be retired in favour of a fresh, larger one.
+	growable: bool,
 }
 
 impl Arena {
 	/// Create a self-allocated arena.
 	///
-	/// The region reserves the full [`MAX_BLOCK_SIZE`] address space so that a single non-growing bump arena can serve
-	/// arbitrarily large parses without exhausting (the arena never relocates, so it cannot grow after construction).
+	/// Where address space can be reserved lazily the first chunk is the full [`MAX_BLOCK_SIZE`] region, costing no
+	/// physical memory until written to, so one non-relocating chunk serves arbitrarily large parses. Elsewhere every
+	/// byte of a chunk is paid for up front, so the arena starts small and adds chunks as it fills.
 	#[inline]
 	pub fn new() -> Self {
-		Self::with_capacity(MAX_BLOCK_SIZE)
+		let size = if vm::RESERVABLE { MAX_BLOCK_SIZE } else { INITIAL_COMMIT };
+		let (base, backing) = Self::new_chunk(size).expect("arena backing reservation failed");
+		Self::from_chunk(base, size, backing, true)
 	}
 
-	/// Create a self-allocated arena reserving `size` usable bytes (clamped to [`MAX_BLOCK_SIZE`]).
+	/// Create a self-allocated arena of exactly `size` usable bytes (clamped to [`MAX_BLOCK_SIZE`]).
+	///
+	/// The arena never grows: once `size` bytes are handed out, allocation fails.
 	///
 	/// # Panics
 	/// Panics if the backing allocation fails.
 	pub fn with_capacity(size: usize) -> Self {
 		let size = size.clamp(1, MAX_BLOCK_SIZE);
-		let reservation = vm::reserve(size).expect("arena backing reservation failed");
-		debug_assert_eq!(reservation.base.as_ptr() as usize % BLOCK_ALIGN, 0, "arena base must be 4 GiB aligned");
+		let (base, backing) = Self::new_chunk(size).expect("arena backing reservation failed");
+		Self::from_chunk(base, size, backing, false)
+	}
+
+	/// Take `size` usable bytes for a chunk: reserved address space where the target has it, a block from the global
+	/// allocator otherwise.
+	fn new_chunk(size: usize) -> Option<(NonNull<u8>, Backing)> {
+		vm::reserve(size)
+			.map(|reservation| {
+				debug_assert!(
+					(reservation.base.as_ptr() as usize).is_multiple_of(BLOCK_ALIGN),
+					"arena base must be 4 GiB aligned"
+				);
+				let backing = Backing::Owned { reservation: reservation.reservation, reserved: reservation.reserved };
+				(reservation.base, backing)
+			})
+			.or_else(|| Self::heap_chunk(size, CHUNK_ALIGN))
+	}
+
+	/// Take `size` bytes from the global allocator for a chunk, aligned to at least `align`.
+	///
+	/// `None` for a zero-sized or otherwise unrepresentable request: a chunk with no room is no use to the arena, and
+	/// the global allocator may not be asked for zero bytes.
+	fn heap_chunk(size: usize, align: usize) -> Option<(NonNull<u8>, Backing)> {
+		let layout = Layout::from_size_align(size, align).ok().filter(|layout| layout.size() > 0)?;
+		// SAFETY: the layout is not zero sized.
+		let base = NonNull::new(unsafe { std::alloc::alloc(layout) })?;
+		Some((base, Backing::Heap(layout)))
+	}
+
+	fn from_chunk(base: NonNull<u8>, size: usize, backing: Backing, growable: bool) -> Self {
 		Self {
-			base: reservation.base,
-			size,
+			base: Cell::new(base),
+			size: Cell::new(size),
 			cursor: Cell::new(0),
 			#[cfg(windows)]
-			committed: Cell::new(0),
-			backing: Backing::Owned { reservation: reservation.reservation, reserved: reservation.reserved },
+			committed: Cell::new(if matches!(backing, Backing::Owned { .. }) { 0 } else { size }),
+			backing: Cell::new(backing),
+			prev: Cell::new(None),
+			prev_used: Cell::new(0),
+			prev_size: Cell::new(0),
+			growable,
 		}
 	}
 
@@ -110,49 +169,99 @@ impl Arena {
 	/// `ptr` must be the base of a live, writable region of at least `size` bytes that outlives the arena, aligned to
 	/// [`BLOCK_ALIGN`] and no larger than [`MAX_BLOCK_SIZE`], and it must not be handed to another allocator.
 	pub unsafe fn from_raw_parts(ptr: NonNull<u8>, size: usize) -> Self {
-		debug_assert_eq!(ptr.as_ptr() as usize % BLOCK_ALIGN, 0, "borrowed arena base must be 4 GiB aligned");
+		debug_assert!((ptr.as_ptr() as usize).is_multiple_of(BLOCK_ALIGN), "borrowed arena base must be 4 GiB aligned");
 		debug_assert!(size <= MAX_BLOCK_SIZE, "borrowed arena must not exceed MAX_BLOCK_SIZE");
-		Self {
-			base: ptr,
-			size,
-			cursor: Cell::new(0),
-			// Borrowed memory is already backed by its owner.
-			#[cfg(windows)]
-			committed: Cell::new(size),
-			backing: Backing::Borrowed,
-		}
+		Self::from_chunk(ptr, size, Backing::Borrowed, false)
 	}
 
 	/// The base address of the usable region.
 	#[inline]
 	pub fn base_ptr(&self) -> NonNull<u8> {
-		self.base
+		self.base.get()
+	}
+
+	/// Whether every allocation lives in one region starting at [`Arena::base_ptr`], and so whether the low 32 bits of
+	/// every pointer handed out is its offset into that region.
+	///
+	/// - Over a reserved region this is [`Arena::base_ptr`], until the arena has to add a chunk: there is then no
+	///   single region left to be an offset into, and this becomes `None`.
+	/// - Where pointers are 32 bits wide they already are their own offsets, so the base is `0` however many chunks
+	///   the arena holds: the buffer is the whole address space, which on wasm32 is the linear memory the binding
+	///   layer already has.
+	/// - On a 64 bit target with nothing to reserve - wasm64 under `memory64`, whose linear memory may exceed 4 GiB -
+	///   a pointer's upper half is unconstrained, so its low 32 bits mean nothing and this is always `None`.
+	#[inline]
+	pub fn transfer_base(&self) -> Option<usize> {
+		if !cfg!(target_pointer_width = "64") {
+			return Some(0);
+		}
+		// `BLOCK_ALIGN` is 1 without a reservation, so the alignment alone would wave anything through; and a
+		// reservation that fell back to the global allocator is unaligned even though `RESERVABLE` holds.
+		let base = self.base.get().as_ptr() as usize;
+		(vm::RESERVABLE && self.prev.get().is_none() && base.is_multiple_of(BLOCK_ALIGN)).then_some(base)
 	}
 
 	/// Number of bytes handed out so far.
 	#[inline]
 	pub fn used_bytes(&self) -> usize {
-		self.cursor.get()
+		self.prev_used.get() + self.cursor.get()
 	}
 
-	/// Total usable capacity of the region in bytes.
+	/// Total usable capacity of every chunk in bytes.
 	#[inline]
 	pub fn capacity(&self) -> usize {
-		self.size
+		self.prev_size.get() + self.size.get()
 	}
 
-	/// Release every allocation at once by rewinding the bump cursor to the start of the region.
+	/// Release every allocation at once by rewinding the bump cursor to the start of the first chunk, freeing any chunk
+	/// the arena had to add.
 	///
-	/// Takes `&mut self` so no allocation can outlive the reset. The backing memory is retained.
-	#[inline]
+	/// Takes `&mut self` so no allocation can outlive the reset. The first chunk's memory is retained.
 	pub fn reset(&mut self) {
+		while let Some(node) = self.prev.get() {
+			// SAFETY: every chunk in the chain came from `Box::into_raw`, and `&mut self` proves nothing allocated from
+			// the chunk being dropped is still live.
+			let chunk = *unsafe { Box::from_raw(node.as_ptr()) };
+			// SAFETY: as above.
+			unsafe { release(self.base.get(), self.backing.replace(chunk.backing)) };
+			self.base.set(chunk.base);
+			self.size.set(chunk.size);
+			self.prev.set(chunk.prev);
+			// Every chunk the arena added comes from the global allocator, so is backed in full.
+			#[cfg(windows)]
+			self.committed.set(chunk.size);
+		}
+		self.prev_used.set(0);
+		self.prev_size.set(0);
 		self.cursor.set(0);
 	}
 }
 
+/// Give a chunk's memory back.
+///
+/// # Safety
+/// `base` and `backing` must be exactly what the chunk was built with, and nothing allocated from it may outlive the
+/// call.
+unsafe fn release(base: NonNull<u8>, backing: Backing) {
+	match backing {
+		// SAFETY: `reservation`/`reserved` are exactly what `vm::reserve` returned.
+		Backing::Owned { reservation, reserved } => unsafe { vm::release(reservation, reserved) },
+		// SAFETY: `base`/`layout` are exactly what the global allocator was asked for.
+		Backing::Heap(layout) => unsafe { std::alloc::dealloc(base.as_ptr(), layout) },
+		Backing::Borrowed => {}
+	}
+}
+
+/// Bytes to skip from `addr` to reach the next multiple of `align`.
+#[inline]
+fn pad_to(addr: usize, align: usize) -> usize {
+	debug_assert!(align.is_power_of_two(), "Layout alignment is always a power of two");
+	(align - (addr & (align - 1))) & (align - 1)
+}
+
 /// How far to commit when `end` bytes are needed and `committed` are already backed, given a region of `size` bytes.
 ///
-/// Growth doubles so that a parse does not pay a syscall per bump, but never overshoots the region nor undershoots
+/// Growth doubles so that a parse does not pay a syscall per bump, but never overshoots the chunk nor undershoots
 /// what was asked for. Only Windows commits, but the arithmetic is compiled everywhere so it can be tested everywhere.
 #[inline]
 #[cfg(any(test, windows))]
@@ -161,15 +270,15 @@ fn commit_target(end: usize, committed: usize, size: usize) -> usize {
 }
 
 impl Arena {
-	/// Ensure the region is backed by physical memory up to `end`, which must be within the region.
+	/// Ensure the chunk is backed by physical memory up to `end`, which must be within the chunk.
 	#[cfg(windows)]
 	#[cold]
 	#[inline(never)]
 	fn commit_to(&self, end: usize) -> bool {
 		let committed = self.committed.get();
-		let target = commit_target(end, committed, self.size);
+		let target = commit_target(end, committed, self.size.get());
 		// SAFETY: `committed <= target <= size`, so the range lies within the reservation.
-		let ptr = unsafe { NonNull::new_unchecked(self.base.as_ptr().add(committed)) };
+		let ptr = unsafe { NonNull::new_unchecked(self.base.get().as_ptr().add(committed)) };
 		// SAFETY: ditto.
 		if !unsafe { vm::commit(ptr, target - committed) } {
 			return false;
@@ -178,21 +287,62 @@ impl Arena {
 		true
 	}
 
+	/// Retire the current chunk and bump from a fresh, larger one able to serve `layout`.
+	#[cold]
+	#[inline(never)]
+	fn grow_chunk(&self, layout: Layout) -> Option<NonNull<[u8]>> {
+		if !self.growable {
+			return None;
+		}
+		let total = self.capacity();
+		// The arena stays within MAX_BLOCK_SIZE however many chunks it takes, so every offset it hands out still fits
+		// in a u32.
+		let spare = MAX_BLOCK_SIZE.checked_sub(total)?;
+		// Double, so growth costs a logarithmic number of allocations, but never less than the request nor more than
+		// the budget leaves.
+		let size = layout.size().max(total.max(INITIAL_COMMIT).min(spare));
+		if size > spare {
+			return None;
+		}
+		// Aligning the chunk to the request means the allocation fits at its base.
+		let (base, backing) = Self::heap_chunk(size, layout.align().max(CHUNK_ALIGN))?;
+		let retired = Chunk {
+			base: self.base.get(),
+			size: self.size.get(),
+			backing: self.backing.replace(backing),
+			prev: self.prev.get(),
+		};
+		self.prev_used.set(self.prev_used.get() + self.cursor.get());
+		self.prev_size.set(total);
+		// SAFETY: `Box::into_raw` never returns null.
+		self.prev.set(Some(unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(retired))) }));
+		self.base.set(base);
+		self.size.set(size);
+		self.cursor.set(0);
+		// A chunk from the global allocator is backed in full.
+		#[cfg(windows)]
+		self.committed.set(size);
+		// The fresh chunk is big enough and aligned for `layout`, so this cannot recurse again.
+		self.bump(layout)
+	}
+
 	/// Bump-allocate `layout.size()` bytes aligned to `layout.align()`.
 	///
-	/// Returns `None` if the region is exhausted.
+	/// Returns `None` if the arena is exhausted.
 	#[inline]
 	fn bump(&self, layout: Layout) -> Option<NonNull<[u8]>> {
 		let align = layout.align();
 		let bytes = layout.size();
 		debug_assert!(align.is_power_of_two(), "Layout alignment is always a power of two");
+		let base = self.base.get();
 		let start = self.cursor.get();
-		debug_assert!(start <= self.size, "cursor must never exceed the region size");
-		// Round the cursor up to the requested alignment.
-		let aligned = (start + align - 1) & !(align - 1);
+		debug_assert!(start <= self.size.get(), "cursor must never exceed the chunk size");
+		// Round the cursor up to the requested alignment. It is the address that is rounded rather than the offset: a
+		// chunk from the global allocator is only CHUNK_ALIGN aligned, so an aligned offset within it need not be one.
+		let aligned = start + pad_to(base.as_ptr() as usize + start, align);
 		let end = aligned.checked_add(bytes)?;
-		if end > self.size {
-			return None;
+		if end > self.size.get() {
+			return self.grow_chunk(layout);
 		}
 		#[cfg(windows)]
 		if end > self.committed.get() && !self.commit_to(end) {
@@ -200,8 +350,8 @@ impl Arena {
 		}
 		debug_assert!(aligned >= start && end >= aligned, "bump must advance the cursor monotonically");
 		self.cursor.set(end);
-		// SAFETY: `aligned + bytes <= size`, so the range is within the region.
-		let ptr = unsafe { NonNull::new_unchecked(self.base.as_ptr().add(aligned)) };
+		// SAFETY: `aligned + bytes <= size`, so the range is within the chunk.
+		let ptr = unsafe { NonNull::new_unchecked(base.as_ptr().add(aligned)) };
 		debug_assert_eq!(ptr.as_ptr() as usize % align, 0, "returned pointer must satisfy the requested alignment");
 		Some(NonNull::slice_from_raw_parts(ptr, bytes))
 	}
@@ -209,23 +359,25 @@ impl Arena {
 	/// A zero-length allocation at the cursor.
 	///
 	/// Nothing is written, so the cursor does not move and the pages need not be committed, but the pointer is still an
-	/// interior pointer of the region: handing out an out-of-region dangling pointer would break raw transfer, whose
+	/// interior pointer of the chunk: handing out an out-of-region dangling pointer would break raw transfer, whose
 	/// offsets are the low 32 bits of every pointer.
 	#[inline]
 	fn empty(&self, align: usize) -> Option<NonNull<[u8]>> {
-		let aligned = (self.cursor.get() + align - 1) & !(align - 1);
-		if aligned > self.size {
+		let base = self.base.get();
+		let start = self.cursor.get();
+		let aligned = start + pad_to(base.as_ptr() as usize + start, align);
+		if aligned > self.size.get() {
 			return None;
 		}
-		// SAFETY: `aligned <= size`, so the address is within the region.
-		let ptr = unsafe { NonNull::new_unchecked(self.base.as_ptr().add(aligned)) };
+		// SAFETY: `aligned <= size`, so the address is within the chunk.
+		let ptr = unsafe { NonNull::new_unchecked(base.as_ptr().add(aligned)) };
 		Some(NonNull::slice_from_raw_parts(ptr, 0))
 	}
 }
 
 impl std::fmt::Debug for Arena {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("Arena").field("capacity", &self.size).field("used", &self.cursor.get()).finish()
+		f.debug_struct("Arena").field("capacity", &self.capacity()).field("used", &self.used_bytes()).finish()
 	}
 }
 
@@ -238,9 +390,15 @@ impl Default for Arena {
 
 impl Drop for Arena {
 	fn drop(&mut self) {
-		if let Backing::Owned { reservation, reserved } = self.backing {
-			// SAFETY: `reservation`/`reserved` are exactly what `vm::reserve` returned, and every allocation is dead.
-			unsafe { vm::release(reservation, reserved) };
+		// SAFETY: `&mut self` proves every allocation is dead.
+		unsafe { release(self.base.get(), self.backing.get()) };
+		let mut node = self.prev.get();
+		while let Some(chunk) = node {
+			// SAFETY: every chunk in the chain came from `Box::into_raw` and has not been freed.
+			let chunk = *unsafe { Box::from_raw(chunk.as_ptr()) };
+			node = chunk.prev;
+			// SAFETY: as above; every allocation from the chunk is dead.
+			unsafe { release(chunk.base, chunk.backing) };
 		}
 	}
 }
@@ -277,15 +435,15 @@ unsafe impl Allocator for &Arena {
 		debug_assert!(new_layout.size() >= old_layout.size(), "grow must not shrink");
 		// If `ptr` is the most recent allocation, extend it in place by bumping the cursor, avoiding
 		// stranding the old bytes. This is the common case for a `Vec` growing while it is the last
-		// thing allocated.
+		// thing allocated. A pointer from a chunk the arena has bumped past falls through to the copy
+		// below: chunks never overlap, so its offset within this one cannot also be the live cursor.
 		let addr = ptr.as_ptr() as usize;
-		let base = self.base.as_ptr() as usize;
-		debug_assert!(addr >= base, "grown pointer must lie within this arena's region");
-		let offset = addr - base;
-		debug_assert!(offset + old_layout.size() <= self.size, "grown allocation must lie within the region");
+		let base = self.base.get().as_ptr() as usize;
+		let offset = addr.wrapping_sub(base);
 		if new_layout.align() <= old_layout.align()
+			&& offset < self.size.get()
 			&& offset + old_layout.size() == self.cursor.get()
-			&& offset + new_layout.size() <= self.size
+			&& offset + new_layout.size() <= self.size.get()
 		{
 			let end = offset + new_layout.size();
 			#[cfg(windows)]
@@ -308,9 +466,16 @@ unsafe impl Allocator for &Arena {
 
 #[cfg(test)]
 mod test {
-	use crate::{Arena, BLOCK_ALIGN, INITIAL_COMMIT, MAX_BLOCK_SIZE, commit_target};
+	use crate::{Arena, BLOCK_ALIGN, INITIAL_COMMIT, MAX_BLOCK_SIZE, commit_target, vm};
 	use allocator_api2::alloc::Allocator;
 	use std::alloc::Layout;
+
+	/// A growing arena over a chunk from the global allocator, which unlike a reservation is only `CHUNK_ALIGN` aligned
+	/// and small enough to outgrow. This is what [`Arena::new`] builds where nothing can be reserved.
+	fn growing(size: usize) -> Arena {
+		let (base, backing) = Arena::heap_chunk(size, crate::CHUNK_ALIGN).unwrap();
+		Arena::from_chunk(base, size, backing, true)
+	}
 
 	#[test]
 	fn commit_target_covers_the_request_and_doubles() {
@@ -331,10 +496,13 @@ mod test {
 
 	#[test]
 	fn base_is_4gib_aligned() {
+		if !vm::RESERVABLE {
+			return;
+		}
 		let arena = Arena::new();
-		assert_eq!(arena.base_ptr().as_ptr() as usize % BLOCK_ALIGN, 0);
-		let fixed = Arena::new();
-		assert_eq!(fixed.base_ptr().as_ptr() as usize % BLOCK_ALIGN, 0);
+		assert!((arena.base_ptr().as_ptr() as usize).is_multiple_of(BLOCK_ALIGN));
+		let fixed = Arena::with_capacity(4096);
+		assert!((fixed.base_ptr().as_ptr() as usize).is_multiple_of(BLOCK_ALIGN));
 	}
 
 	#[test]
@@ -346,7 +514,41 @@ mod test {
 		let data = alloc.as_ptr() as *mut u8 as usize;
 		let offset = data - base;
 		assert!(offset <= MAX_BLOCK_SIZE);
-		assert_eq!(data as u32 as usize, offset, "ptr low 32 bits must equal arena offset");
+		if vm::RESERVABLE {
+			// A 4 GiB aligned base puts the region offset in the low 32 bits of every pointer into it.
+			assert_eq!(arena.transfer_base(), Some(base));
+			assert_eq!(data as u32 as usize, offset, "ptr low 32 bits must equal arena offset");
+		} else if cfg!(target_pointer_width = "64") {
+			// wasm64: linear memory may exceed 4 GiB and nothing constrains a pointer's upper half.
+			assert_eq!(arena.transfer_base(), None);
+		} else {
+			// Nothing to align, and no need: a 32 bit pointer already is the offset a binding layer reads, into the
+			// whole address space (linear memory, on wasm32) rather than the region.
+			assert_eq!(arena.transfer_base(), Some(0));
+			assert_eq!(data as u32 as usize, data);
+		}
+	}
+
+	#[test]
+	fn an_unaligned_region_promises_no_offsets() {
+		// The shape a 64 bit target with nothing to reserve is stuck with, and the one a failed reservation falls back
+		// to: a single chunk, but from the global allocator, so its base has none of the alignment offsets need.
+		let arena = growing(1024);
+		if cfg!(target_pointer_width = "64") {
+			assert_eq!(arena.transfer_base(), None);
+		} else {
+			assert_eq!(arena.transfer_base(), Some(0));
+		}
+	}
+
+	#[test]
+	fn over_aligned_allocation_is_aligned() {
+		// A chunk from the global allocator is only CHUNK_ALIGN aligned, so an allocation wanting more has to be padded
+		// to an absolute boundary, not to an offset within the chunk.
+		let arena = growing(INITIAL_COMMIT);
+		let _ = (&arena).allocate(Layout::from_size_align(1, 1).unwrap()).unwrap();
+		let a = (&arena).allocate(Layout::from_size_align(64, 64).unwrap()).unwrap();
+		assert_eq!(a.as_ptr() as *mut u8 as usize % 64, 0);
 	}
 
 	#[test]
@@ -370,7 +572,9 @@ mod test {
 		let offset = a.as_ptr() as *mut u8 as usize - arena.base_ptr().as_ptr() as usize;
 		assert_eq!(offset, 0);
 		assert_eq!(a.as_ptr() as *mut u8 as usize % 4, 0);
-		assert_eq!(a.as_ptr() as *mut u8 as usize as u32 as usize, offset);
+		if vm::RESERVABLE {
+			assert_eq!(a.as_ptr() as *mut u8 as usize as u32 as usize, offset);
+		}
 	}
 
 	#[test]
@@ -390,17 +594,26 @@ mod test {
 
 	#[test]
 	fn from_raw_parts_over_borrowed_memory_never_frees() {
-		let backing = Arena::new();
+		let backing = Arena::with_capacity(8192);
 		let borrowed = unsafe { Arena::from_raw_parts(backing.base_ptr(), 4096) };
 		let a = (&borrowed).allocate(Layout::from_size_align(256, 1).unwrap()).unwrap();
 		assert_eq!(a.len(), 256);
+		// Borrowed memory is exactly as big as the caller says, so the arena must not grow past it.
+		assert!((&borrowed).allocate(Layout::from_size_align(8192, 1).unwrap()).is_err());
 		drop(borrowed);
-		// Still valid: backing owns the memory and is untouched.
-		assert_eq!(backing.base_ptr().as_ptr() as usize % BLOCK_ALIGN, 0);
+		// `backing` owns the memory, so dropping the borrow left it alone: it still hands out bytes, and they are still
+		// writable.
+		assert_eq!(backing.capacity(), 8192);
+		let b = (&backing).allocate(Layout::from_size_align(8192, 1).unwrap()).unwrap();
+		// SAFETY: the allocation is live and exclusively owned here.
+		unsafe { b.cast::<u8>().write_bytes(0x44, 8192) };
 	}
 
 	#[test]
 	fn tiny_alloc_commits_little_physical_memory() {
+		if !vm::RESERVABLE {
+			return;
+		}
 		let arena = Arena::new();
 		let _ = (&arena).allocate(Layout::new::<u64>()).unwrap();
 		assert!(arena.used_bytes() < 4096, "tiny alloc used {} bytes", arena.used_bytes());
@@ -437,7 +650,97 @@ mod test {
 		let arena = Arena::with_capacity(128);
 		// First alloc fits.
 		assert!((&arena).allocate(Layout::from_size_align(64, 1).unwrap()).is_ok());
-		// Second overflows the 128-byte region.
+		// Second overflows the 128-byte region, which was asked for a fixed size and so cannot grow.
 		assert!((&arena).allocate(Layout::from_size_align(128, 1).unwrap()).is_err());
+	}
+
+	#[test]
+	fn growing_the_last_allocation_extends_it_in_place() {
+		let arena = Arena::new();
+		let old = Layout::from_size_align(64, 8).unwrap();
+		let a = (&arena).allocate(old).unwrap();
+		let new = Layout::from_size_align(4096, 8).unwrap();
+		let b = unsafe { (&arena).grow(a.cast::<u8>(), old, new) }.unwrap();
+		assert_eq!(a.as_ptr() as *mut u8, b.as_ptr() as *mut u8, "the last allocation grows without moving");
+		assert_eq!(arena.used_bytes(), 4096, "growing in place strands nothing");
+	}
+
+	#[test]
+	fn a_growing_arena_adds_chunks_and_keeps_counting() {
+		let arena = growing(1024);
+		let layout = Layout::from_size_align(256, 8).unwrap();
+		let allocs: Vec<_> = (0..64)
+			.map(|_| {
+				let a = (&arena).allocate(layout).unwrap();
+				// SAFETY: the allocation is live and exclusively owned here.
+				unsafe { a.cast::<u8>().write_bytes(0xEE, layout.size()) };
+				a
+			})
+			.collect();
+		assert!(arena.capacity() > 1024, "the arena outgrew its first chunk");
+		assert_eq!(arena.used_bytes(), 64 * 256, "allocations in retired chunks are still counted");
+		if cfg!(target_pointer_width = "64") {
+			assert_eq!(arena.transfer_base(), None, "more than one chunk leaves nothing for offsets to be relative to");
+		} else {
+			assert_eq!(arena.transfer_base(), Some(0), "a 32 bit pointer is its own offset whatever the chunking");
+		}
+		// Every allocation from every chunk is still live and holds what was written to it.
+		for a in &allocs {
+			// SAFETY: each allocation is live and every byte was initialised above.
+			assert!(unsafe { a.as_ref() }.iter().all(|b| *b == 0xEE));
+		}
+	}
+
+	#[test]
+	fn a_growing_arena_serves_an_allocation_larger_than_a_chunk() {
+		let arena = growing(1024);
+		let layout = Layout::from_size_align(3 * 1024 * 1024, 8).unwrap();
+		let a = (&arena).allocate(layout).unwrap();
+		// SAFETY: the allocation is live and exclusively owned here.
+		unsafe { a.cast::<u8>().write_bytes(0x11, layout.size()) };
+		assert!(arena.capacity() >= layout.size());
+	}
+
+	#[test]
+	fn growth_stops_at_the_offset_budget() {
+		let arena = growing(1024);
+		// A request that cannot fit within MAX_BLOCK_SIZE has to fail rather than hand out an offset too big for a u32.
+		assert!((&arena).allocate(Layout::from_size_align(MAX_BLOCK_SIZE, 8).unwrap()).is_err());
+		// The arena is untouched and still usable.
+		assert!((&arena).allocate(Layout::from_size_align(64, 8).unwrap()).is_ok());
+	}
+
+	#[test]
+	fn reset_rewinds_to_the_first_chunk() {
+		let mut arena = growing(1024);
+		let layout = Layout::from_size_align(256, 8).unwrap();
+		for _ in 0..64 {
+			let _ = (&arena).allocate(layout).unwrap();
+		}
+		assert!(arena.capacity() > 1024, "the arena outgrew its first chunk");
+		arena.reset();
+		assert_eq!(arena.used_bytes(), 0);
+		assert_eq!(arena.capacity(), 1024, "chunks added since construction are freed");
+		// Still usable, from the top of the first chunk.
+		let a = (&arena).allocate(layout).unwrap();
+		assert_eq!(a.as_ptr() as *mut u8, arena.base_ptr().as_ptr());
+	}
+
+	#[test]
+	fn reset_reuses_the_backing_region() {
+		let mut arena = Arena::with_capacity(2 * 1024 * 1024);
+		let base = arena.base_ptr();
+		let layout = Layout::from_size_align(1 << 20, 8).unwrap();
+		let a = (&arena).allocate(layout).unwrap();
+		// SAFETY: the allocation is live and exclusively owned here.
+		unsafe { a.cast::<u8>().write_bytes(0x22, layout.size()) };
+		arena.reset();
+		assert_eq!(arena.used_bytes(), 0);
+		assert_eq!(arena.base_ptr(), base, "reset keeps the backing region");
+		// The bytes are handed out again, and are still writable: a committed page stays committed.
+		let b = (&arena).allocate(layout).unwrap();
+		assert_eq!(b.as_ptr() as *mut u8, base.as_ptr());
+		// SAFETY: the allocation is live and exclusively owned here.
+		unsafe { b.cast::<u8>().write_bytes(0x33, layout.size()) };
 	}
 }

--- a/crates/csskit_arena/src/vm.rs
+++ b/crates/csskit_arena/src/vm.rs
@@ -1,10 +1,17 @@
 //! Virtual memory reservation for the [`Arena`][crate::Arena] region.
 //!
-//! The region is reserved at its full size up front, because a single-chunk arena can never grow. Reserving it through
-//! the system allocator would ask for real memory: Windows has no overcommit and charges every byte of a `HeapAlloc`
-//! against the commit limit, so a handful of live arenas exhausts memory. Reserving address space directly costs
-//! nothing until the pages are touched.
+//! The region is reserved at its full size up front, because a chunk can never grow. Reserving it through the system
+//! allocator would ask for real memory: Windows has no overcommit and charges every byte of a `HeapAlloc` against the
+//! commit limit, so a handful of live arenas exhausts memory. Reserving address space directly costs nothing until the
+//! pages are touched.
+//!
+//! Reserving needs a 64 bit address space (a 4 GiB alignment does not fit in a 32 bit pointer) and the unix or windows
+//! APIs. Where either is missing (wasm32 above all) [`reserve`] always fails and the arena falls back to chunks from
+//! the global allocator, which it has to grow into as it fills.
 use std::ptr::NonNull;
+
+/// Whether this target can reserve address space lazily, and so hold a whole arena in one chunk.
+pub(crate) const RESERVABLE: bool = cfg!(all(target_pointer_width = "64", any(unix, windows)));
 
 /// A reserved region of address space, plus the 4 GiB-aligned window inside it that the arena allocates from.
 pub(crate) struct Reservation {
@@ -16,12 +23,14 @@ pub(crate) struct Reservation {
 	pub(crate) base: NonNull<u8>,
 }
 
+/// Only the reserving implementations round anything up.
+#[cfg(all(target_pointer_width = "64", any(unix, windows)))]
 #[inline]
 fn align_up(addr: usize, align: usize) -> usize {
 	(addr + align - 1) & !(align - 1)
 }
 
-#[cfg(unix)]
+#[cfg(all(target_pointer_width = "64", unix))]
 mod imp {
 	use super::{Reservation, align_up};
 	use crate::BLOCK_ALIGN;
@@ -83,7 +92,7 @@ mod imp {
 	}
 }
 
-#[cfg(windows)]
+#[cfg(all(target_pointer_width = "64", windows))]
 mod imp {
 	use super::{Reservation, align_up};
 	use crate::BLOCK_ALIGN;
@@ -122,6 +131,29 @@ mod imp {
 		// SAFETY: `MEM_RELEASE` requires the base of the reservation and a zero size.
 		unsafe { VirtualFree(reservation.as_ptr().cast(), 0, MEM_RELEASE) };
 	}
+}
+
+/// No lazy reservation here, so [`reserve`] always fails and [`Arena`][crate::Arena] allocates its chunks from the
+/// global allocator instead. The rest exists only so its callers need no `cfg` of their own; none of it runs.
+#[cfg(not(all(target_pointer_width = "64", any(unix, windows))))]
+mod imp {
+	use super::Reservation;
+	use std::ptr::NonNull;
+
+	pub(crate) fn reserve(_size: usize) -> Option<Reservation> {
+		None
+	}
+
+	/// # Safety
+	/// Never call this: [`reserve`] never succeeds here, so there is nothing to commit.
+	#[cfg(windows)]
+	pub(crate) unsafe fn commit(_ptr: NonNull<u8>, _len: usize) -> bool {
+		false
+	}
+
+	/// # Safety
+	/// Never call this: [`reserve`] never succeeds here, so there is nothing to release.
+	pub(crate) unsafe fn release(_reservation: NonNull<u8>, _reserved: usize) {}
 }
 
 #[cfg(windows)]

--- a/crates/csskit_wasm/Cargo.toml
+++ b/crates/csskit_wasm/Cargo.toml
@@ -20,8 +20,8 @@ fancy = ["miette", "miette/fancy-no-syscall"]
 
 [dependencies]
 css_lexer = { workspace = true } # @release
-css_ast = { workspace = true, features = ["bumpalo", "visitable"] } # @release
-css_parse = { workspace = true, features = ["bumpalo"] } # @release
+css_ast = { workspace = true, features = ["visitable"] } # @release
+css_parse = { workspace = true } # @release
 csskit_transform = { workspace = true } # @release
 
 miette = { workspace = true, features = ["derive"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,26 +25,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
-name = "bumpalo"
-version = "3.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-dependencies = [
- "allocator-api2",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,10 +44,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "css_ast"
-version = "0.0.24"
+version = "0.0.28"
 dependencies = [
  "bitmask-enum",
- "bumpalo",
  "css_lexer",
  "css_parse",
  "csskit_derives",
@@ -91,32 +61,34 @@ dependencies = [
  "smallvec",
  "syn",
  "thiserror",
+ "visit-flow",
 ]
 
 [[package]]
 name = "css_lexer"
-version = "0.0.24"
+version = "0.0.28"
 dependencies = [
  "allocator-api2",
  "bitmask-enum",
- "bumpalo",
  "derive_atom_set",
- "memchr",
+ "fearless_simd",
 ]
 
 [[package]]
 name = "css_parse"
-version = "0.0.24"
+version = "0.0.28"
 dependencies = [
+ "allocator-api2",
  "bitmask-enum",
- "bumpalo",
  "css_lexer",
+ "csskit_arena",
+ "csskit_proc_macro",
  "smallvec",
 ]
 
 [[package]]
 name = "css_value_definition_parser"
-version = "0.0.24"
+version = "0.0.28"
 dependencies = [
  "css_lexer",
  "heck",
@@ -130,7 +102,6 @@ dependencies = [
 name = "csskit-fuzz"
 version = "0.0.0"
 dependencies = [
- "bumpalo",
  "css_ast",
  "css_lexer",
  "css_parse",
@@ -138,8 +109,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "csskit_arena"
+version = "0.0.28"
+dependencies = [
+ "allocator-api2",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "csskit_derives"
-version = "0.0.24"
+version = "0.0.28"
 dependencies = [
  "darling",
  "heck",
@@ -152,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_proc_macro"
-version = "0.0.24"
+version = "0.0.28"
 dependencies = [
  "css_lexer",
  "css_value_definition_parser",
@@ -166,13 +146,9 @@ dependencies = [
 
 [[package]]
 name = "csskit_source_finder"
-version = "0.0.24"
+version = "0.0.28"
 dependencies = [
  "glob",
- "grep-matcher",
- "grep-regex",
- "grep-searcher",
- "heck",
  "quote",
  "syn",
 ]
@@ -213,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "derive_atom_set"
-version = "0.0.24"
+version = "0.0.28"
 dependencies = [
  "heck",
  "itertools",
@@ -229,28 +205,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "encoding_rs_io"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
-dependencies = [
- "encoding_rs",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fearless_simd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f5f895dac0865bc235f1364793899569a7db538137f1024dccea56bf41c78d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -275,43 +239,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "grep-matcher"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "grep-regex"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
-dependencies = [
- "bstr",
- "grep-matcher",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "grep-searcher"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
-dependencies = [
- "bstr",
- "encoding_rs",
- "encoding_rs_io",
- "grep-matcher",
- "log",
- "memchr",
- "memmap2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -343,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -374,27 +301,6 @@ checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "log"
-version = "0.4.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
-
-[[package]]
-name = "memchr"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
-
-[[package]]
-name = "memmap2"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -440,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -452,32 +358,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "serde_core"
@@ -516,9 +396,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -528,9 +408,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -620,12 +500,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "visit-flow"
+version = "0.0.28"
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]


### PR DESCRIPTION
Currently the only reason we keep Bumpalo around is due to
csskit_arena's lack of ability to grow in chunks; it can only lazily reserve a
large block of memory, which makes it unusable for some targets, namely
wasm.

This change introduces a new mode for the arena so it can now bumps one chunk at
a time. Where address space can be reserved lazily the first chunk is still the
whole region per the old model, but everywhere else chunks come from the global
allocator, starting at 64 KiB and doubling, with the total capped at
MAX_BLOCK_SIZE so every offset still fits in a u32.

This change allows us to drop bumpalo from the workspace, and use
csskit_arena in WASM contexts, albeit losing the offset guarantee -
though this is not important for wasm.
