### PR TITLE
csskit_ast: Use ErasedNode in selector matching, add NodeKey for identity

### DIFF
--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -19,7 +19,7 @@ mod root;
 mod visit_node;
 pub use root::{ErasedNode, ParsedRoot, parse_root};
 pub(crate) use visit_node::QueryNodeData;
-pub use visit_node::VisitNode;
+pub use visit_node::{NodeKey, VisitNode};
 
 use crate::*;
 

--- a/crates/css_ast/src/visit/visit_node.rs
+++ b/crates/css_ast/src/visit/visit_node.rs
@@ -14,6 +14,22 @@ pub(crate) trait QueryNodeData {
 	fn get_property(&self, kind: PropertyKind) -> Option<Cursor>;
 }
 
+/// Identity of one node within a parsed tree.
+///
+/// Keys remain valid while the tree lives. They are opaque and meaningful only among nodes from
+/// the same tree.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct NodeKey {
+	address: usize,
+	node_id: NodeId,
+}
+
+impl NodeKey {
+	fn of<T: ?Sized>(value: &T, node_id: NodeId) -> Self {
+		Self { address: (std::ptr::from_ref(value) as *const ()).addr(), node_id }
+	}
+}
+
 /// The single node view passed to every [`Visit`](super::Visit) callback.
 #[derive(Clone, Copy)]
 pub struct VisitNode<'n> {
@@ -33,6 +49,12 @@ impl<'n> VisitNode<'n> {
 	#[inline]
 	pub fn new_transparent(span: Span) -> Self {
 		Self { span, node_id: None, source: None }
+	}
+
+	/// The identity of this queryable node, or `None` for a transparent node.
+	#[inline]
+	pub fn key(&self) -> Option<NodeKey> {
+		self.source.zip(self.node_id).map(|(source, node_id)| NodeKey::of(source, node_id))
 	}
 
 	/// Aggregated metadata for this node *and its entire subtree*.

--- a/crates/css_value_definition_parser/src/sized_types.rs
+++ b/crates/css_value_definition_parser/src/sized_types.rs
@@ -206,6 +206,7 @@ pub(crate) const SIZED_TYPES: &[&str] = &[
 	"NamespaceTag",
 	"NavControlsMediaFeature",
 	"NavControlsMediaFeatureKeyword",
+	"NodeKey",
 	"NodeKinds",
 	"NonEmpty",
 	"NonNegative",

--- a/crates/csskit_ast/src/collector/mod.rs
+++ b/crates/csskit_ast/src/collector/mod.rs
@@ -404,6 +404,7 @@ impl<'a> Collector<'a> {
 			let mut match_output = MatchOutput {
 				span: parent_span,
 				node_id: css_ast::NodeId::StyleRule,
+				node_key: None,
 				properties: Default::default(),
 				size: 0,
 				stat_snapshot: SmallVec::new(),

--- a/crates/csskit_ast/src/selector/matcher/node_data.rs
+++ b/crates/csskit_ast/src/selector/matcher/node_data.rs
@@ -1,13 +1,14 @@
 use super::PropertyValues;
 use css_ast::CssMetadata;
 use css_ast::VisitNode;
-use css_ast::visit::NodeId;
+use css_ast::visit::{NodeId, NodeKey};
 use css_lexer::Span;
 
 /// Node-specific data captured during visit (independent of sibling position).
 #[derive(Clone, Copy)]
 pub(crate) struct NodeData {
 	pub(crate) node_id: NodeId,
+	pub(crate) node_key: NodeKey,
 	pub(crate) span: Span,
 	pub(crate) metadata: CssMetadata,
 	pub(crate) properties: PropertyValues,
@@ -17,6 +18,13 @@ impl NodeData {
 	#[inline]
 	pub(crate) fn from_query(node: VisitNode) -> Self {
 		let node_id = node.node_id.expect("NodeData only stores queryable nodes");
-		Self { node_id, span: node.span, metadata: node.self_metadata(), properties: PropertyValues::from_query(&node) }
+		let node_key = node.key().expect("queryable nodes have identity");
+		Self {
+			node_id,
+			node_key,
+			span: node.span,
+			metadata: node.self_metadata(),
+			properties: PropertyValues::from_query(&node),
+		}
 	}
 }

--- a/crates/csskit_ast/src/selector/matcher/output.rs
+++ b/crates/csskit_ast/src/selector/matcher/output.rs
@@ -1,5 +1,5 @@
 use super::PropertyValues;
-use css_ast::NodeId;
+use css_ast::visit::{NodeId, NodeKey};
 use css_lexer::Span;
 use indexmap::IndexSet;
 use smallvec::SmallVec;
@@ -11,6 +11,8 @@ pub struct MatchOutput {
 	pub span: Span,
 	/// The type of the matched node.
 	pub node_id: NodeId,
+	/// Identity of the matched node, absent for synthetic matches.
+	pub node_key: Option<NodeKey>,
 	/// Property values for the matched node (used for diagnostic attr() function).
 	pub properties: PropertyValues,
 	/// Size of the matched node (number of children, declarations, selectors, etc.).

--- a/crates/csskit_ast/src/selector/matcher/selector_matcher.rs
+++ b/crates/csskit_ast/src/selector/matcher/selector_matcher.rs
@@ -3,8 +3,8 @@ use crate::{
 	QueryCombinator, QueryCompoundSelector, QueryFunctionalPseudoClass, QuerySelectorComponent, QuerySelectorList,
 	SelectorRequirements, SelectorSegment,
 };
-use css_ast::visit::{NodeId, Visitable};
-use css_ast::{CssMetadata, PropertyKind};
+use css_ast::PropertyKind;
+use css_ast::visit::{ErasedNode, NodeId};
 use css_parse::NodeWithMetadata;
 use smallvec::SmallVec;
 
@@ -91,7 +91,7 @@ impl<'a, 'b> SelectorMatcher<'a, 'b> {
 		}
 	}
 
-	pub fn run<T: Visitable + NodeWithMetadata<CssMetadata>>(mut self, root: &T) -> impl Iterator<Item = MatchOutput> {
+	pub fn run<T: ErasedNode + ?Sized>(mut self, root: &T) -> impl Iterator<Item = MatchOutput> {
 		let css_meta = root.metadata();
 		self.selectors.retain(|s| {
 			let m = s.metadata();
@@ -115,6 +115,7 @@ impl<'a, 'b> SelectorMatcher<'a, 'b> {
 					self.matches.insert(MatchOutput {
 						span: node.data.span,
 						node_id: node.data.node_id,
+						node_key: Some(node.data.node_key),
 						properties: node.data.properties,
 						size: node.data.metadata.size,
 						stat_snapshot: SmallVec::new(),
@@ -126,13 +127,9 @@ impl<'a, 'b> SelectorMatcher<'a, 'b> {
 		self.matches.into_iter()
 	}
 
-	fn collect_nodes<T: Visitable + NodeWithMetadata<CssMetadata>>(
-		&self,
-		root: &T,
-		buckets: &SelectorBuckets<'a, 'b>,
-	) -> Vec<TreeNode> {
+	fn collect_nodes<T: ErasedNode + ?Sized>(&self, root: &T, buckets: &SelectorBuckets<'a, 'b>) -> Vec<TreeNode> {
 		let mut collector = NodeCollector::new(buckets);
-		let _ = root.accept(&mut collector);
+		let _ = root.accept_dyn(&mut collector);
 		collector.finalize(self.needs_type_tracking)
 	}
 

--- a/crates/csskit_ast/src/selector/matcher/tests.rs
+++ b/crates/csskit_ast/src/selector/matcher/tests.rs
@@ -1,10 +1,42 @@
-use crate::assert_query;
-use css_ast::NodeId;
+use super::SelectorMatcher;
+use crate::{CsskitAtomSet, QuerySelectorList, assert_query};
+use css_ast::{NodeId, parse_root};
+use css_lexer::Lexer;
+use css_parse::{Arena, Parser};
 
 #[test]
 fn match_basic_types() {
 	assert_query!("a { color: red; }", "style-rule", 1, [NodeId::StyleRule]);
 	assert_query!("a, b { color: red; }", "selector-list", 1, [NodeId::SelectorList]);
+}
+
+#[test]
+fn erased_root_matches_preserve_node_identity() {
+	let arena = Arena::default();
+	let selector_arena = Arena::default();
+	let source = "a{}b{}";
+	let parsed = parse_root(NodeId::StyleSheet, &arena, source).expect("style-sheet is a root");
+	let root = parsed.root.expect("the source parses");
+
+	let selector_source = "style-rule";
+	let lexer = Lexer::new(&CsskitAtomSet::ATOMS, selector_source);
+	let selectors = Parser::new(&selector_arena, selector_source, lexer)
+		.parse_entirely::<QuerySelectorList>()
+		.output
+		.expect("the selector parses");
+
+	let match_keys = || {
+		SelectorMatcher::new(&selectors, selector_source, source)
+			.run(root)
+			.map(|matched| matched.node_key.expect("a matched node has identity"))
+			.collect::<std::vec::Vec<_>>()
+	};
+	let first_walk = match_keys();
+	let second_walk = match_keys();
+
+	assert_eq!(first_walk.len(), 2);
+	assert_ne!(first_walk[0], first_walk[1]);
+	assert_eq!(first_walk, second_walk);
 }
 
 #[test]


### PR DESCRIPTION
A node ID identifies its syntax kind but not a specific entry in a parsed tree.
Dynamic consumers (such as selector matcher) therefore cannot map selector
matches back to the concrete nodes they represent.

This change implements a NodeKey type which carries both the NodeId and the
position in the tree, so that selector matching can make use of the ErasedNode
object safe traits.
