### PR TITLE
css_ast: Support dynamically Visiting & Parsing

### DIFF
--- a/crates/css_ast/build.rs
+++ b/crates/css_ast/build.rs
@@ -213,6 +213,40 @@ fn main() {
 	}
 
 	{
+		let parse_arms = queryable
+			.iter()
+			.filter_map(|node| {
+				let ident = node.ident();
+				let generics = node.generics();
+				if generics.type_params().next().is_some() || generics.const_params().next().is_some() {
+					return None;
+				}
+				let ty = match generics.lifetimes().count() {
+					0 => quote! { #ident },
+					lifetimes => {
+						let each = std::iter::repeat_n(quote! { 'a }, lifetimes);
+						quote! { #ident<#(#each),*> }
+					}
+				};
+				Some(quote! { NodeId::#ident => ErasedNodeParser::<#ty>(PhantomData).parse(arena, source) })
+			})
+			.collect::<Vec<_>>();
+		#[rustfmt::skip]
+		let source = quote! {
+			/// Parses `source` as the node kind that `id` names, into `arena`.
+			///
+			/// Returns `None` if the kind has no standalone grammar.
+			pub fn parse_root<'a>(id: NodeId, arena: &'a Arena, source: &'a str) -> Option<ParsedRoot<'a>> {
+				match id {
+					#(#parse_arms,)*
+					_ => None,
+				}
+			}
+		};
+		write_tokens("css_root_dispatch.rs", source).unwrap();
+	}
+
+	{
 		let mut vendor_atoms: Vec<proc_macro2::Ident> = Vec::new();
 		let variants = all_visitable.iter().filter_map(|node| {
 			let ident = node.ident();

--- a/crates/css_ast/src/test_helpers.rs
+++ b/crates/css_ast/src/test_helpers.rs
@@ -194,7 +194,10 @@ impl ControlFlowTestVisitor {
 }
 
 #[cfg(feature = "visitable")]
-impl crate::Visit for ControlFlowTestVisitor {
+impl crate::Visit for ControlFlowTestVisitor {}
+
+#[cfg(feature = "visitable")]
+impl crate::NodeVisitor for ControlFlowTestVisitor {
 	fn consider_node(&self, node: crate::VisitNode) -> VisitFlow {
 		if let Some(filter_span) = self.span_filter {
 			let span = node.span;

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -15,7 +15,9 @@ use visit_flow::{VisitFlow, try_visit};
 pub use csskit_derives::visitor;
 pub use visit_flow::{VisitAction, VisitBreak, VisitFlowExt};
 
+mod root;
 mod visit_node;
+pub use root::{ErasedNode, ParsedRoot, parse_root};
 pub(crate) use visit_node::QueryNodeData;
 pub use visit_node::VisitNode;
 
@@ -42,32 +44,50 @@ macro_rules! visit_mut_trait {
 }
 apply_visit_methods!(visit_mut_trait);
 
+/// The object-safe core of [`Visit`].
+///
+/// [`Visit`] has methods that are type-specific. A visitor that needs the node kind and the span can implement just
+/// this trait, and can then walk a node whose type is erased, such as an [`ErasedNode`].
+///
+/// The methods have no defaults, thus an implementation cannot drop one by mistake.
+pub trait NodeVisitor {
+	/// Called before entering a node.
+	///
+	/// Return [`VisitFlow::SKIP_CHILDREN`] to prune the node and its entire subtree (it is never entered). Return
+	/// [`VisitFlow::STOP`] to halt the whole traversal.
+	fn consider_node(&self, node: VisitNode) -> VisitFlow;
+
+	/// Called on entry to every queryable node.
+	///
+	/// Receives a [`VisitNode`]; per-node metadata and properties are available via its methods. Return
+	/// [`VisitFlow::SKIP_CHILDREN`] to skip the typed `visit_*` call and children.
+	fn enter_node(&mut self, node: VisitNode) -> VisitFlow;
+
+	/// Called on exit from every queryable node.
+	fn exit_node(&mut self, node: VisitNode) -> VisitFlow;
+}
+
+impl NodeVisitor for &mut (dyn NodeVisitor + '_) {
+	fn consider_node(&self, node: VisitNode) -> VisitFlow {
+		(**self).consider_node(node)
+	}
+
+	fn enter_node(&mut self, node: VisitNode) -> VisitFlow {
+		(**self).enter_node(node)
+	}
+
+	fn exit_node(&mut self, node: VisitNode) -> VisitFlow {
+		(**self).exit_node(node)
+	}
+}
+
+impl Visit for &mut (dyn NodeVisitor + '_) {}
+
 macro_rules! visit_trait {
 	( $(
 		$name: ident$(<$($gen:tt),+>)?($obj: ty),
 	)+ ) => {
-		pub trait Visit: Sized {
-			/// Called before entering a node.
-			///
-			/// Return [`VisitFlow::SKIP_CHILDREN`] to prune the node and its entire subtree (it is
-			/// never entered). Return [`VisitFlow::STOP`] to halt the whole traversal. Default
-			/// considers everything.
-			fn consider_node(&self, _node: VisitNode) -> VisitFlow {
-				VisitFlow::DESCEND
-			}
-
-			/// Called on entry to every queryable node. Override to handle all queryable nodes uniformly.
-			///
-			/// Receives a [`VisitNode`]; per-node metadata and properties are available lazily via
-			/// its methods. Return [`VisitFlow::SKIP_CHILDREN`] to skip the typed `visit_*` call and children.
-			fn enter_node(&mut self, _node: VisitNode) -> VisitFlow {
-				VisitFlow::DESCEND
-			}
-
-			/// Called on exit from every queryable node.
-			fn exit_node(&mut self, _node: VisitNode) -> VisitFlow {
-				VisitFlow::DESCEND
-			}
+		pub trait Visit: NodeVisitor + Sized {
 
 			fn enter_declaration<'a, T: DeclarationValue<'a, CssMetadata>>(&mut self, _rule: &Declaration<'a, T, CssMetadata>, _node: VisitNode) -> VisitFlow {
 				VisitFlow::DESCEND

--- a/crates/css_ast/src/visit/root.rs
+++ b/crates/css_ast/src/visit/root.rs
@@ -1,0 +1,139 @@
+use super::{NodeId, NodeVisitor, Visitable};
+use crate::*;
+use css_lexer::Lexer;
+use css_parse::{Arena, Box, Diagnostic, NodeWithMetadata, Parse, Parser, ToCursors, ToSpan, Vec};
+use std::marker::PhantomData;
+use visit_flow::VisitFlow;
+
+include!(concat!(env!("OUT_DIR"), "/css_root_dispatch.rs"));
+
+/// A node whose type is erased.
+pub trait ErasedNode: ToSpan + NodeWithMetadata<CssMetadata> {
+	fn accept_dyn(&self, visitor: &mut dyn NodeVisitor) -> VisitFlow;
+}
+
+impl<T: ToSpan + Visitable + NodeWithMetadata<CssMetadata>> ErasedNode for T {
+	fn accept_dyn(&self, mut visitor: &mut dyn NodeVisitor) -> VisitFlow {
+		Visitable::accept(self, &mut visitor)
+	}
+}
+
+/// What [`parse_root`] gives back.
+pub struct ParsedRoot<'a> {
+	/// The root node, or `None` if the source does not parse as the node kind.
+	pub root: Option<&'a dyn ErasedNode>,
+	pub diagnostics: Vec<'a, Diagnostic>,
+}
+
+struct ErasedNodeParser<'a, T>(PhantomData<&'a T>);
+
+impl<'a, T> ErasedNodeParser<'a, T>
+where
+	T: Parse<'a> + ToCursors + ToSpan + Visitable + NodeWithMetadata<CssMetadata> + 'a,
+{
+	fn parse(&self, arena: &'a Arena, source: &'a str) -> Option<ParsedRoot<'a>> {
+		let lexer = Lexer::new(&CssAtomSet::ATOMS, source);
+		let result = Parser::new(arena, source, lexer).parse_entirely::<T>();
+		let root = result.output.map(|value| &*Box::new_in(arena, value).leak() as &'a dyn ErasedNode);
+		Some(ParsedRoot { root, diagnostics: result.errors })
+	}
+}
+
+trait ParseFallback<'a> {
+	fn parse(&self, _: &'a Arena, _: &'a str) -> Option<ParsedRoot<'a>> {
+		None
+	}
+}
+
+impl<'a, T> ParseFallback<'a> for ErasedNodeParser<'a, T> {}
+
+#[cfg(test)]
+mod tests {
+	use super::{NodeId, NodeVisitor, VisitNode, parse_root};
+	use css_parse::Arena;
+	use visit_flow::{VisitFlow, VisitFlowExt};
+
+	#[test]
+	fn parseability_follows_the_parse_impl_not_a_list() {
+		let arena = Arena::default();
+		for tag in ["style-value", "font-face-rule-style-value", "font-feature-value"] {
+			let id = NodeId::from_tag_name(tag).unwrap_or_else(|| panic!("{tag} is a node kind"));
+			assert!(parse_root(id, &arena, "").is_none(), "{tag} has no standalone grammar");
+		}
+		for tag in ["style-sheet", "length", "angle", "scope-rule", "bg-layer"] {
+			let id = NodeId::from_tag_name(tag).unwrap_or_else(|| panic!("{tag} is a node kind"));
+			assert!(parse_root(id, &arena, "").is_some(), "{tag} parses on its own");
+		}
+		// Math functions are generic over their leaf type. You cannot name them as one root.
+		assert!(parse_root(NodeId::CalcFunction, &arena, "").is_none());
+	}
+
+	#[test]
+	fn parse_root_gives_an_erased_root_that_walks() {
+		struct Kinds(std::vec::Vec<NodeId>);
+
+		impl NodeVisitor for Kinds {
+			fn consider_node(&self, _: VisitNode) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
+
+			fn enter_node(&mut self, node: VisitNode) -> VisitFlow {
+				self.0.extend(node.node_id);
+				VisitFlow::DESCEND
+			}
+
+			fn exit_node(&mut self, _: VisitNode) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
+		}
+
+		let arena = Arena::default();
+		let parsed = parse_root(NodeId::StyleSheet, &arena, "a{color:red}").expect("style-sheet is a root");
+		let root = parsed.root.expect("the source parses");
+		assert!(parsed.diagnostics.is_empty());
+		assert_eq!(root.to_span().end().0, 12);
+
+		let mut kinds = Kinds(std::vec::Vec::new());
+		let _ = root.accept_dyn(&mut kinds);
+		assert!(kinds.0.contains(&NodeId::StyleSheet), "got {:?}", kinds.0);
+		assert!(kinds.0.contains(&NodeId::StyleRule), "got {:?}", kinds.0);
+
+		assert!(parse_root(NodeId::StyleValue, &arena, "red").is_none(), "style-value is not a root");
+	}
+
+	#[test]
+	fn a_walk_of_an_erased_root_prunes_as_a_typed_walk_does() {
+		use super::{Visitable, visitor};
+		use crate::StyleSheet;
+		use css_lexer::Lexer;
+		use css_parse::Parser;
+
+		struct Pruner(std::vec::Vec<NodeId>);
+
+		#[visitor]
+		impl super::Visit for Pruner {
+			fn consider_node(&self, node: VisitNode) -> VisitFlow {
+				if node.node_id == Some(NodeId::StyleRule) { VisitFlow::SKIP_CHILDREN } else { VisitFlow::DESCEND }
+			}
+
+			fn enter_node(&mut self, node: VisitNode) {
+				self.0.extend(node.node_id);
+			}
+		}
+
+		let arena = Arena::default();
+		let source = "a{color:red}";
+		let lexer = Lexer::new(&crate::CssAtomSet::ATOMS, source);
+		let typed =
+			Parser::new(&arena, source, lexer).parse_entirely::<StyleSheet>().output.expect("the source parses");
+		let mut typed_kinds = Pruner(std::vec::Vec::new());
+		let _ = typed.accept(&mut typed_kinds);
+
+		let parsed = parse_root(NodeId::StyleSheet, &arena, source).expect("style-sheet is a root");
+		let mut erased_kinds = Pruner(std::vec::Vec::new());
+		let _ = parsed.root.expect("the source parses").accept_dyn(&mut erased_kinds);
+
+		assert_eq!(typed_kinds.0, erased_kinds.0);
+		assert_eq!(typed_kinds.0, [NodeId::StyleSheet]);
+	}
+}

--- a/crates/css_parse/src/arena_box.rs
+++ b/crates/css_parse/src/arena_box.rs
@@ -30,6 +30,18 @@ impl<'a, T, A: Allocator> Box<'a, T, A> {
 	}
 }
 
+impl<'a, T> Box<'a, T> {
+	/// Gives up ownership of the value. The value stays in the arena, thus its `Drop` does not run.
+	#[inline]
+	pub fn leak(self) -> &'a mut T {
+		let ptr = self.ptr;
+		std::mem::forget(self);
+		// SAFETY: `ptr` addresses a live value in an arena that outlives `'a`, and this `Box` was the
+		// only owner of it. The arena frees the whole region at once.
+		unsafe { &mut *ptr.as_ptr() }
+	}
+}
+
 impl<'a, T, A: Allocator> Deref for Box<'a, T, A> {
 	type Target = T;
 

--- a/crates/csskit/src/commands/colors.rs
+++ b/crates/csskit/src/commands/colors.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use allocator_api2::alloc::Allocator;
 use chromashift::*;
-use css_ast::{Color as ASTColor, ToChromashift, Visitable};
+use css_ast::{Color as ASTColor, NodeVisitor, ToChromashift, VisitNode, Visitable};
 use css_lexer::LineIndex;
 use css_parse::{Diagnostic, Span, ToSpan};
 use itertools::Itertools;

--- a/crates/csskit/src/commands/specificity.rs
+++ b/crates/csskit/src/commands/specificity.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 use crate::commands::{Extract, OutputFormat};
 use allocator_api2::alloc::Allocator;
 use css_ast::specificity::ToSpecificity;
-use css_ast::{SelectorList, StyleRule, Visit, Visitable, visitor};
+use css_ast::{NodeVisitor, SelectorList, StyleRule, Visit, VisitNode, Visitable, visitor};
 use css_lexer::{LineIndex, Span};
 use css_parse::ToSpan;
 use serde::Serialize;

--- a/crates/csskit/src/commands/tree.rs
+++ b/crates/csskit/src/commands/tree.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 use css_ast::VisitNode;
-use css_ast::visit::{Visit, Visitable, visitor};
+use css_ast::visit::{NodeVisitor, Visit, Visitable, visitor};
 use css_ast::{PROPERTY_KIND_VARIANTS, PropertyKind};
 use css_parse::{Cursor, ToSpan};
 use csskit_ast::{QueryFunctionalPseudoClass, QueryPseudoClass};

--- a/crates/csskit_ast/src/selector/matcher/node_collector.rs
+++ b/crates/csskit_ast/src/selector/matcher/node_collector.rs
@@ -1,6 +1,6 @@
 use super::{NodeData, SelectorBuckets};
 use css_ast::VisitNode;
-use css_ast::visit::{NodeId, Visit, visitor};
+use css_ast::visit::{NodeId, NodeVisitor, Visit, visitor};
 use smallvec::SmallVec;
 use std::collections::HashMap;
 use visit_flow::{VisitFlow, VisitFlowExt};

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_bare_return.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_bare_return.snap
@@ -1,7 +1,19 @@
 ---
 source: crates/csskit_derives/src/test/test_visitor.rs
+assertion_line: 48
 expression: out
 ---
+impl NodeVisitor for V {
+    fn consider_node(&self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+    fn enter_node(&mut self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+    fn exit_node(&mut self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+}
 impl Visit for V {
     fn visit_color(&mut self, c: &Color) -> ::visit_flow::VisitFlow {
         if c.is_empty() {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_explicit_return.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_explicit_return.snap
@@ -1,9 +1,17 @@
 ---
 source: crates/csskit_derives/src/test/test_visitor.rs
+assertion_line: 33
 expression: out
 ---
-impl Visit for V {
+impl NodeVisitor for V {
     fn consider_node(&self, q: VisitNode) -> VisitFlow {
         VisitFlow::SKIP_CHILDREN
     }
+    fn enter_node(&mut self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+    fn exit_node(&mut self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
 }
+impl Visit for V {}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_nested_closure.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_nested_closure.snap
@@ -1,7 +1,19 @@
 ---
 source: crates/csskit_derives/src/test/test_visitor.rs
+assertion_line: 63
 expression: out
 ---
+impl NodeVisitor for V {
+    fn consider_node(&self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+    fn enter_node(&mut self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+    fn exit_node(&mut self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+}
 impl Visit for V {
     fn visit_color(&mut self, c: &Color) -> ::visit_flow::VisitFlow {
         let f = || {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_observer.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_observer.snap
@@ -1,7 +1,19 @@
 ---
 source: crates/csskit_derives/src/test/test_visitor.rs
+assertion_line: 21
 expression: out
 ---
+impl NodeVisitor for V {
+    fn consider_node(&self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+    fn enter_node(&mut self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+    fn exit_node(&mut self, _node: VisitNode) -> ::visit_flow::VisitFlow {
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+}
 impl Visit for V {
     fn visit_color(&mut self, c: &Color) -> ::visit_flow::VisitFlow {
         self.seen.push(c);

--- a/crates/csskit_derives/src/test/test_visitor.rs
+++ b/crates/csskit_derives/src/test/test_visitor.rs
@@ -76,6 +76,27 @@ fn explicit_unit_return_opts_out() {
 }
 
 #[test]
+fn impl_attributes_apply_to_both_generated_impls() {
+	let out = expand(quote! {
+		#[cfg(feature = "visitor")]
+		#[allow(dead_code)]
+		impl Visit for V {}
+	});
+	let file = syn::parse_file(&out).unwrap();
+	let impls = file.items.iter().filter_map(|item| match item {
+		syn::Item::Impl(item) => Some(item),
+		_ => None,
+	});
+	let mut count = 0;
+	for item in impls {
+		count += 1;
+		assert!(item.attrs.iter().any(|attr| attr.path().is_ident("cfg")));
+		assert!(item.attrs.iter().any(|attr| attr.path().is_ident("allow")));
+	}
+	assert_eq!(count, 2);
+}
+
+#[test]
 fn rejects_inherent_impl() {
 	let item = syn::parse2::<syn::ItemImpl>(quote! {
 		impl V {

--- a/crates/csskit_derives/src/visitor.rs
+++ b/crates/csskit_derives/src/visitor.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{
 	Expr, ImplItem, ItemImpl, Result, ReturnType, parse_quote,
 	spanned::Spanned,
@@ -75,5 +75,28 @@ pub fn expand(item: ItemImpl) -> Result<TokenStream> {
 			<::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
 		});
 	}
-	Ok(quote! { #item })
+
+	let mut node_visitor = item.clone();
+	node_visitor.trait_ = Some((parse_quote!(NodeVisitor), Default::default()));
+	let is_core = |impl_item: &ImplItem| matches!(impl_item, ImplItem::Fn(method) if NODE_VISITOR_METHODS.iter().any(|(name, _)| method.sig.ident == name));
+	(node_visitor.items, item.items) = std::mem::take(&mut item.items).into_iter().partition(is_core);
+	for (name, receiver) in NODE_VISITOR_METHODS {
+		if node_visitor.items.iter().any(|item| matches!(item, ImplItem::Fn(method) if method.sig.ident == name)) {
+			continue;
+		}
+		let name = format_ident!("{name}");
+		let receiver: TokenStream = receiver.parse().expect("a receiver parses");
+		node_visitor.items.push(parse_quote!(
+			fn #name(#receiver, _node: VisitNode) -> ::visit_flow::VisitFlow {
+				<::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+			}
+		));
+	}
+
+	Ok(quote! { #node_visitor #item })
 }
+
+/// The `NodeVisitor` methods and their receivers. `NodeVisitor` declares no defaults, thus every
+/// impl states all three; the attribute writes the ones the visitor leaves out.
+const NODE_VISITOR_METHODS: [(&str, &str); 3] =
+	[("consider_node", "&self"), ("enter_node", "&mut self"), ("exit_node", "&mut self")];

--- a/crates/csskit_highlight/src/css.rs
+++ b/crates/csskit_highlight/src/css.rs
@@ -1,6 +1,6 @@
 use css_ast::{
-	CSSInt, Color, CssMetadata, Declaration, DeclarationValue, NodeId, PropertyRule, StyleRule, ToChromashift, Visit,
-	VisitNode, visitor,
+	CSSInt, Color, CssMetadata, Declaration, DeclarationValue, NodeId, NodeVisitor, PropertyRule, StyleRule,
+	ToChromashift, Visit, VisitNode, visitor,
 };
 use css_lexer::ToSpan;
 use css_parse::NodeWithMetadata;

--- a/crates/csskit_transform/src/lib.rs
+++ b/crates/csskit_transform/src/lib.rs
@@ -7,7 +7,7 @@ pub use transformer::*;
 
 pub(crate) mod prelude {
 	pub(crate) use crate::{CssMinifierFeature, Transform, Transformer};
-	pub(crate) use css_ast::{CssMetadata, Visit, visitor};
+	pub(crate) use css_ast::{CssMetadata, NodeVisitor, Visit, visitor};
 	pub(crate) use css_lexer::ToSpan;
 	pub(crate) use css_parse::NodeWithMetadata;
 	pub(crate) use visit_flow::{VisitFlow, VisitFlowExt};


### PR DESCRIPTION
Consumers must have a concrete node in order to parse, and use the Visit
methods, even though it can be useful to parse with a NodeID, or just implement
a dynamic node walker. Both of these could be useful in, say, a NodeJS API.

This change adds an object-safe NodeVisitor core, with a parse dispatch which
combines a ParsedRoot which has an "ErasedNode" type, allowing APIs to
generically parse and walk a subtree without a handle on the concrete type.
