### PR TITLE
build: optimise for size, not speed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,9 +140,8 @@ insta.opt-level = 3
 similar.opt-level = 3
 
 [profile.release]
-# Configurations explicitly listed here for clarity.
-# Using the best options for performance.
-opt-level = 3
+# Optimise published artefacts for size.
+opt-level = "s"
 debug = false
 strip = "symbols"
 lto = "fat"


### PR DESCRIPTION
We're now sufficiently fast, but also the binaries are quite large, so I
think we can move to size based optimisations.
