### PR TITLE
release: re-add `@release comments`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/*"]
 exclude = ["packages/csskit_zed"]
 
 [workspace.package]
-version = "0.0.30"
+version = "0.0.31"                                     # @release
 authors = ["Keith Cirkel (https://keithcirkel.co.uk)"]
 edition = "2024"
 description = "Refreshing CSS!"
@@ -19,29 +19,29 @@ warnings = { level = "deny", priority = -1 }
 unsafe_code = "deny"
 
 [workspace.dependencies]
-chromashift = { path = "crates/chromashift", version = "0.0.30" }
-css_ast = { path = "crates/css_ast", version = "0.0.30" }
-css_feature_data = { path = "crates/css_feature_data", version = "0.0.30" }
-css_lexer = { path = "crates/css_lexer", version = "0.0.30" }
-css_parse = { path = "crates/css_parse", version = "0.0.30" }
-css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.30" }
-csskit = { path = "crates/csskit", version = "0.0.30" }
-csskit_arena = { path = "crates/csskit_arena", version = "0.0.30" }
-csskit_ast = { path = "crates/csskit_ast", version = "0.0.30" }
-csskit_derives = { path = "crates/csskit_derives", version = "0.0.30" }
-csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.30" }
-csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.30" }
-csskit_napi = { path = "crates/csskit_napi", version = "0.0.30" }
-csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.30" }
-csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.30" }
-csskit_spec_generator = { path = "tools/csskit_spec_generator", version = "0.0.0" }
-csskit_transform = { path = "crates/csskit_transform", version = "0.0.30" }
-derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.30" }
-bytescan = { path = "crates/bytescan", version = "0.0.30" }
-source_tools = { path = "crates/source_tools", version = "0.0.30" }
-stable_type_layout = { package = "stable-type-layout", path = "crates/stable_type_layout", version = "0.0.30" }
-stable_type_layout_derive = { package = "stable-type-layout-derive", path = "crates/stable_type_layout_derive", version = "0.0.30" }
-visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.30" }
+chromashift = { path = "crates/chromashift", version = "0.0.31" }                                                                    # @release
+css_ast = { path = "crates/css_ast", version = "0.0.31" }                                                                            # @release
+css_feature_data = { path = "crates/css_feature_data", version = "0.0.31" }                                                          # @release
+css_lexer = { path = "crates/css_lexer", version = "0.0.31" }                                                                        # @release
+css_parse = { path = "crates/css_parse", version = "0.0.31" }                                                                        # @release
+css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.31" }                                    # @release
+csskit = { path = "crates/csskit", version = "0.0.31" }                                                                              # @release
+csskit_arena = { path = "crates/csskit_arena", version = "0.0.31" }                                                                  # @release
+csskit_ast = { path = "crates/csskit_ast", version = "0.0.31" }                                                                      # @release
+csskit_derives = { path = "crates/csskit_derives", version = "0.0.31" }                                                              # @release
+csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.31" }                                                          # @release
+csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.31" }                                                                      # @release
+csskit_napi = { path = "crates/csskit_napi", version = "0.0.31" }                                                                    # @release
+csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.31" }                                                        # @release
+csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.31" }                                                  # @release
+csskit_spec_generator = { path = "tools/csskit_spec_generator", version = "0.0.0" }                                                  # @release
+csskit_transform = { path = "crates/csskit_transform", version = "0.0.31" }                                                          # @release
+derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.31" }                                                            # @release
+bytescan = { path = "crates/bytescan", version = "0.0.31" }                                                                          # @release
+source_tools = { path = "crates/source_tools", version = "0.0.31" }                                                                  # @release
+stable_type_layout = { package = "stable-type-layout", path = "crates/stable_type_layout", version = "0.0.31" }                      # @release
+stable_type_layout_derive = { package = "stable-type-layout-derive", path = "crates/stable_type_layout_derive", version = "0.0.31" } # @release
+visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.31" }                                              # @release
 # Memory
 allocator-api2 = { version = "0.4.0" }
 inventory = { version = "0.3.24" }


### PR DESCRIPTION
These were accidentally dropped in https://github.com/csskit/csskit/pull/1437,
but they're needed for release-automation.

For some reason this was meant to be in
https://github.com/csskit/csskit/pull/1474 but somehow that PR got replaced with
an update to css-minify-tests... I wonder if that was a github bug? :'(