### PR TITLE
csskit_napi: Add binary to cargo.toml

### DIFF
--- a/crates/csskit_napi/Cargo.toml
+++ b/crates/csskit_napi/Cargo.toml
@@ -16,6 +16,11 @@ workspace = true
 bench = false
 crate-type = ["cdylib", "rlib"]
 
+[[bin]]
+name = "generate_node_classes"
+path = "src/bin/generate_node_classes.rs"
+bench = false
+
 [dependencies]
 css_ast = { workspace = true }
 css_lexer = { workspace = true }


### PR DESCRIPTION
Without this the nightly benchmark script seems to be failing.
