### PR TITLE
css_parse: Expose diagnostic details

### DIFF
--- a/crates/css_ast/src/selector/pseudo_class.rs
+++ b/crates/css_ast/src/selector/pseudo_class.rs
@@ -162,7 +162,7 @@ mod tests {
 		let lexer = css_lexer::Lexer::new(&CssAtomSet::ATOMS, source);
 		let result = css_parse::Parser::new(&arena, source, lexer).parse_entirely::<PseudoClass>();
 		let error = result.errors.first().expect("a diagnostic");
-		let meta = (error.formatter)(error, source);
+		let meta = error.meta(source);
 		assert_eq!(meta.message, "Unexpected pseudo selector ':nonsense'");
 	}
 

--- a/crates/css_parse/src/diagnostics.rs
+++ b/crates/css_parse/src/diagnostics.rs
@@ -81,22 +81,29 @@ impl Diagnostic {
 		self
 	}
 
+	/// Render the code, message, help text and labels of this diagnostic against `source`.
+	pub fn meta(&self, source: &str) -> DiagnosticMeta {
+		(self.formatter)(self, source)
+	}
+
+	/// The source range this diagnostic covers, from the first cursor to the last cursor consumed to recover.
+	pub fn span(&self) -> Span {
+		self.start_cursor.span() + self.end_cursor.span()
+	}
+
 	/// Get formatted message
 	pub fn message(&self, source: &str) -> String {
-		let DiagnosticMeta { message, .. } = (self.formatter)(self, source);
-		message
+		self.meta(source).message
 	}
 
 	/// Get diagnostic code
 	pub fn code(&self, source: &str) -> &'static str {
-		let DiagnosticMeta { code, .. } = (self.formatter)(self, source);
-		code
+		self.meta(source).code
 	}
 
 	/// Get help text
 	pub fn help(&self, source: &str) -> String {
-		let DiagnosticMeta { help, .. } = (self.formatter)(self, source);
-		help
+		self.meta(source).help
 	}
 
 	/// Add a desired cursor (what was expected)
@@ -109,7 +116,7 @@ impl Diagnostic {
 	#[cfg(feature = "miette")]
 	pub fn into_diagnostic(self, source: &str) -> MietteDiagnostic {
 		use miette::LabeledSpan;
-		let DiagnosticMeta { code, message, help, mut labels } = (self.formatter)(&self, source);
+		let DiagnosticMeta { code, message, help, mut labels } = self.meta(source);
 		let miette_labels = labels.drain(0..).map(|(span, label)| LabeledSpan::new_with_span(Some(label), span));
 		MietteDiagnostic::new(message)
 			.with_code(code)

--- a/crates/csskit/src/commands/mod.rs
+++ b/crates/csskit/src/commands/mod.rs
@@ -102,6 +102,6 @@ pub fn format_diagnostic_error(err: &Diagnostic, source: &str, file_name: &str) 
 	if handler.render_report(&mut report, &*err_with_source).is_ok() {
 		return report;
 	}
-	let DiagnosticMeta { code, message, help, .. } = (err.formatter)(err, source);
+	let DiagnosticMeta { code, message, help, .. } = err.meta(source);
 	format!("Error [{code}]: {message}\nHelp: {help}\n")
 }

--- a/crates/csskit_wasm/src/lib.rs
+++ b/crates/csskit_wasm/src/lib.rs
@@ -45,8 +45,8 @@ pub fn parse(source_text: String) -> Result<SerializableParserResult, serde_wasm
 		.errors
 		.iter()
 		.map(|err| {
-			let DiagnosticMeta { code, message, help, .. } = (err.formatter)(err, &source_text);
-			let span = err.start_cursor.span() + err.end_cursor.span();
+			let DiagnosticMeta { code, message, help, .. } = err.meta(&source_text);
+			let span = err.span();
 			let from = span.start().into();
 			let to = span.end().into();
 			SerializableDiagnostic {
@@ -109,7 +109,7 @@ fn format_with_options(source_text: &str, options: FormatOptions) -> Result<Stri
 	let result = Parser::new(&allocator, source_text, lexer).parse_entirely::<StyleSheet>();
 	if !result.errors.is_empty() {
 		let first_error = &result.errors[0];
-		let DiagnosticMeta { code, message, help, .. } = (first_error.formatter)(first_error, source_text);
+		let DiagnosticMeta { code, message, help, .. } = first_error.meta(source_text);
 		return Err(format!("Parse error [{}]: {} (Help: {})", code, message, help));
 	}
 	let mut output_string = String::new();
@@ -156,7 +156,7 @@ fn build_error(err: &Diagnostic, source: &str, w: &mut impl Write) {
 			return;
 		}
 	}
-	let DiagnosticMeta { code, message, help, .. } = (err.formatter)(err, source);
+	let DiagnosticMeta { code, message, help, .. } = err.meta(source);
 	write!(w, "Error [{code}]: {message}\nHelp: {help}\n").unwrap();
 }
 


### PR DESCRIPTION
Diagnostic consumers invoke the formatter field directly and reconstruct source
spans from the diagnostic cursors. This unnecessarily exposes details and
duplicates formatting logic.

This change adds metadata and span methods which allows for a more
opaque handling of message formatting.
