### PR TITLE
build: add napi through local dependencies, not mise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           key: release-${{ matrix.target }}
-          tools: rust node npm npm:@napi-rs/cli
+          tools: rust node npm
           components: ""
 
       - name: Rustup target
@@ -73,9 +73,13 @@ jobs:
       - name: Build Binary
         run: cargo build --release --target ${{ matrix.target }} -p csskit
 
+      - name: Install native addon dependencies
+        working-directory: crates/csskit_napi
+        run: npm ci
+
       - name: Build native addon
         working-directory: crates/csskit_napi
-        run: napi build --release --target ${{ matrix.target }} --features napi
+        run: npm run build -- --target ${{ matrix.target }}
 
       - name: Stage native addon
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -297,7 +297,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           key: test-napi
-          tools: rust node npm npm:@napi-rs/cli
+          tools: rust node npm
           components: ""
 
       - name: Build addon and run native object model tests

--- a/.mise.toml
+++ b/.mise.toml
@@ -11,7 +11,6 @@ hyperfine = "latest"
 "cargo:wasm-bindgen-cli" = "0.2.127"
 "aqua:WebAssembly/binaryen" = "131"
 "cargo:cargo-fuzz" = "0.13.2"
-"npm:@napi-rs/cli" = "3.7.4"
 
 [tasks.clean]
 confirm = 'Are you sure?'
@@ -53,7 +52,8 @@ sources = [
 ]
 outputs = ["{{config_root}}/packages/csskit/csskit.node"]
 run = [
-  "napi build --features napi",
+  "npm ci",
+  "npm run build:debug",
   "cp csskit_napi.node {{config_root}}/packages/csskit/csskit.node",
 ]
 


### PR DESCRIPTION
Looks like for windows builds, they need an optional obug dependency.
This should trigger that to end up in the lockfile.
