### PR TITLE
css_ast/css_parse/csskit_derives: Derive empty block, prelude, nested metadata kinds

### DIFF
--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -417,6 +417,19 @@ impl CssMetadata {
 		self.node_kinds.contains(NodeKinds::EmptyBlock)
 	}
 
+	/// Returns true if this node, or a node in its subtree, is nested inside another node.
+	#[inline]
+	pub fn is_nested(&self) -> bool {
+		self.node_kinds.contains(NodeKinds::Nested)
+	}
+
+	/// Returns true if this node has a prelude which covers no source text, such as the omitted
+	/// selector of `@page {}` or the anonymous layer of `@layer {}`.
+	#[inline]
+	pub fn has_empty_prelude(&self) -> bool {
+		self.node_kinds.contains(NodeKinds::EmptyPrelude)
+	}
+
 	/// Returns true if this node can be a container (has StyleRule or AtRule kind).
 	#[inline]
 	pub fn can_be_empty(&self) -> bool {
@@ -450,6 +463,18 @@ impl NodeMetadata for CssMetadata {
 	#[inline]
 	fn with_size(mut self, size: u16) -> Self {
 		self.size = size;
+		self
+	}
+
+	#[inline]
+	fn with_declaration(mut self) -> Self {
+		self.node_kinds |= NodeKinds::Declaration;
+		self
+	}
+
+	#[inline]
+	fn with_nested(mut self) -> Self {
+		self.node_kinds |= NodeKinds::Nested;
 		self
 	}
 }
@@ -716,6 +741,68 @@ mod tests {
 
 		assert!(metadata.property_groups.contains(PropertyGroup::Color));
 		assert!(metadata.used_at_rules.contains(AtRuleId::Media));
+	}
+
+	fn first_rule_metadata(css: &str) -> CssMetadata {
+		let alloc = Arena::new();
+		let lexer = Lexer::new(&CssAtomSet::ATOMS, css);
+		let mut parser = Parser::new(&alloc, css, lexer);
+		let stylesheet = parser.parse::<StyleSheet>().unwrap();
+		match stylesheet.rules.first().expect("stylesheet has no rules") {
+			crate::Rule::Style(rule) => rule.self_metadata(),
+			crate::Rule::Media(rule) => rule.self_metadata(),
+			crate::Rule::FontFace(rule) => rule.self_metadata(),
+			crate::Rule::Keyframes(rule) => rule.self_metadata(),
+			crate::Rule::Layer(rule) => rule.self_metadata(),
+			crate::Rule::Page(rule) => rule.self_metadata(),
+			crate::Rule::Scope(rule) => rule.self_metadata(),
+			rule => panic!("unexpected rule kind {rule:?}"),
+		}
+	}
+
+	fn stylesheet_metadata(css: &str) -> CssMetadata {
+		let alloc = Arena::new();
+		let lexer = Lexer::new(&CssAtomSet::ATOMS, css);
+		let mut parser = Parser::new(&alloc, css, lexer);
+		parser.parse::<StyleSheet>().unwrap().metadata()
+	}
+
+	#[test]
+	fn nested_rules_are_marked_nested() {
+		assert!(!stylesheet_metadata("a { color: red }").is_nested());
+		assert!(!stylesheet_metadata("@media screen { color: red }").is_nested());
+		assert!(stylesheet_metadata("a { b { color: red } }").is_nested());
+		assert!(stylesheet_metadata("@media screen { a { color: red } }").is_nested());
+	}
+
+	#[test]
+	fn omitted_preludes_are_marked_empty() {
+		assert!(first_rule_metadata("@page {}").has_empty_prelude());
+		assert!(first_rule_metadata("@layer { a { color: red } }").has_empty_prelude());
+		assert!(first_rule_metadata("@scope { a { color: red } }").has_empty_prelude());
+	}
+
+	#[test]
+	fn written_preludes_are_not_marked_empty() {
+		assert!(!first_rule_metadata("@page :left {}").has_empty_prelude());
+		assert!(!first_rule_metadata("@layer base { a { color: red } }").has_empty_prelude());
+		assert!(!first_rule_metadata("@scope (.card) { a { color: red } }").has_empty_prelude());
+	}
+
+	#[test]
+	fn rules_with_an_empty_block_are_marked_empty() {
+		assert!(first_rule_metadata("a {}").is_empty_container());
+		assert!(first_rule_metadata("@media screen {}").is_empty_container());
+		assert!(first_rule_metadata("@page {}").is_empty_container());
+		assert!(first_rule_metadata("@keyframes fade {}").is_empty_container());
+	}
+
+	#[test]
+	fn rules_with_a_filled_block_are_not_marked_empty() {
+		assert!(!first_rule_metadata("a { color: red }").is_empty_container());
+		assert!(!first_rule_metadata("nav { a {} }").is_empty_container());
+		assert!(!first_rule_metadata("@media screen { a { color: red } }").is_empty_container());
+		assert!(!first_rule_metadata("@font-face { font-display: swap }").is_empty_container());
 	}
 
 	// Child leaf types carrying distinct node_kinds bits, used to verify delegation

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use css_lexer::Kind;
 use css_parse::{
-	AtomSet, ComponentValues, Cursor, Declaration, DeclarationValue, Diagnostic, KindSet, NodeWithMetadata, Parser,
-	Peek, Result as ParserResult, SemanticEq as SemanticEqTrait, State, T,
+	AtomSet, ComponentValues, Cursor, Declaration, DeclarationValue, Diagnostic, KindSet, NodeMetadata,
+	NodeWithMetadata, Parser, Peek, Result as ParserResult, SemanticEq as SemanticEqTrait, State, T,
 };
 use csskit_derives::*;
 use csskit_proc_macro::node;
@@ -280,9 +280,8 @@ impl<'a> StyleValue<'a> {
 
 impl<'a> DeclarationValue<'a, CssMetadata> for StyleValue<'a> {
 	fn declaration_metadata(decl: &Declaration<'a, Self, CssMetadata>) -> CssMetadata {
-		let mut meta = decl.value.metadata();
 		// Mark this node as a declaration
-		meta.node_kinds |= NodeKinds::Declaration;
+		let mut meta = decl.value.metadata().with_declaration();
 		if decl.important.is_some() {
 			meta.declaration_kinds |= DeclarationKind::Important;
 		}

--- a/crates/css_ast/src/rules/color_profile.rs
+++ b/crates/css_ast/src/rules/color_profile.rs
@@ -28,6 +28,7 @@ pub struct ColorProfileRule<'a> {
 	#[atom(CssAtomSet::ColorProfile)]
 	pub name: T![AtKeyword],
 	pub prelude: ColorProfilePrelude,
+	#[metadata(block)]
 	pub block: ColorProfileRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -19,6 +19,7 @@ pub struct ContainerRule<'a> {
 	#[atom(CssAtomSet::Container)]
 	pub name: T![AtKeyword],
 	pub prelude: ContainerConditionList<'a>,
+	#[metadata(block)]
 	pub block: ContainerRulesBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/counter_style.rs
+++ b/crates/css_ast/src/rules/counter_style.rs
@@ -17,6 +17,7 @@ pub struct CounterStyleRule<'a> {
 	#[atom(CssAtomSet::CounterStyle)]
 	pub name: T![AtKeyword],
 	pub prelude: CounterStyleName,
+	#[metadata(block)]
 	pub block: CounterStyleRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -12,6 +12,7 @@ pub struct DocumentRule<'a> {
 	#[atom(CssAtomSet::Document)]
 	pub name: T![AtKeyword],
 	pub prelude: DocumentMatcherList<'a>,
+	#[metadata(block)]
 	pub block: DocumentRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -16,6 +16,7 @@ pub struct FontFaceRule<'a> {
 	#[atom(CssAtomSet::FontFace)]
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub name: T![AtKeyword],
+	#[metadata(block)]
 	pub block: FontFaceRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/font_feature_values.rs
+++ b/crates/css_ast/src/rules/font_feature_values.rs
@@ -28,6 +28,7 @@ pub struct FontFeatureValuesRule<'a> {
 	#[atom(CssAtomSet::FontFeatureValues)]
 	pub name: T![AtKeyword],
 	pub prelude: FontFeatureValuesPrelude<'a>,
+	#[metadata(block)]
 	pub block: FontFeatureValuesRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/font_palette_values.rs
+++ b/crates/css_ast/src/rules/font_palette_values.rs
@@ -28,6 +28,7 @@ pub struct FontPaletteValuesRule<'a> {
 	#[atom(CssAtomSet::FontPaletteValues)]
 	pub name: T![AtKeyword],
 	pub prelude: PaletteIdentifier,
+	#[metadata(block)]
 	pub block: FontPaletteValuesRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -17,6 +17,7 @@ pub struct KeyframesRule<'a> {
 	#[atom(CssAtomSet::Keyframes)]
 	pub name: T![AtKeyword],
 	pub prelude: KeyframesName,
+	#[metadata(block)]
 	pub block: KeyframesRuleBlock<'a>,
 }
 
@@ -78,6 +79,7 @@ pub struct KeyframesRuleBlock<'a>(pub RuleList<'a, Keyframe<'a>, CssMetadata>);
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct Keyframe<'a>(
+	#[metadata(block)]
 	QualifiedRule<'a, KeyframeSelectors<'a>, StyleValue<'a>, NoBlockAllowed<StyleValue<'a>, CssMetadata>, CssMetadata>,
 );
 

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -12,6 +12,7 @@ pub struct LayerRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Layer)]
 	pub name: T![AtKeyword],
+	#[metadata(prelude)]
 	pub prelude: LayerNameList<'a>,
 	pub block: Option<LayerRuleBlock<'a>>,
 	#[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -1,5 +1,4 @@
 use super::prelude::*;
-use crate::{AtRuleId, NodeKinds};
 use css_parse::Box;
 
 mod features;
@@ -11,34 +10,22 @@ pub use features::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.media"))]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[derive(csskit_derives::NodeWithMetadata)]
+#[metadata(node_kinds = AtRule, used_at_rules = Media)]
 pub struct MediaRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Media)]
 	pub name: T![AtKeyword],
 	pub prelude: MediaQueryList<'a>,
+	#[metadata(block)]
 	pub block: MediaRuleBlock<'a>,
-}
-
-impl<'a> NodeWithMetadata<CssMetadata> for MediaRule<'a> {
-	fn self_metadata(&self) -> CssMetadata {
-		let child_meta = self.block.0.metadata();
-		let is_empty = child_meta.declaration_kinds.is_none() && !child_meta.has_rules();
-		let mut node_kinds = NodeKinds::AtRule;
-		if is_empty {
-			node_kinds |= NodeKinds::EmptyBlock;
-		}
-		CssMetadata { used_at_rules: AtRuleId::Media, node_kinds, ..Default::default() }
-	}
-
-	fn metadata(&self) -> CssMetadata {
-		self.block.0.metadata().merge(self.prelude.metadata()).merge(self.self_metadata())
-	}
 }
 
 #[node]
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub struct MediaRuleBlock<'a>(pub Block<'a, StyleValue<'a>, Rule<'a>, CssMetadata>);
 #[node]
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -12,6 +12,7 @@ pub struct MozDocumentRule<'a> {
 	#[atom(CssAtomSet::_MozDocument)]
 	pub name: T![AtKeyword],
 	pub prelude: DocumentMatcherList<'a>,
+	#[metadata(block)]
 	pub block: DocumentRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -16,7 +16,9 @@ pub struct PageRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Page)]
 	pub name: T![AtKeyword],
+	#[metadata(prelude)]
 	pub prelude: Option<PageSelectorList<'a>>,
+	#[metadata(block)]
 	pub block: PageRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -15,6 +15,7 @@ pub struct PropertyRule<'a> {
 	#[atom(CssAtomSet::Property)]
 	pub name: T![AtKeyword],
 	pub prelude: PropertyPrelude,
+	#[metadata(block)]
 	pub block: PropertyRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/scope.rs
+++ b/crates/css_ast/src/rules/scope.rs
@@ -22,8 +22,11 @@ pub struct ScopeRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Scope)]
 	pub name: T![AtKeyword],
+	#[metadata(prelude)]
 	pub start: Option<Box<'a, ScopeStart<'a>>>,
+	#[metadata(prelude)]
 	pub end: Option<Box<'a, ScopeEnd<'a>>>,
+	#[metadata(block)]
 	pub block: ScopeRuleBlock<'a>,
 }
 
@@ -83,5 +86,6 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ScopeRule, "@scope(.card){color:black}");
 		assert_parse!(CssAtomSet::ATOMS, ScopeRule, "@scope(.card){img{color:black}}");
 		assert_parse!(CssAtomSet::ATOMS, ScopeRule, "@scope(){}");
+		assert_parse!(CssAtomSet::ATOMS, ScopeRule, "@scope{img{color:black}}");
 	}
 }

--- a/crates/css_ast/src/rules/starting_style.rs
+++ b/crates/css_ast/src/rules/starting_style.rs
@@ -16,6 +16,7 @@ pub struct StartingStyleRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::StartingStyle)]
 	pub name: T![AtKeyword],
+	#[metadata(block)]
 	pub block: StartingStyleRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -46,6 +46,7 @@ pub struct SupportsRule<'a> {
 	#[atom(CssAtomSet::Supports)]
 	pub name: T![AtKeyword],
 	pub prelude: SupportsCondition<'a>,
+	#[metadata(block)]
 	pub block: SupportsRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -17,6 +17,7 @@ pub struct WebkitKeyframesRule<'a> {
 	#[atom(CssAtomSet::_WebkitKeyframes)]
 	pub name: T![AtKeyword],
 	pub prelude: KeyframesName,
+	#[metadata(block)]
 	pub block: KeyframesRuleBlock<'a>,
 }
 

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -1,10 +1,9 @@
 use crate::{
-	CssAtomSet, CssMetadata, NodeKinds, SelectorList, StyleValue, UnknownAtRule, UnknownQualifiedRule,
-	diagnostics::CssDiagnostic, rules,
+	CssAtomSet, CssMetadata, SelectorList, StyleValue, UnknownAtRule, UnknownQualifiedRule, diagnostics::CssDiagnostic,
+	rules,
 };
 use css_parse::{
-	Box, Cursor, DeclarationGroup, Diagnostic, NodeMetadata, NodeWithMetadata, Parse, Parser, QualifiedRule,
-	Result as ParserResult, RuleVariants,
+	Box, Cursor, DeclarationGroup, Diagnostic, Parse, Parser, QualifiedRule, Result as ParserResult, RuleVariants,
 };
 use csskit_derives::*;
 use csskit_proc_macro::node;
@@ -19,24 +18,11 @@ use csskit_proc_macro::node;
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[derive(csskit_derives::NodeWithMetadata)]
+#[metadata(node_kinds = StyleRule)]
 pub struct StyleRule<'a> {
+	#[metadata(block)]
 	pub rule: QualifiedRule<'a, SelectorList<'a>, StyleValue<'a>, NestedGroupRule<'a>, CssMetadata>,
-}
-
-impl<'a> NodeWithMetadata<CssMetadata> for StyleRule<'a> {
-	fn self_metadata(&self) -> CssMetadata {
-		let child_meta = self.rule.metadata();
-		let is_empty = child_meta.declaration_kinds.is_none() && !child_meta.has_rules();
-		let mut node_kinds = NodeKinds::StyleRule;
-		if is_empty {
-			node_kinds |= NodeKinds::EmptyBlock;
-		}
-		CssMetadata { node_kinds, ..Default::default() }
-	}
-
-	fn metadata(&self) -> CssMetadata {
-		self.rule.metadata().merge(self.self_metadata())
-	}
 }
 
 // https://drafts.csswg.org/css-nesting/#conditionals

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -58,10 +58,11 @@ where
 	where
 		Iter: Iterator<Item = crate::Cursor> + Clone,
 	{
+		let nested = p.is(State::Nested);
 		let open_curly = p.parse::<T!['{']>()?;
 		let mut declarations = Vec::new_in(p.alloc());
 		let mut rules = Vec::new_in(p.alloc());
-		let mut meta = M::default();
+		let mut meta = if nested { M::default().with_nested() } else { M::default() };
 
 		// Per CSS Syntax spec: maintain a buffer of declarations to flush when we encounter rules.
 		// This enables proper interleaving of declarations and rules.

--- a/crates/css_parse/src/syntax/declaration_list.rs
+++ b/crates/css_parse/src/syntax/declaration_list.rs
@@ -61,9 +61,13 @@ where
 	where
 		Iter: Iterator<Item = crate::Cursor> + Clone,
 	{
+		let nested = p.is(State::Nested);
 		let open_curly = p.parse::<T!['{']>()?;
 		let mut declarations = Vec::new_in(p.alloc());
 		let mut meta: M = Default::default();
+		if nested {
+			meta = meta.with_nested();
+		}
 		loop {
 			if p.at_end() {
 				meta = meta.with_size(declarations.len().min(u16::MAX as usize) as u16);

--- a/crates/css_parse/src/syntax/rule_list.rs
+++ b/crates/css_parse/src/syntax/rule_list.rs
@@ -53,9 +53,10 @@ where
 	where
 		Iter: Iterator<Item = crate::Cursor> + Clone,
 	{
+		let nested = p.is(State::Nested);
 		let open_curly = p.parse::<T!['{']>()?;
 		let mut rules = Vec::new_in(p.alloc());
-		let mut meta = M::default();
+		let mut meta = if nested { M::default().with_nested() } else { M::default() };
 		loop {
 			p.parse_if_peek::<T![;]>().ok();
 			if p.at_end() {

--- a/crates/css_parse/src/traits/declaration_value.rs
+++ b/crates/css_parse/src/traits/declaration_value.rs
@@ -9,9 +9,10 @@ pub trait DeclarationValue<'a, M: NodeMetadata>: Sized + NodeWithMetadata<M> + T
 	/// This allows the value to inspect the declaration (e.g., checking for !important)
 	/// and include that information in the metadata.
 	///
-	/// The default implementation just returns the value's metadata, ignoring the declaration context.
+	/// The default implementation returns the value's metadata marked as a declaration, ignoring the
+	/// declaration context.
 	fn declaration_metadata(declaration: &Declaration<'a, Self, M>) -> M {
-		declaration.value.metadata()
+		declaration.value.metadata().with_declaration()
 	}
 
 	/// Determines if the given [Cursor] represents a valid [Ident][crate::token_macros::Ident] matching a known property

--- a/crates/css_parse/src/traits/node_metadata.rs
+++ b/crates/css_parse/src/traits/node_metadata.rs
@@ -8,6 +8,18 @@ pub trait NodeMetadata: Sized + Copy + Default {
 	fn with_size(self, _size: u16) -> Self {
 		self
 	}
+
+	/// Marks this metadata as describing a declaration.
+	/// Default implementation is a no-op for metadata types that don't track node kinds.
+	fn with_declaration(self) -> Self {
+		self
+	}
+
+	/// Marks this metadata as describing a node nested inside another node.
+	/// Default implementation is a no-op for metadata types that don't track node kinds.
+	fn with_nested(self) -> Self {
+		self
+	}
 }
 
 /// A Node that has NodeMetadata

--- a/crates/csskit_ast/src/selector/metadata.rs
+++ b/crates/csskit_ast/src/selector/metadata.rs
@@ -131,6 +131,7 @@ pub enum SelectorRequirements {
 	Rule,
 	AtRule,
 	Empty,
+	Nested,
 }
 
 impl SelectorRequirements {
@@ -147,6 +148,7 @@ impl SelectorRequirements {
 			&& (!self.contains(Self::Rule) || meta.has_rules())
 			&& (!self.contains(Self::AtRule) || meta.has_at_rules())
 			&& (!self.contains(Self::Empty) || meta.is_empty_container())
+			&& (!self.contains(Self::Nested) || meta.is_nested())
 	}
 }
 

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -573,6 +573,12 @@ impl NodeWithMetadata<QuerySelectorMetadata> for QueryPseudoClass {
 				structure,
 				..Default::default()
 			},
+			Self::Nested(..) => QuerySelectorMetadata {
+				requirements: SelectorRequirements::Nested,
+				self_requirements: SelectorRequirements::Nested,
+				structure,
+				..Default::default()
+			},
 			Self::FirstOfType(..) => {
 				QuerySelectorMetadata { deferred: true, needs_type_tracking: true, structure, ..Default::default() }
 			}

--- a/crates/csskit_derives/src/node_with_metadata.rs
+++ b/crates/csskit_derives/src/node_with_metadata.rs
@@ -11,6 +11,10 @@ struct MetadataArgs {
 	#[darling(default)]
 	pub skip: bool,
 	#[darling(default)]
+	pub block: bool,
+	#[darling(default)]
+	pub prelude: bool,
+	#[darling(default)]
 	pub node_kinds: Option<PipeList<Ident>>,
 	#[darling(default)]
 	pub used_at_rules: Option<PipeList<Ident>>,
@@ -37,6 +41,14 @@ impl MetadataArgs {
 	fn field_is_skipped(attrs: &[syn::Attribute]) -> bool {
 		MetadataArgs::from_attributes(attrs).map(|a| a.skip).unwrap_or(false)
 	}
+
+	fn field_is_block(attrs: &[syn::Attribute]) -> bool {
+		MetadataArgs::from_attributes(attrs).map(|a| a.block).unwrap_or(false)
+	}
+
+	fn field_is_prelude(attrs: &[syn::Attribute]) -> bool {
+		MetadataArgs::from_attributes(attrs).map(|a| a.prelude).unwrap_or(false)
+	}
 }
 
 /// Accessors (`self.<member>`) of every field that contributes metadata, plus their types.
@@ -60,6 +72,52 @@ fn aggregated_fields(fields: &Fields) -> Vec<(TokenStream, &Type)> {
 			.collect(),
 		Fields::Unit => Vec::new(),
 	}
+}
+
+/// Accessors (`self.<member>`) of every field, paired with the field itself.
+fn members(fields: &Fields) -> Vec<(TokenStream, &syn::Field)> {
+	match fields {
+		Fields::Named(named) => {
+			named.named.iter().filter_map(|f| f.ident.as_ref().map(|i| (quote! { #i }, f))).collect()
+		}
+		Fields::Unnamed(unnamed) => unnamed
+			.unnamed
+			.iter()
+			.enumerate()
+			.map(|(i, f)| {
+				let idx = Index::from(i);
+				(quote! { #idx }, f)
+			})
+			.collect(),
+		Fields::Unit => Vec::new(),
+	}
+}
+
+/// Accessor (`self.<member>`) of the field marked `#[metadata(block)]`, if any.
+fn block_field(fields: &Fields) -> Result<Option<TokenStream>> {
+	let mut found: Option<TokenStream> = None;
+	for (member, field) in members(fields) {
+		if !MetadataArgs::field_is_block(&field.attrs) {
+			continue;
+		}
+		if MetadataArgs::field_is_skipped(&field.attrs) {
+			return Err(Error::new_spanned(field, "#[metadata(block)] cannot be combined with #[metadata(skip)]."));
+		}
+		if found.is_some() {
+			return Err(Error::new_spanned(field, "#[metadata(block)] can only be applied to one field."));
+		}
+		found = Some(member);
+	}
+	Ok(found)
+}
+
+/// Accessors (`self.<member>`) of every field marked `#[metadata(prelude)]`.
+fn prelude_fields(fields: &Fields) -> Vec<TokenStream> {
+	members(fields)
+		.into_iter()
+		.filter(|(_, field)| MetadataArgs::field_is_prelude(&field.attrs))
+		.map(|(member, _)| member)
+		.collect()
 }
 
 fn merge_expr(base: TokenStream, values: impl IntoIterator<Item = TokenStream>) -> TokenStream {
@@ -91,6 +149,67 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let property_kinds = MetadataArgs::pipe_tokens(&args.property_kinds, parse_quote! { crate::PropertyKind });
 	let value_kinds = MetadataArgs::pipe_tokens(&args.value_kinds, parse_quote! { crate::CssTypes });
 	let uses_substitution = args.uses_substitution;
+
+	let block = match &input.data {
+		Data::Struct(DataStruct { fields, .. }) => block_field(fields)?,
+		Data::Enum(DataEnum { variants, .. }) => {
+			for variant in variants {
+				if block_field(&variant.fields)?.is_some() {
+					return Err(Error::new_spanned(variant, "#[metadata(block)] is only supported on structs."));
+				}
+			}
+			None
+		}
+		Data::Union(_) => None,
+	};
+
+	let preludes = match &input.data {
+		Data::Struct(DataStruct { fields, .. }) => prelude_fields(fields),
+		Data::Enum(DataEnum { variants, .. }) => {
+			for variant in variants {
+				if !prelude_fields(&variant.fields).is_empty() {
+					return Err(Error::new_spanned(variant, "#[metadata(prelude)] is only supported on structs."));
+				}
+			}
+			Vec::new()
+		}
+		Data::Union(_) => Vec::new(),
+	};
+
+	// `EmptyBlock` marks a rule whose block holds neither declarations nor rules.
+	let node_kinds = if let Some(block) = &block {
+		quote! {
+			{
+				let child = <_ as css_parse::NodeWithMetadata<crate::CssMetadata>>::metadata(&self.#block);
+				let mut kinds = #node_kinds;
+				if !child.node_kinds.intersects(
+					crate::NodeKinds::Declaration | crate::NodeKinds::StyleRule | crate::NodeKinds::AtRule,
+				) {
+					kinds |= crate::NodeKinds::EmptyBlock;
+				}
+				kinds
+			}
+		}
+	} else {
+		node_kinds
+	};
+
+	// A prelude which covers no source text is absent: `None` spans `Span::DUMMY` and an empty
+	// list spans `Span::ZERO`, both of zero length.
+	let node_kinds = if preludes.is_empty() {
+		node_kinds
+	} else {
+		quote! {
+			{
+				let kinds = #node_kinds;
+				if #(css_parse::ToSpan::to_span(&self.#preludes).len() == 0)&&* {
+					kinds | crate::NodeKinds::EmptyPrelude
+				} else {
+					kinds
+				}
+			}
+		}
+	};
 
 	let self_metadata = quote! {
 		fn self_metadata(&self) -> crate::CssMetadata {


### PR DESCRIPTION
Rules like `MediaRule` and `StyleRole` had manual `NodeWithMetadata` impls
purely to set `EmptyBlock` in their metadata. However this doesn't scale, as
evidenced by the fact that I've forgotten to do this for all other rules.

So this changes the derive to add `#[metadata(block)]` and
`#[metadata(prelude)]` markers for rules, to make it super easy to
delegate NodeKind flags to the derive impls. This also means we can drop
the manual impls, and start annotating members with these. During this I
also realised `Nested` was never set. This needs changes in css_parse as
those are generic nodes in there, so this change also adds Nested to those.
