### PR TITLE
css_lexer/css_parse: Ensure parsed whitespace survives minification

### DIFF
--- a/coverage/basic/vars.min.css
+++ b/coverage/basic/vars.min.css
@@ -1,1 +1,1 @@
-hr{background:linear-gradient(to right,transparent,var(--border-color)20%,var(--border-color)80%,transparent)}
+hr{background:linear-gradient(to right,transparent,var(--border-color) 20%,var(--border-color) 80%,transparent)}

--- a/crates/css_lexer/src/cursor.rs
+++ b/crates/css_lexer/src/cursor.rs
@@ -97,6 +97,21 @@ impl Cursor {
 		Self::new(self.offset(), self.token().with_sign_required())
 	}
 
+	/// Returns a new [Cursor] with the `whitespace_is_significant` flag set to `significant` on the token.
+	/// This indicates that the whitespace must be preserved during minification.
+	pub fn with_significant_whitespace(&self, significant: bool) -> Self {
+		debug_assert!(self.1 == Kind::Whitespace);
+		if self.1.whitespace_is_significant() == significant {
+			return *self;
+		}
+		Self::new(self.offset(), self.token().with_significant_whitespace(significant))
+	}
+
+	#[inline]
+	pub fn whitespace_is_significant(&self) -> bool {
+		self.1.whitespace_is_significant()
+	}
+
 	#[inline]
 	pub fn atom_bits(&self) -> u32 {
 		self.1.atom_bits()

--- a/crates/css_lexer/src/source_cursor.rs
+++ b/crates/css_lexer/src/source_cursor.rs
@@ -129,6 +129,16 @@ impl<'a> SourceCursor<'a> {
 		}
 	}
 
+	pub fn with_significant_whitespace(&self, significant: bool) -> Self {
+		Self {
+			cursor: self.cursor.with_significant_whitespace(significant),
+			source: self.source,
+			should_compact: self.should_compact,
+			#[cfg(feature = "egg")]
+			should_expand: self.should_expand,
+		}
+	}
+
 	/// Returns a new `SourceCursor` with the `should_compact` flag set.
 	///
 	/// With the `should_compact` flag set, the cursor will format with optimised displays of:

--- a/crates/css_lexer/src/token.rs
+++ b/crates/css_lexer/src/token.rs
@@ -813,6 +813,27 @@ impl Token {
 		}
 	}
 
+	/// If the [Token] is a [Kind::Whitespace] then this returns true if that whitespace is significant; i.e. it must be
+	/// preserved during minification. Descendant combinators (`a b`) and the space in `@charset "utf-8";` are examples
+	/// of this.
+	///
+	/// If the [Token] is not a [Kind::Whitespace] this will return `false`.
+	#[inline]
+	pub const fn whitespace_is_significant(&self) -> bool {
+		self.kind_bits() == Kind::Whitespace as u8 && self.0 & 1 == 1
+	}
+
+	/// Returns a new [Token] with the `whitespace_is_significant` flag set.
+	///
+	/// If the [Token] is not a [Kind::Whitespace] this will return the same [Token].
+	#[inline]
+	pub const fn with_significant_whitespace(&self, significant: bool) -> Token {
+		if self.kind_bits() != Kind::Whitespace as u8 {
+			return *self;
+		}
+		if significant { Token(self.0 | 1, self.1) } else { Token(self.0 & !1, self.1) }
+	}
+
 	/// Returns the [AssociatedWhitespaceRules].
 	///
 	/// If the [Kind] is not "Delim Like" (i.e. it is not [Kind::Delim], [Kind::Colon], [Kind::Semicolon], [Kind::Comma],
@@ -1199,7 +1220,13 @@ impl core::fmt::Debug for Token {
 				.field("end", &format_args!("U+{:X}", self.unicode_range_end()))
 				.field("len", &self.len()),
 			Kind::CdcOrCdo => d.field("is_cdc", &self.first_flag()).field("len", &self.len()),
-			Kind::Whitespace => d.field("contains", &self.whitespace_style()).field("len", &self.len()),
+			Kind::Whitespace => {
+				d.field("contains", &self.whitespace_style());
+				if self.whitespace_is_significant() {
+					d.field("significant", &true);
+				}
+				d.field("len", &self.len())
+			}
 			_ => d
 				.field("flag_0", &self.first_flag())
 				.field("flag_1", &self.second_flag())
@@ -1426,6 +1453,26 @@ fn test_with_quotes() {
 		Token::new_string(QuoteStyle::Double, true, true, 8).with_quotes(QuoteStyle::Single),
 		Token::new_string(QuoteStyle::Single, true, true, 8),
 	);
+}
+
+#[test]
+fn test_with_significant_whitespace() {
+	for len in [1, 3, 4, 255, 256, 0xFF_FFFF, u32::MAX] {
+		for style in [Whitespace::Space, Whitespace::Tab, Whitespace::Space | Whitespace::Newline] {
+			let token = Token::new_whitespace(style, len);
+			let significant = token.with_significant_whitespace(true);
+			assert!(!token.whitespace_is_significant());
+			assert!(significant.whitespace_is_significant());
+			assert_eq!(token.len(), len);
+			assert_eq!(significant.len(), len);
+			assert_eq!(significant.whitespace_style(), style);
+			assert_eq!(significant.kind(), Kind::Whitespace);
+			assert_eq!(significant.with_significant_whitespace(false), token);
+		}
+	}
+	let ident = Token::new_interned(Kind::Ident, 1, 3);
+	assert_eq!(ident.with_significant_whitespace(true), ident);
+	assert!(!ident.whitespace_is_significant());
 }
 
 #[test]

--- a/crates/css_parse/src/cursor_compact_write_sink.rs
+++ b/crates/css_parse/src/cursor_compact_write_sink.rs
@@ -18,13 +18,30 @@ pub struct CursorCompactWriteSink<'a, T: SourceCursorSink<'a>> {
 const PENDING_KINDSET: KindSet = KindSet::new(&[Kind::Semicolon, Kind::Whitespace]);
 // `;` is redundant immediately before/after these.
 const REDUNDANT_SEMI_KINDSET: KindSet = KindSet::new(&[Kind::Semicolon, Kind::RightCurly]);
-// Whitespace immediately before these tokens can always be removed (overrides any
-// `AssociatedWhitespaceRules::EnforceBefore` annotations carried from the source).
-const NO_WHITESPACE_BEFORE_KINDSET: KindSet =
-	KindSet::new(&[Kind::Whitespace, Kind::Colon, Kind::Delim, Kind::LeftCurly, Kind::RightCurly, Kind::Eof]);
-// Whitespace immediately after these tokens can always be removed.
-const NO_WHITESPACE_AFTER_KINDSET: KindSet =
-	KindSet::new(&[Kind::Comma, Kind::RightParen, Kind::RightCurly, Kind::LeftCurly, Kind::Colon]);
+// Whitespace immediately before these tokens is never meaningful in any CSS grammar, so it can always be removed -
+// even when the parser marked it significant. `:` is absent because `.a :hover` is not `.a:hover`, and `)`/`]` only
+// appear here as the *closing* token of a block, where `foo( a )` is always `foo(a)`.
+const NO_WHITESPACE_BEFORE_KINDSET: KindSet = KindSet::new(&[
+	Kind::Whitespace,
+	Kind::Comma,
+	Kind::Semicolon,
+	Kind::LeftCurly,
+	Kind::RightCurly,
+	Kind::RightParen,
+	Kind::RightSquare,
+	Kind::Eof,
+]);
+// Whitespace immediately after these tokens is never meaningful. `)`/`]` are absent because `:is(a) b` and `[x] b`
+// require a space, therefore we cannot reliable elide them.
+const NO_WHITESPACE_AFTER_KINDSET: KindSet = KindSet::new(&[
+	Kind::Comma,
+	Kind::Semicolon,
+	Kind::Colon,
+	Kind::LeftCurly,
+	Kind::RightCurly,
+	Kind::LeftParen,
+	Kind::LeftSquare,
+]);
 
 impl<'a, T: SourceCursorSink<'a>> CursorCompactWriteSink<'a, T> {
 	pub fn new(source_text: &'a str, sink: T) -> Self {
@@ -70,16 +87,14 @@ impl<'a, T: SourceCursorSink<'a>> CursorCompactWriteSink<'a, T> {
 
 		let enforce_before = c.token() == AssociatedWhitespaceRules::EnforceBefore;
 		let suppress_separator = self.last_forbids_ws_after() && !enforce_before;
+		let significant_pending_whitespace = self.pending.is_some_and(|p| p.token().whitespace_is_significant());
 		if let Some(prev) = self.pending.take() {
 			let keep = match prev.token().kind() {
 				Kind::Semicolon => {
 					c != REDUNDANT_SEMI_KINDSET && self.last_token.is_some_and(|t| t != REDUNDANT_SEMI_KINDSET)
 				}
-				_ => {
-					!suppress_separator
-						&& (enforce_before || c != NO_WHITESPACE_BEFORE_KINDSET)
-						&& self.needs_separator(c.token())
-				}
+				_ if suppress_separator || (!enforce_before && c == NO_WHITESPACE_BEFORE_KINDSET) => false,
+				_ => (significant_pending_whitespace && self.last_token.is_some()) || self.needs_separator(c.token()),
 			};
 			if keep {
 				self.emit(prev.compact());
@@ -87,7 +102,12 @@ impl<'a, T: SourceCursorSink<'a>> CursorCompactWriteSink<'a, T> {
 		}
 
 		if c == PENDING_KINDSET {
-			self.pending = Some(c);
+			// Adjacent whitespace tokens collapse into one, which stays significant if either part was.
+			self.pending = Some(if significant_pending_whitespace && c == Kind::Whitespace {
+				c.with_significant_whitespace(true)
+			} else {
+				c
+			});
 			return;
 		}
 		if c == Kind::Eof {
@@ -180,6 +200,7 @@ mod test {
 		"#,
 			"body > div{bar:baz}"
 		);
+		assert_format!(".a   .b", ".a .b");
 	}
 
 	#[test]
@@ -194,9 +215,10 @@ mod test {
 	}
 
 	#[test]
-	fn test_removes_whitespace_after_right_paren() {
-		assert_format!("foo() bar", "foo()bar");
-		assert_format!("rgb(0, 0, 0) solid", "rgb(0,0,0)solid");
+	fn test_keeps_whitespace_after_right_paren_and_square() {
+		assert_format!("foo() bar", "foo() bar");
+		assert_format!("rgb(0, 0, 0) solid", "rgb(0,0,0) solid");
+		assert_format!("[x] bar", "[x] bar");
 	}
 
 	#[test]
@@ -283,7 +305,7 @@ mod test {
 		);
 		assert_format!(
 			"@media (prefers-reduced-motion:no-preference){:root{}}",
-			"@media(prefers-reduced-motion:no-preference){:root{}}"
+			"@media (prefers-reduced-motion:no-preference){:root{}}"
 		);
 		assert_format!("@media(min-width:576px){}", "@media(min-width:576px){}");
 	}

--- a/crates/css_parse/src/cursor_interleave_sink.rs
+++ b/crates/css_parse/src/cursor_interleave_sink.rs
@@ -38,7 +38,7 @@ impl<'a, S: CursorSink> CursorSink for CursorInterleaveSink<'a, S> {
 		// Check if this content cursor has associated trivia
 		while self.current_index < self.interleave.len() {
 			let (trivia, associated_cursor) = &self.interleave[self.current_index];
-			if *associated_cursor == c {
+			if associated_cursor.offset() == c.offset() && associated_cursor.token().kind() == c.token().kind() {
 				for cursor in trivia {
 					self.sink.append(*cursor);
 				}

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -23,6 +23,7 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
 	{
 		let mut values = Vec::new_in(p.alloc());
 		let mut last_was_whitespace = false;
+		let mut trailing_whitespace = None;
 
 		loop {
 			if p.at_end() {
@@ -39,10 +40,34 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
 					let rules = d.associated_whitespace() | AssociatedWhitespaceRules::EnforceBefore;
 					value = ComponentValue::Delim(d.with_associated_whitespace(rules))
 				}
-				last_was_whitespace = matches!(value, ComponentValue::Whitespace(_));
+				// Whitespace at either edge of the list separates nothing - CSS discards it when consuming a
+				// declaration value or an at-rule prelude - so it is trivia and a minifier can remove it.
+				// Whitespace between two values is grammar (`foo(.a .b)` is not `foo(.a.b)`) and stays significant.
+				last_was_whitespace = match value {
+					ComponentValue::Whitespace(ws) => {
+						if values.is_empty() {
+							value = ComponentValue::Whitespace(ws.with_significant_whitespace(false));
+						} else if trailing_whitespace.is_none() {
+							trailing_whitespace = Some(values.len());
+						}
+						true
+					}
+					_ => {
+						trailing_whitespace = None;
+						false
+					}
+				};
 				values.push(value);
 			} else {
 				break;
+			}
+		}
+
+		if let Some(index) = trailing_whitespace {
+			for value in &mut values[index..] {
+				if let ComponentValue::Whitespace(ws) = value {
+					*value = ComponentValue::Whitespace(ws.with_significant_whitespace(false));
+				}
 			}
 		}
 		Ok(Self { values })

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -464,6 +464,17 @@ define_kind_idents! {
 pub struct Whitespace(Cursor);
 cursor_wrapped!(Whitespace);
 
+impl Whitespace {
+	/// Returns a new [Whitespace] with the significance flag set to `significant`.
+	///
+	/// Whitespace parsed with [Parse] is significant by default: a [Whitespace] in an AST node carries meaning
+	/// (a descendant combinator, or the space in `@charset "utf-8";`) and minifiers must keep it. Set this to
+	/// `false` for whitespace kept only as trivia, which a minifier is free to remove.
+	pub fn with_significant_whitespace(&self, significant: bool) -> Self {
+		Self(self.0.with_significant_whitespace(significant))
+	}
+}
+
 impl<'a> Peek<'a> for Whitespace {
 	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Whitespace]);
 
@@ -490,7 +501,7 @@ impl<'a> Parse<'a> for Whitespace {
 		if c != Kind::Whitespace {
 			Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
 		}
-		Ok(Self(c))
+		Ok(Self(c.with_significant_whitespace(true)))
 	}
 }
 

--- a/crates/csskit_transform/src/css_minifier.rs
+++ b/crates/csskit_transform/src/css_minifier.rs
@@ -78,4 +78,45 @@ mod tests {
 		let (_, changed) = minify(input, CssMinifierFeature::all_bits());
 		assert!(!changed, "Should report no changes when no optimizations apply");
 	}
+
+	#[test]
+	fn test_keeps_significant_whitespace() {
+		for input in [
+			"@charset \"utf-8\";",
+			":is(a) b{color:red}",
+			"[x] d{color:red}",
+			"* e{color:red}",
+			"a:not(.x) f{color:red}",
+			"a.b c{color:red}",
+			".a :hover{color:red}",
+			"@supports foo(.a .b){a{color:red}}",
+		] {
+			let (output, _) = minify(input, CssMinifierFeature::none());
+			assert_eq!(output, input);
+		}
+	}
+
+	#[test]
+	fn test_compacts_significant_whitespace() {
+		for (input, expected) in
+			[(".a   .b{color:red}", ".a .b{color:red}"), ("a{--custom:.a\n\t.b}", "a{--custom:.a .b}")]
+		{
+			let (output, _) = minify(input, CssMinifierFeature::none());
+			assert_eq!(output, expected);
+		}
+	}
+
+	#[test]
+	fn test_removes_trivia_whitespace() {
+		for (input, expected) in [
+			("a  ,  b {color: red}", "a,b{color:red}"),
+			("a{color: rgb(255, 128, 0)}", "a{color:rgb(255,128,0)}"),
+			("a{margin:  0   0 }", "a{margin:0 0}"),
+			("a{color:red}\n\nb{color:blue}", "a{color:red}b{color:blue}"),
+			("@media screen {\n\ta {\n\t\tcolor: red;\n\t}\n}", "@media screen{a{color:red}}"),
+		] {
+			let (output, _) = minify(input, CssMinifierFeature::none());
+			assert_eq!(output, expected);
+		}
+	}
 }

--- a/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
+++ b/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
@@ -18,11 +18,11 @@ FAIL anchor/0004
 -@position-try --empty{}
 
 FAIL charset/0001
--@charset"UTF-8";a{color:red}
+-@charset "UTF-8";a{color:red}
 +a{color:red}
 
 FAIL charset/0002
--@charset"ISO-8859-1";@charset"ISO-8859-15";a{color:red}
+-@charset "ISO-8859-1";@charset "ISO-8859-15";a{color:red}
 +@charset "ISO-8859-1";a{color:red}
 
 FAIL colors/0031
@@ -96,7 +96,7 @@ FAIL duplicates/0008
 +a{transform:rotate(45deg)}
 
 FAIL duplicates/0009
--.nav.item,.footer,.nav.item{color:red}
+-.nav .item,.footer,.nav .item{color:red}
 +.nav .item,.footer{color:red}
 
 FAIL duplicates/0010
@@ -104,7 +104,7 @@ FAIL duplicates/0010
 +h1,h2{color:red}
 
 FAIL duplicates/0011
--.foo.bar{color:red}.foo{.bar{color:red}}
+-.foo .bar{color:red}.foo{.bar{color:red}}
 +.foo .bar{color:red}
 
 FAIL duplicates/0012
@@ -112,7 +112,7 @@ FAIL duplicates/0012
 +a{color:red;font-size:1rem}
 
 FAIL duplicates/0013
--a{--color:blue;--color:red!important}
+-a{--color:blue;--color:red !important}
 +a{--color:red !important}
 
 FAIL duplicates/0014
@@ -180,7 +180,7 @@ FAIL gradients/0005
 +a{background:radial-gradient(red,#00f)}
 
 FAIL import/0005
--@import url("foo.css")layer(base)supports(foo:bar);
+-@import url("foo.css") layer(base) supports(foo:bar);
 +@import"foo.css"layer(base)supports(foo:bar);
 
 FAIL keyframes/0001
@@ -305,10 +305,6 @@ FAIL nesting/0019
 
 FAIL page/0003
 -@page{}
-
-FAIL scope/0002
--@scope(.card)to (.card.content){a{color:red}}
-+@scope(.card)to (.card .content){a{color:red}}
 
 FAIL scope/0003
 -@scope(.card){}


### PR DESCRIPTION
For rules like `.a .b`, and `@charset "utf-8"`, the whitespace is an
integral part of the syntax and CursorCompactWriteSink erroneously removes it,
causing broken CSS (either unparseable or semantically different).

This change introduces the concept of "significant whitespace" by stealing
a bit in Whitespace's `length` bits. This allows us to determine if a whitespace
token must be preserved through minification. CursorCompactWriteSink has also
been refactored to make use of this

Fixes https://github.com/csskit/csskit/issues/1402
