### PR TITLE
csskit_arena: Reuse reservations across arenas

### DIFF
--- a/crates/csskit_arena/src/lib.rs
+++ b/crates/csskit_arena/src/lib.rs
@@ -30,6 +30,7 @@ use std::alloc::Layout;
 use std::cell::Cell;
 use std::ptr::NonNull;
 
+mod pool;
 mod vm;
 
 /// Required alignment of the arena region (4 GiB), so that `ptr as u32` equals the byte offset
@@ -55,8 +56,9 @@ const CHUNK_ALIGN: usize = 16;
 #[derive(Clone, Copy)]
 enum Backing {
 	/// Address space reserved by this crate. `reservation` and `reserved` are the base and length of the whole
-	/// reservation, both of which are needed to release it.
-	Owned { reservation: NonNull<u8>, reserved: usize },
+	/// reservation, both of which are needed to release it, and `size` is the usable region at the chunk's base,
+	/// which is what the pool keeps it under.
+	Owned { reservation: NonNull<u8>, reserved: usize, size: usize },
 	/// A block from the global allocator, for targets that cannot reserve address space lazily.
 	Heap(Layout),
 	/// Memory owned by the caller (e.g. a V8 `ArrayBuffer`). Never freed by the arena.
@@ -67,6 +69,8 @@ enum Backing {
 struct Chunk {
 	base: NonNull<u8>,
 	size: usize,
+	/// High-water mark of bytes handed out from the chunk, which is how much of it is resident.
+	used: usize,
 	backing: Backing,
 	prev: Option<NonNull<Chunk>>,
 }
@@ -82,6 +86,9 @@ pub struct Arena {
 	size: Cell<usize>,
 	/// Bump cursor: byte offset of the next free position within the chunk.
 	cursor: Cell<usize>,
+	/// High-water mark of [`Arena::cursor`] for this chunk. A reset rewinds the cursor but not the pages behind it, so
+	/// this and not the cursor is how much of the chunk is resident.
+	resident: Cell<usize>,
 	/// Bytes of the chunk backed by physical memory. Windows has no lazy commit, so the arena commits as it bumps.
 	#[cfg(windows)]
 	committed: Cell<usize>,
@@ -137,13 +144,18 @@ impl Arena {
 	/// Take `size` usable bytes for a chunk: reserved address space where the target has it, a block from the global
 	/// allocator otherwise.
 	fn new_chunk(size: usize) -> Option<(NonNull<u8>, Backing)> {
-		vm::reserve(size)
+		pool::take(size)
+			.or_else(|| vm::reserve(size))
 			.map(|reservation| {
 				debug_assert!(
 					(reservation.base.as_ptr() as usize).is_multiple_of(BLOCK_ALIGN),
 					"arena base must be 4 GiB aligned"
 				);
-				let backing = Backing::Owned { reservation: reservation.reservation, reserved: reservation.reserved };
+				let backing = Backing::Owned {
+					reservation: reservation.reservation,
+					reserved: reservation.reserved,
+					size: reservation.size,
+				};
 				(reservation.base, backing)
 			})
 			.or_else(|| Self::heap_chunk(size, CHUNK_ALIGN))
@@ -165,6 +177,7 @@ impl Arena {
 			base: Cell::new(base),
 			size: Cell::new(size),
 			cursor: Cell::new(0),
+			resident: Cell::new(0),
 			#[cfg(windows)]
 			committed: Cell::new(if matches!(backing, Backing::Owned { .. }) { 0 } else { size }),
 			backing: Cell::new(backing),
@@ -233,14 +246,17 @@ impl Arena {
 	///
 	/// Takes `&mut self` so no allocation can outlive the reset. The first chunk's memory is retained.
 	pub fn reset(&mut self) {
+		self.resident.set(self.resident_bytes());
+		self.cursor.set(0);
 		while let Some(node) = self.prev.get() {
 			// SAFETY: every chunk in the chain came from `Box::into_raw`, and `&mut self` proves nothing allocated from
 			// the chunk being dropped is still live.
 			let chunk = *unsafe { Box::from_raw(node.as_ptr()) };
 			// SAFETY: as above.
-			unsafe { release(self.base.get(), self.backing.replace(chunk.backing)) };
+			unsafe { release(self.base.get(), self.backing.replace(chunk.backing), self.resident.get()) };
 			self.base.set(chunk.base);
 			self.size.set(chunk.size);
+			self.resident.set(chunk.used);
 			self.prev.set(chunk.prev);
 			// Every chunk the arena added comes from the global allocator, so is backed in full.
 			#[cfg(windows)]
@@ -248,19 +264,32 @@ impl Arena {
 		}
 		self.prev_used.set(0);
 		self.prev_size.set(0);
-		self.cursor.set(0);
+	}
+
+	/// How many bytes of the chunk being bumped from have ever been handed out, and so how much of it is resident.
+	#[inline]
+	fn resident_bytes(&self) -> usize {
+		self.resident.get().max(self.cursor.get())
 	}
 }
 
-/// Give a chunk's memory back.
+/// Give a chunk's memory back to the thread's pool where it is reserved address space and the pool has room, and to the
+/// OS otherwise. `used` is how many bytes of the chunk were handed out.
 ///
 /// # Safety
 /// `base` and `backing` must be exactly what the chunk was built with, and nothing allocated from it may outlive the
 /// call.
-unsafe fn release(base: NonNull<u8>, backing: Backing) {
+unsafe fn release(base: NonNull<u8>, backing: Backing, used: usize) {
 	match backing {
-		// SAFETY: `reservation`/`reserved` are exactly what `vm::reserve` returned.
-		Backing::Owned { reservation, reserved } => unsafe { vm::release(reservation, reserved) },
+		Backing::Owned { reservation, reserved, size } => {
+			let kept = vm::Reservation { reservation, reserved, base, size };
+			// SAFETY: the caller guarantees nothing allocated from the chunk is live.
+			if unsafe { pool::give(kept, used) } {
+				return;
+			}
+			// SAFETY: `reservation`/`reserved` are exactly what `vm::reserve` returned.
+			unsafe { vm::release(reservation, reserved) };
+		}
 		// SAFETY: `base`/`layout` are exactly what the global allocator was asked for.
 		Backing::Heap(layout) => unsafe { std::alloc::dealloc(base.as_ptr(), layout) },
 		Backing::Borrowed => {}
@@ -324,6 +353,7 @@ impl Arena {
 		let retired = Chunk {
 			base: self.base.get(),
 			size: self.size.get(),
+			used: self.resident_bytes(),
 			backing: self.backing.replace(backing),
 			prev: self.prev.get(),
 		};
@@ -334,6 +364,7 @@ impl Arena {
 		self.base.set(base);
 		self.size.set(size);
 		self.cursor.set(0);
+		self.resident.set(0);
 		// A chunk from the global allocator is backed in full.
 		#[cfg(windows)]
 		self.committed.set(size);
@@ -406,14 +437,14 @@ impl Default for Arena {
 impl Drop for Arena {
 	fn drop(&mut self) {
 		// SAFETY: `&mut self` proves every allocation is dead.
-		unsafe { release(self.base.get(), self.backing.get()) };
+		unsafe { release(self.base.get(), self.backing.get(), self.resident_bytes()) };
 		let mut node = self.prev.get();
 		while let Some(chunk) = node {
 			// SAFETY: every chunk in the chain came from `Box::into_raw` and has not been freed.
 			let chunk = *unsafe { Box::from_raw(chunk.as_ptr()) };
 			node = chunk.prev;
 			// SAFETY: as above; every allocation from the chunk is dead.
-			unsafe { release(chunk.base, chunk.backing) };
+			unsafe { release(chunk.base, chunk.backing, chunk.used) };
 		}
 	}
 }

--- a/crates/csskit_arena/src/pool.rs
+++ b/crates/csskit_arena/src/pool.rs
@@ -1,0 +1,190 @@
+//! A thread-local cache of arena reservations.
+//!
+//! Reserving address space is not free. A process that parses one document never notices, but a server or a CLI that
+//! parses thousands pays it thousands of times, which is what makes a short-lived [`Arena`][crate::Arena] cost more
+//! than the parse it serves.
+//!
+//! So a reservation is not given back to the OS when its arena is dropped: it is kept here, on the thread that made
+//! it, and the next arena of the same size takes it. Nothing is shared between threads, thus no lock is needed, and
+//! the pages stay resident, thus the next parse writes to memory it has already faulted in.
+//!
+//! A thread keeps at most [`CAPACITY`] reservations, and hands the pages of anything bigger than [`KEEP`] straight
+//! back, so a thread that once parsed a huge document does not hold its memory for the life of the process.
+
+use crate::vm::{self, Reservation};
+use std::cell::RefCell;
+use std::ptr::NonNull;
+
+/// How many reservations one thread keeps.
+const CAPACITY: usize = 4;
+
+/// How many bytes of a returned reservation stay resident. Beyond this the pages go back to the OS.
+const KEEP: usize = 4 * 1024 * 1024;
+
+/// The reservations this thread is holding. Dropping it hands them all back, so a thread that ends does not leak
+/// what it kept.
+struct Cache(Vec<Reservation>);
+
+impl Drop for Cache {
+	fn drop(&mut self) {
+		for reservation in self.0.drain(..) {
+			// SAFETY: a reservation in the cache belongs to no arena, thus nothing is allocated from it.
+			unsafe { vm::release(reservation.reservation, reservation.reserved) };
+		}
+	}
+}
+
+thread_local! {
+	static FREE: RefCell<Cache> = const { RefCell::new(Cache(Vec::new())) };
+}
+
+/// A reservation of exactly `size` usable bytes, if this thread is holding one.
+pub(crate) fn take(size: usize) -> Option<Reservation> {
+	FREE.try_with(|free| {
+		let mut free = free.try_borrow_mut().ok()?;
+		let found = free.0.iter().position(|reservation| reservation.size == size)?;
+		Some(free.0.swap_remove(found))
+	})
+	.ok()
+	.flatten()
+}
+
+/// Keep `reservation` for the next arena, and say whether it was kept. `used` is how many bytes of it were handed
+/// out, which is how much of it is resident.
+///
+/// # Safety
+/// Nothing allocated from the reservation may still be in use, and the caller must release the reservation itself
+/// where this gives back `false`.
+pub(crate) unsafe fn give(reservation: Reservation, used: usize) -> bool {
+	FREE.try_with(|free| {
+		let Ok(mut free) = free.try_borrow_mut() else {
+			return false;
+		};
+		if free.0.len() >= CAPACITY {
+			return false;
+		}
+		if let Some(tail) = used.checked_sub(KEEP).filter(|tail| *tail > 0) {
+			// Only what a document of ordinary size would not have touched goes back: the first [`KEEP`] bytes stay
+			// resident, so the next parse writes to pages it already has, and one huge document does not leave its
+			// memory held for the life of the thread.
+			// SAFETY: the caller guarantees nothing allocated from the reservation is live, and `used` is within it.
+			let tail_base = unsafe { NonNull::new_unchecked(reservation.base.as_ptr().add(KEEP)) };
+			// SAFETY: as above.
+			unsafe { vm::discard(tail_base, tail) };
+		}
+		free.0.push(reservation);
+		true
+	})
+	.unwrap_or(false)
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::{Arena, MAX_BLOCK_SIZE};
+
+	fn isolated(test: impl FnOnce() + Send + 'static) {
+		std::thread::spawn(test).join().expect("the test thread panicked");
+	}
+
+	#[test]
+	fn an_arena_reuses_the_region_the_last_one_left() {
+		if !vm::RESERVABLE {
+			return;
+		}
+		isolated(|| {
+			let first = {
+				let arena = Arena::new();
+				arena.base_ptr()
+			};
+			let arena = Arena::new();
+			assert_eq!(arena.base_ptr(), first, "the second arena took the first one's reservation");
+			assert_eq!(arena.capacity(), MAX_BLOCK_SIZE);
+			assert_eq!(arena.used_bytes(), 0, "a reused arena starts empty");
+		});
+	}
+
+	#[test]
+	fn a_reused_region_still_allocates() {
+		if !vm::RESERVABLE {
+			return;
+		}
+		isolated(|| {
+			let written = {
+				let arena = Arena::new();
+				let mut vec = allocator_api2::vec::Vec::new_in(&arena);
+				vec.extend_from_slice(&[7u8; 4096]);
+				vec.iter().map(|byte| *byte as usize).sum::<usize>()
+			};
+			let arena = Arena::new();
+			let mut vec = allocator_api2::vec::Vec::new_in(&arena);
+			vec.extend_from_slice(&[9u8; 4096]);
+			assert_eq!(vec.iter().map(|byte| *byte as usize).sum::<usize>(), 4096 * 9);
+			assert_eq!(written, 4096 * 7);
+		});
+	}
+
+	#[test]
+	fn a_thread_keeps_no_more_than_the_cap() {
+		if !vm::RESERVABLE {
+			return;
+		}
+		isolated(|| {
+			let arenas: Vec<Arena> = (0..CAPACITY + 2).map(|_| Arena::new()).collect();
+			drop(arenas);
+			let kept = FREE.with(|free| free.borrow().0.len());
+			assert_eq!(kept, CAPACITY, "a thread keeps the cap and no more");
+		});
+	}
+
+	#[test]
+	fn a_size_the_pool_does_not_hold_is_reserved_fresh() {
+		if !vm::RESERVABLE {
+			return;
+		}
+		isolated(|| {
+			drop(Arena::new());
+			assert!(take(MAX_BLOCK_SIZE - 4096).is_none(), "only an exact size matches");
+			assert!(take(MAX_BLOCK_SIZE).is_some(), "the full size is the one that was kept");
+		});
+	}
+
+	#[test]
+	fn a_reset_does_not_hide_what_the_arena_touched() {
+		if !vm::RESERVABLE {
+			return;
+		}
+		isolated(|| {
+			let mut arena = Arena::new();
+			{
+				let mut vec = allocator_api2::vec::Vec::new_in(&arena);
+				vec.extend_from_slice(&[1u8; KEEP * 2]);
+				assert_eq!(vec.len(), KEEP * 2);
+			}
+			arena.reset();
+			assert_eq!(arena.used_bytes(), 0, "a reset rewinds the cursor");
+			assert!(arena.resident_bytes() >= KEEP * 2, "a reset does not un-touch the pages behind the cursor");
+		});
+	}
+
+	#[test]
+	fn a_region_whose_tail_was_discarded_still_allocates() {
+		if !vm::RESERVABLE {
+			return;
+		}
+		isolated(|| {
+			{
+				let arena = Arena::new();
+				let mut vec = allocator_api2::vec::Vec::new_in(&arena);
+				vec.extend_from_slice(&[3u8; KEEP * 2]);
+				assert_eq!(vec.len(), KEEP * 2);
+			}
+			assert_eq!(FREE.with(|free| free.borrow().0.len()), 1, "the reservation was kept");
+			let arena = Arena::new();
+			let mut vec = allocator_api2::vec::Vec::new_in(&arena);
+			vec.extend_from_slice(&[5u8; KEEP * 2]);
+			assert!(vec.iter().all(|byte| *byte == 5), "writes across the discarded boundary hold");
+			assert_eq!(vec.len(), KEEP * 2);
+		});
+	}
+}

--- a/crates/csskit_arena/src/vm.rs
+++ b/crates/csskit_arena/src/vm.rs
@@ -14,6 +14,7 @@ use std::ptr::NonNull;
 pub(crate) const RESERVABLE: bool = cfg!(all(target_pointer_width = "64", any(unix, windows)));
 
 /// A reserved region of address space, plus the 4 GiB-aligned window inside it that the arena allocates from.
+#[derive(Clone, Copy)]
 pub(crate) struct Reservation {
 	/// Start of the whole reservation, needed to hand the address space back.
 	pub(crate) reservation: NonNull<u8>,
@@ -21,6 +22,8 @@ pub(crate) struct Reservation {
 	pub(crate) reserved: usize,
 	/// The 4 GiB-aligned base of the usable region.
 	pub(crate) base: NonNull<u8>,
+	/// Usable bytes at [`Reservation::base`], which is what was asked for.
+	pub(crate) size: usize,
 }
 
 /// Only the reserving implementations round anything up.
@@ -81,7 +84,26 @@ mod imp {
 		}
 		// SAFETY: `mmap` succeeded, so `aligned` is a live, non-null address within the mapping.
 		let base = unsafe { NonNull::new_unchecked(aligned as *mut u8) };
-		Some(Reservation { reservation: base, reserved: len, base })
+		// `size` is what was asked for, and so what the pool keeps the reservation under; `len` is the page-rounded
+		// mapping, which is what `munmap` needs.
+		Some(Reservation { reservation: base, reserved: len, base, size })
+	}
+
+	/// Tell the kernel the first `len` bytes at `base` hold nothing worth keeping.
+	///
+	/// The pages stay mapped and stay usable, so the next write to one costs no fault, but the kernel may take them
+	/// back under memory pressure. Where `MADV_FREE` is missing the pages go back at once instead, which costs a fault
+	/// to touch again but is still correct.
+	///
+	/// # Safety
+	/// The range must lie within a live reservation, and nothing allocated from it may still be in use.
+	pub(crate) unsafe fn discard(base: NonNull<u8>, len: usize) {
+		#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+		let advice = libc::MADV_FREE;
+		#[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos", target_os = "freebsd")))]
+		let advice = libc::MADV_DONTNEED;
+		// SAFETY: the caller guarantees the range is a live mapping whose contents are dead.
+		unsafe { libc::madvise(base.as_ptr().cast(), len, advice) };
 	}
 
 	/// # Safety
@@ -98,7 +120,7 @@ mod imp {
 	use crate::BLOCK_ALIGN;
 	use std::ptr::{self, NonNull};
 	use windows_sys::Win32::System::Memory::{
-		MEM_COMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_READWRITE, VirtualAlloc, VirtualFree,
+		MEM_COMMIT, MEM_DECOMMIT, MEM_RELEASE, MEM_RESERVE, PAGE_READWRITE, VirtualAlloc, VirtualFree,
 	};
 
 	/// Reserve `size` bytes of address space at a 4 GiB-aligned base, committing none of it.
@@ -113,7 +135,7 @@ mod imp {
 		// SAFETY: the reservation spans `size + BLOCK_ALIGN` bytes, so `aligned` and the `size` bytes after it are
 		// inside it.
 		let base = unsafe { NonNull::new_unchecked(aligned as *mut u8) };
-		Some(Reservation { reservation, reserved: over, base })
+		Some(Reservation { reservation, reserved: over, base, size })
 	}
 
 	/// Back `len` bytes at `ptr` with physical memory. Committing an already-committed page is a no-op.
@@ -123,6 +145,17 @@ mod imp {
 	pub(crate) unsafe fn commit(ptr: NonNull<u8>, len: usize) -> bool {
 		// SAFETY: the caller guarantees the range is inside the reservation.
 		!unsafe { VirtualAlloc(ptr.as_ptr().cast(), len, MEM_COMMIT, PAGE_READWRITE) }.is_null()
+	}
+
+	/// Hand the physical memory behind the first `len` bytes at `base` back, leaving the address space reserved.
+	///
+	/// The next write to one of those pages commits it again, which [`commit`] does as the arena bumps.
+	///
+	/// # Safety
+	/// The range must lie within a live reservation, and nothing allocated from it may still be in use.
+	pub(crate) unsafe fn discard(base: NonNull<u8>, len: usize) {
+		// SAFETY: the caller guarantees the range is inside a live reservation whose contents are dead.
+		unsafe { VirtualFree(base.as_ptr().cast(), len, MEM_DECOMMIT) };
 	}
 
 	/// # Safety
@@ -152,10 +185,14 @@ mod imp {
 	}
 
 	/// # Safety
+	/// Never call this: [`reserve`] never succeeds here, so there is nothing to discard.
+	pub(crate) unsafe fn discard(_base: NonNull<u8>, _len: usize) {}
+
+	/// # Safety
 	/// Never call this: [`reserve`] never succeeds here, so there is nothing to release.
 	pub(crate) unsafe fn release(_reservation: NonNull<u8>, _reserved: usize) {}
 }
 
 #[cfg(windows)]
 pub(crate) use imp::commit;
-pub(crate) use imp::{release, reserve};
+pub(crate) use imp::{discard, release, reserve};


### PR DESCRIPTION
Reserving a region costs a pair of syscalls. Small parse steps pay a steep cost
for this if they're allocating a fresh arena, then dropping. A reservation could
outlives its arena, therefore amortizing this cost when a program resets and
renews an arena.

This change does just that - reservations go on a thread-local free list, keyed
by usable size, and the next arena of that size takes it.
