### PR TITLE
benchmarks: fix lightningcss

### DIFF
--- a/.mise-tasks/.benchmark-compare/package.json
+++ b/.mise-tasks/.benchmark-compare/package.json
@@ -8,5 +8,8 @@
     "cssnano": "^8.0.0",
     "postcss-cli": "^11.0.1",
     "esbuild": "^0.28.0"
+  },
+  "allowScripts": {
+    "lightningcss-cli@1.33.0": true
   }
 }


### PR DESCRIPTION
The upgrade to npm 12 blocks install scripts, but lightningcss-cli needs the
postinstall script to replace its binary with the native one.

This allows lightningcss to run it's postinstall, meaning it'll work again and
we can do benchmark comparisons on it again.
