### PR TITLE
csskit_ast: Unflag stable_type_layout from test.

### DIFF
--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
 bitmask-enum = { workspace = true }
+stable_type_layout = { workspace = true } # @release
 
 [build-dependencies]
 csskit_source_finder = { workspace = true } # @release
@@ -49,7 +50,6 @@ insta = { workspace = true, features = ["ron"] }
 similar = { workspace = true }
 console = { workspace = true }
 dhat = { workspace = true }
-stable_type_layout = { workspace = true }  # @release
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 pprof = { workspace = true, features = ["flamegraph", "criterion"] }

--- a/crates/css_ast/build.rs
+++ b/crates/css_ast/build.rs
@@ -61,8 +61,22 @@ fn main() {
 
 		let display_arms = queryable.iter().map(|node| {
 			let ident = node.ident();
-			let ident_str = ident.to_string();
-			quote! { Self::#ident => write!(f, #ident_str) }
+			let generics = node.generics();
+			if generics.type_params().next().is_some() || generics.const_params().next().is_some() {
+				let ident_str = ident.to_string();
+				return quote! { Self::#ident => f.write_str(#ident_str) };
+			}
+			let statics = std::iter::repeat_n(quote! { 'static }, generics.lifetimes().count()).collect::<Vec<_>>();
+			let ty = if statics.is_empty() {
+				quote! { #ident }
+			} else {
+				quote! { #ident<#(#statics),*> }
+			};
+			quote! {
+				Self::#ident => f.write_str(
+					<crate::#ty as ::stable_type_layout::TypeLayout>::TYPE_LAYOUT.name
+				)
+			}
 		});
 
 		#[rustfmt::skip]

--- a/crates/css_parse/Cargo.toml
+++ b/crates/css_parse/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { workspace = true, optional = true }
 bitmask-enum = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+stable_type_layout = { workspace = true } # @release
 
 [dev-dependencies]
 csskit_derives = { workspace = true }  # @release
@@ -33,7 +34,6 @@ derive_atom_set = { workspace = true } # @release
 insta = { workspace = true }
 glob = { workspace = true }
 dhat = { workspace = true }
-stable_type_layout = { workspace = true }  # @release
 
 [features]
 default = []

--- a/crates/csskit_proc_macro/src/layout.rs
+++ b/crates/csskit_proc_macro/src/layout.rs
@@ -25,7 +25,7 @@ pub fn derive_attr(generics: &Generics) -> TokenStream {
 	if lifetimes(generics).is_none() {
 		return quote! {};
 	}
-	quote! { #[cfg_attr(test, derive(::stable_type_layout::TypeLayout))] }
+	quote! { #[derive(::stable_type_layout::TypeLayout)] }
 }
 
 /// Registers a node type's layout with the crate's `layout_test` collector so its

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_struct_with_range.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_struct_with_range.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 #[parse(all_must_occur)]
 struct Foo<'a>(

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_with_group_alternatives.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_with_group_alternatives.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Legacy)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__alternatives_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__alternatives_with_checks_derive_parse.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Bar)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_and_length_with_range.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_and_length_with_range.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 #[parse(all_must_occur)]
 struct Foo<'a>(

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_fixed_multiplier.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_fixed_multiplier.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub crate::AutoOr<

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse, Visitable)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none_or_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none_or_type.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(pub crate::AutoNoneOr<crate::CalcableValue<'a, crate::Length>>);
 #[cfg(test)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub crate::AutoOr<

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks_derive_parse.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub crate::AutoOr<

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bg_image.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bg_image.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(pub crate::Value<'a, crate::BgImage<'a>>);
 #[cfg(test)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bound_range_multiplier_with_keyword.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     Length(

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_multiplier_of_keywords.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 #[derive(
     ::csskit_derives::Parse,
@@ -32,7 +32,7 @@ pub enum FooKeywords {
 #[cfg(test)]
 ::stable_type_layout::register!(FooKeywords);
 #[derive(Visitable, Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     #[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub crate::BorderTopColorStyleValue<'a>,

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional2_keyword.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 #[parse(one_must_occur)]
 struct Foo {

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords_with_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords_with_derive_parse.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse, Visitable)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 #[parse(one_must_occur)]
 struct Foo {

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_keyword.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_last_keyword.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_all_optionals.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_all_optionals.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a> {
     pub caret_color: Option<crate::CaretColorStyleValue<'a>>,

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_type.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_variant_with_args.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::FitContent)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_variant_with_multiplier_args.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(pub crate::NormalOr<crate::StylesetFunction<'a>>);
 #[cfg(test)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks_derive_parse.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_list.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_list.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 #[derive(
     ::csskit_derives::Parse,
@@ -27,7 +27,7 @@ pub enum FooKeywords {}
 #[cfg(test)]
 ::stable_type_layout::register!(FooKeywords);
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub Option<::css_parse::Vec<'a, (::css_parse::T![Ident], ::css_parse::T![,])>>,

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_with_nested_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_with_nested_options.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[parse(one_must_occur)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_type_with_lifetime.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     Color(crate::Value<'a, crate::Color<'a>>),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_group_in_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_group_in_options.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Nowrap)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_options.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::None)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_variable_count_type.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__just_optional.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__just_optional.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub Option<crate::Value<'a, crate::Color<'a>>>,

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_bounded_type.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_int_literal.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     Keyword(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_int_literal_dimension_literal.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Keyword)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_only_alternation_group_in_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_only_alternation_group_in_options.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[parse(one_must_occur)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__literal_with_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__literal_with_derive_parse.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     Literal0deg(#[atom(CssAtomSet::Deg)] crate::Exact<::css_parse::T![Dimension], 0i32>),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiple_keywords.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Black)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiple_keywords_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiple_keywords_derive_parse.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Black)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_keywords.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 #[derive(
     ::csskit_derives::Parse,
@@ -31,7 +31,7 @@ pub enum FooKeywords {
 }
 #[cfg(test)]
 ::stable_type_layout::register!(FooKeywords);
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub ::css_parse::CommaSeparated<'a, crate::Value<'a, crate::FooKeywords>>,

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_types.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_types.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[derive(
     ::csskit_derives::Parse,
     ::csskit_derives::Peek,
@@ -30,7 +30,7 @@ enum SingleFoo<'a> {
 }
 #[cfg(test)]
 ::stable_type_layout::register!(SingleFoo < 'static >);
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::SingleFoo<'a>>);
 #[cfg(test)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_just_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_just_keywords.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 #[derive(
     ::csskit_derives::Parse,
@@ -31,7 +31,7 @@ pub enum FooKeywords {
 }
 #[cfg(test)]
 ::stable_type_layout::register!(FooKeywords);
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(pub ::css_parse::Vec<'a, crate::Value<'a, crate::FooKeywords>>);
 #[cfg(test)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_two_type_alternatives.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_two_type_alternatives.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Baz<'a>(
     pub ::css_parse::CommaSeparated<

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_combinator_with_checks_derives_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_combinator_with_checks_derives_parse.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Bar)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_custom_function_last_option.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_custom_function_last_option.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub crate::CaretColorStyleValue<'a>,

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__simple_all_must_occur.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__simple_all_must_occur.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 #[parse(all_must_occur)]
 struct Foo<'a>(pub crate::CalcableValue<'a, crate::Length>, pub ::css_parse::T![Ident]);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_keyword_group_options_with_style_values.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_keyword_group_options_with_style_values.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[parse(one_must_occur)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_nonor_keyword_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_nonor_keyword_options.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[derive(
     ::csskit_derives::Parse,
     ::csskit_derives::Peek,
@@ -40,7 +40,7 @@ struct FooOptions {
 #[cfg(test)]
 ::stable_type_layout::register!(FooOptions);
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo(pub crate::NoneOr<crate::FooOptions>);
 #[cfg(test)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_with_one_or_more_commas.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_with_one_or_more_commas.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub ::css_parse::CommaSeparated<

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_with_variable_count_type.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub ::css_parse::CommaSeparated<'a, crate::Value<'a, crate::AnimateableFeature>>,

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_auto_color2_optimized.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_color2_optimized.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub crate::Value<'a, crate::Color<'a>>,

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_group_type_keyword.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     Length(crate::CalcableValue<'a, crate::Positive<crate::Length>>),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(pub crate::NumericValue<'a, crate::Integer>);
 #[cfg(test)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type_with_lifetime.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(pub crate::Value<'a, crate::Image<'a>>);
 #[cfg(test)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_vec_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_vec_type_with_lifetime.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::Value<'a, crate::Image<'a>>>);
 #[cfg(test)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_parse_skips_impl.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_parse_skips_impl.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Foo)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_visitable_adds_attributes.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_visitable_adds_attributes.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse, Visitable)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo {
     #[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_multiplier_oneormore.snap
@@ -3,7 +3,7 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_multiplier_range.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_multiplier_range.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[derive(::stable_type_layout::TypeLayout)]
 #[repr(C)]
 struct Foo<'a>(
     pub crate::CalcableValue<'a, crate::Length>,


### PR DESCRIPTION
stable_type_layout produces string names for all nodes which can be useful.
