### PR TITLE
Release v0.0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+## [0.0.30] - 2026-08-22
+
+### Css_ast
+- css_ast: Allow symbolic-counter-style in content syntax (#1419) ([#1419](https://github.com/csskit/csskit/pull/1419))
+- css_ast: Boxup rare nodes to reduce allocation size (#1421) ([#1421](https://github.com/csskit/csskit/pull/1421))
+- css_ast: Clean up & improve NodeWithMetadata derives, add value_kinds (#1422) ([#1422](https://github.com/csskit/csskit/pull/1422))
+- csskit_transform: implement ReduceCharsetRule (#1427) ([#1427](https://github.com/csskit/csskit/pull/1427))
+- css_ast: Add missing webkit pseudo elements (#1428) ([#1428](https://github.com/csskit/csskit/pull/1428))
+- css_ast: Implement InitialLetterAlignStyleValue (#1429) ([#1429](https://github.com/csskit/csskit/pull/1429))
+- css_ast: Allow prelude-less `@layer` (#1434) ([#1434](https://github.com/csskit/csskit/pull/1434))
+
+
+### Css_lexer
+- css_lexer/css_parse: Ensure parsed whitespace survives minification (#1420) ([#1420](https://github.com/csskit/csskit/pull/1420))
+
+
+### Csskit
+- chore(deps): update dependencies (patch) (#1407) ([#1407](https://github.com/csskit/csskit/pull/1407))
+
+
+### Csskit_arena
+- csskit_arena: Reuse reservations across arenas (#1430) ([#1430](https://github.com/csskit/csskit/pull/1430))
+- csskit_arena: Clean up and consolidate allocation modes (#1431) ([#1431](https://github.com/csskit/csskit/pull/1431))
+- csskit_arena: Add a detailed readme (#1433) ([#1433](https://github.com/csskit/csskit/pull/1433))
+
+
+### Csskit_transform
+- coverage: update css-minify-tests (#1423) ([#1423](https://github.com/csskit/csskit/pull/1423))
+- csskit_transform: skip subtrees which don't match metadata (#1424) ([#1424](https://github.com/csskit/csskit/pull/1424))
+
+
+### Csskit_vscode
+- chore(deps): update dependency mocha to v11.8.0 (#1410) ([#1410](https://github.com/csskit/csskit/pull/1410))
+- chore(deps): update dependency oxlint to v1.76.0 (#1411) ([#1411](https://github.com/csskit/csskit/pull/1411))
+- chore(deps): update dependency oxlint to v1.78.0 (#1413) ([#1413](https://github.com/csskit/csskit/pull/1413))
+
+
+### Derive_atom_set
+- derive_atom_set: Don't case fold on punctuation. (#1426) ([#1426](https://github.com/csskit/csskit/pull/1426))
+- derive_atom_set: Expand readme with more detail (#1432) ([#1432](https://github.com/csskit/csskit/pull/1432))
+
 ## [0.0.29] - 2026-08-14
 
 ### Other Changes
@@ -86,6 +127,7 @@
 - chore(deps): update dependencies (patch) (#1312) ([#1312](https://github.com/csskit/csskit/pull/1312))
 - csskit-wasm: Fix wasm-opt errors (#1330) ([#1330](https://github.com/csskit/csskit/pull/1330))
 - csskit: Clean up imports with preludes (#1366) ([#1366](https://github.com/csskit/csskit/pull/1366))
+- Release v0.0.29 (#1314) ([#1314](https://github.com/csskit/csskit/pull/1314))
 
 
 ### Csskit_arena

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/*"]
 exclude = ["packages/csskit_zed"]
 
 [workspace.package]
-version = "0.0.29"
+version = "0.0.30"
 authors = ["Keith Cirkel (https://keithcirkel.co.uk)"]
 edition = "2024"
 description = "Refreshing CSS!"
@@ -15,29 +15,28 @@ license = "MIT"
 keywords = ["CSS", "parser"]
 
 [workspace.dependencies]
-chromashift = { path = "crates/chromashift", version = "0.0.29" }
-css_ast = { path = "crates/css_ast", version = "0.0.29" }
-css_feature_data = { path = "crates/css_feature_data", version = "0.0.29" }
-css_lexer = { path = "crates/css_lexer", version = "0.0.29" }
-css_parse = { path = "crates/css_parse", version = "0.0.29" }
-css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.29" }
-source_tools = { path = "crates/source_tools", version = "0.0.29" }
-# Local packages
-csskit = { path = "crates/csskit", version = "0.0.29" }
-csskit_arena = { path = "crates/csskit_arena", version = "0.0.29" }
-csskit_ast = { path = "crates/csskit_ast", version = "0.0.29" }
-csskit_derives = { path = "crates/csskit_derives", version = "0.0.29" }
-csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.29" }
-csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.29" }
-csskit_napi = { path = "crates/csskit_napi", version = "0.0.29" }
-csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.29" }
-csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.29" }
+chromashift = { path = "crates/chromashift", version = "0.0.30" }
+css_ast = { path = "crates/css_ast", version = "0.0.30" }
+css_feature_data = { path = "crates/css_feature_data", version = "0.0.30" }
+css_lexer = { path = "crates/css_lexer", version = "0.0.30" }
+css_parse = { path = "crates/css_parse", version = "0.0.30" }
+css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.30" }
+csskit = { path = "crates/csskit", version = "0.0.30" }
+csskit_arena = { path = "crates/csskit_arena", version = "0.0.30" }
+csskit_ast = { path = "crates/csskit_ast", version = "0.0.30" }
+csskit_derives = { path = "crates/csskit_derives", version = "0.0.30" }
+csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.30" }
+csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.30" }
+csskit_napi = { path = "crates/csskit_napi", version = "0.0.30" }
+csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.30" }
+csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.30" }
 csskit_spec_generator = { path = "tools/csskit_spec_generator", version = "0.0.0" }
-csskit_transform = { path = "crates/csskit_transform", version = "0.0.29" }
-derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.29" }
-stable_type_layout = { package = "stable-type-layout", path = "crates/stable_type_layout", version = "0.0.29" }
-stable_type_layout_derive = { package = "stable-type-layout-derive", path = "crates/stable_type_layout_derive", version = "0.0.29" }
-visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.29" }
+csskit_transform = { path = "crates/csskit_transform", version = "0.0.30" }
+derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.30" }
+source_tools = { path = "crates/source_tools", version = "0.0.30" }
+stable_type_layout = { package = "stable-type-layout", path = "crates/stable_type_layout", version = "0.0.30" }
+stable_type_layout_derive = { package = "stable-type-layout-derive", path = "crates/stable_type_layout_derive", version = "0.0.30" }
+visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.30" }
 
 # Memory
 allocator-api2 = { version = "0.4.0" }

--- a/packages/csskit-darwin-arm64/package.json
+++ b/packages/csskit-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-arm64",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Refreshing CSS - macOS arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-darwin-x64/package.json
+++ b/packages/csskit-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-x64",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Refreshing CSS - macOS x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-arm64/package.json
+++ b/packages/csskit-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-arm64",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Refreshing CSS - Linux arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-x64/package.json
+++ b/packages/csskit-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-x64",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Refreshing CSS - Linux x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-arm64/package.json
+++ b/packages/csskit-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-arm64",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Refreshing CSS - Windows arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-x64/package.json
+++ b/packages/csskit-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-x64",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Refreshing CSS - Windows x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit/package-lock.json
+++ b/packages/csskit/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "csskit",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "csskit",
-            "version": "0.0.29",
+            "version": "0.0.30",
             "license": "MIT",
             "dependencies": {
                 "csskit-darwin-arm64": "^0.0.29",

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit",
-    "version": "0.0.29",
+    "version": "0.0.30",
     "description": "Refreshing CSS",
     "keywords": [],
     "repository": "https://github.com/csskit/csskit",
@@ -51,11 +51,11 @@
         "./bundle"
     ],
     "optionalDependencies": {
-        "csskit-darwin-arm64": "0.0.29",
-        "csskit-darwin-x64": "0.0.29",
-        "csskit-linux-arm64": "0.0.29",
-        "csskit-linux-x64": "0.0.29",
-        "csskit-win32-arm64": "0.0.29",
-        "csskit-win32-x64": "0.0.29"
+        "csskit-darwin-arm64": "0.0.30",
+        "csskit-darwin-x64": "0.0.30",
+        "csskit-linux-arm64": "0.0.30",
+        "csskit-linux-x64": "0.0.30",
+        "csskit-win32-arm64": "0.0.30",
+        "csskit-win32-x64": "0.0.30"
     }
 }


### PR DESCRIPTION
## [0.0.30] - 2026-08-22

### Css_ast
- css_ast: Allow symbolic-counter-style in content syntax (#1419) ([#1419](https://github.com/csskit/csskit/pull/1419))
- css_ast: Boxup rare nodes to reduce allocation size (#1421) ([#1421](https://github.com/csskit/csskit/pull/1421))
- css_ast: Clean up & improve NodeWithMetadata derives, add value_kinds (#1422) ([#1422](https://github.com/csskit/csskit/pull/1422))
- csskit_transform: implement ReduceCharsetRule (#1427) ([#1427](https://github.com/csskit/csskit/pull/1427))
- css_ast: Add missing webkit pseudo elements (#1428) ([#1428](https://github.com/csskit/csskit/pull/1428))
- css_ast: Implement InitialLetterAlignStyleValue (#1429) ([#1429](https://github.com/csskit/csskit/pull/1429))
- css_ast: Allow prelude-less `@layer` (#1434) ([#1434](https://github.com/csskit/csskit/pull/1434))


### Css_lexer
- css_lexer/css_parse: Ensure parsed whitespace survives minification (#1420) ([#1420](https://github.com/csskit/csskit/pull/1420))


### Csskit
- chore(deps): update dependencies (patch) (#1407) ([#1407](https://github.com/csskit/csskit/pull/1407))


### Csskit_arena
- csskit_arena: Reuse reservations across arenas (#1430) ([#1430](https://github.com/csskit/csskit/pull/1430))
- csskit_arena: Clean up and consolidate allocation modes (#1431) ([#1431](https://github.com/csskit/csskit/pull/1431))
- csskit_arena: Add a detailed readme (#1433) ([#1433](https://github.com/csskit/csskit/pull/1433))


### Csskit_transform
- coverage: update css-minify-tests (#1423) ([#1423](https://github.com/csskit/csskit/pull/1423))
- csskit_transform: skip subtrees which don't match metadata (#1424) ([#1424](https://github.com/csskit/csskit/pull/1424))


### Csskit_vscode
- chore(deps): update dependency mocha to v11.8.0 (#1410) ([#1410](https://github.com/csskit/csskit/pull/1410))
- chore(deps): update dependency oxlint to v1.76.0 (#1411) ([#1411](https://github.com/csskit/csskit/pull/1411))
- chore(deps): update dependency oxlint to v1.78.0 (#1413) ([#1413](https://github.com/csskit/csskit/pull/1413))


### Derive_atom_set
- derive_atom_set: Don't case fold on punctuation. (#1426) ([#1426](https://github.com/csskit/csskit/pull/1426))
- derive_atom_set: Expand readme with more detail (#1432) ([#1432](https://github.com/csskit/csskit/pull/1432))