### PR TITLE
node: Stop doubling wasm builds!

### DIFF
--- a/.mise-tasks/build-csskit-wasm
+++ b/.mise-tasks/build-csskit-wasm
@@ -13,31 +13,18 @@ cargo build \
   --no-default-features \
   --features serde
 
-# The node target is built into a scratch dir because wasm-bindgen drops its own package.json
-# alongside the output, which would clobber the package's.
-rm -rf "$NODE_OUT"
 wasm-bindgen \
   --out-dir "$NODE_OUT" \
   --target experimental-nodejs-module \
   "$REPO_ROOT/target/wasm32-unknown-unknown/release/csskit_wasm.wasm"
-
-mv "$NODE_OUT/csskit_wasm.js" "$PKG/wasm.js"
-mv "$NODE_OUT/csskit_wasm.d.ts" "$PKG/wasm.d.ts"
-mv "$NODE_OUT/csskit_wasm_bg.wasm" "$PKG/csskit_wasm_bg.wasm"
-mv "$NODE_OUT/csskit_wasm_bg.wasm.d.ts" "$PKG/csskit_wasm_bg.wasm.d.ts"
-rm -rf "$NODE_OUT"
 
 wasm-bindgen \
   --out-dir "$PKG/bundle" \
   --target bundler \
   "$REPO_ROOT/target/wasm32-unknown-unknown/release/csskit_wasm.wasm"
 
-wasm-opt \
-  --enable-bulk-memory \
-  --enable-nontrapping-float-to-int \
-  -Oz \
-  -o "$PKG/csskit_wasm_bg.wasm" \
-  "$PKG/csskit_wasm_bg.wasm"
+mv "$NODE_OUT/csskit_wasm.js" "$PKG/bundle/csskit_wasm_node.js"
+rm -rf "$NODE_OUT"
 
 wasm-opt \
   --enable-bulk-memory \
@@ -45,3 +32,6 @@ wasm-opt \
   -Oz \
   -o "$PKG/bundle/csskit_wasm_bg.wasm" \
   "$PKG/bundle/csskit_wasm_bg.wasm"
+
+rm -f "$PKG/wasm.js" "$PKG/wasm.d.ts" "$PKG/csskit_wasm_bg.wasm.d.ts"
+rm -f "$PKG/csskit_wasm_bg.wasm"

--- a/packages/csskit/bundle.js
+++ b/packages/csskit/bundle.js
@@ -3,9 +3,9 @@
 // This entry needs no native addon, thus it runs where wasm runs. It has no object model: `parse`
 // gives a serialised AST and diagnostics. For the object model use the `csskit` entry.
 
-import { parse_error_report } from './wasm.js';
+import { parse_error_report } from './bundle/csskit_wasm_node.js';
 
-export { format, lex, minify, parse } from './wasm.js';
+export { format, lex, minify, parse } from './bundle/csskit_wasm_node.js';
 
 /** Render a human-readable parse-error report for `source`. */
 export function parseErrorReport(source) {

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -44,10 +44,6 @@
         "./index.d.ts",
         "./bundle.js",
         "./bundle.d.ts",
-        "./wasm.js",
-        "./wasm.d.ts",
-        "./csskit_wasm_bg.wasm",
-        "./csskit_wasm_bg.wasm.d.ts",
         "./bundle"
     ],
     "optionalDependencies": {


### PR DESCRIPTION
Exploring why the node package is so large I realised we... we have two
copies of the WASM build.

This removes one of them! Package sizes massively shrunk!
