### PR TITLE
Release v0.0.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,44 @@
+## [0.0.32] - 2026-09-05
+
+### Css_ast
+- csskit_spec_generator: Ensure longhand emission is ordered (#1478) ([#1478](https://github.com/csskit/csskit/pull/1478))
+- Regenerate css_ast/src/values from csswg drafts (#1480) ([#1480](https://github.com/csskit/csskit/pull/1480))
+- csskit_spec_generator/csskit_derives/csskit_ast: Rewrite shorthand/longhand meta (#1486) ([#1486](https://github.com/csskit/csskit/pull/1486))
+- css_lexer: keep the `--` of a dashed ident in its atom (#1489) ([#1489](https://github.com/csskit/csskit/pull/1489))
+- css_parse: compare SemanticEq nodes through their source text (#1490) ([#1490](https://github.com/csskit/csskit/pull/1490))
+- csskit_derives/css_parse: rewrite derive(ToSpan) (#1492) ([#1492](https://github.com/csskit/csskit/pull/1492))
+- csskit_derives: rewrite derive(Parse) (#1499) ([#1499](https://github.com/csskit/csskit/pull/1499))
+- css_ast: Drop mathml extended elements (#1502) ([#1502](https://github.com/csskit/csskit/pull/1502))
+
+
+### Css_lexer
+- css_lexer: DRY up token parsing with ParsedChars iterator (#1487) ([#1487](https://github.com/csskit/csskit/pull/1487))
+- css_lexer: Mark KindSet::contains const (#1491) ([#1491](https://github.com/csskit/csskit/pull/1491))
+
+
+### Csskit
+- chore(deps): update dependencies (patch) (#1482) ([#1482](https://github.com/csskit/csskit/pull/1482))
+
+
+### Csskit_derives
+- csskit_derives: rewrite derive(ToCursors) (#1493) ([#1493](https://github.com/csskit/csskit/pull/1493))
+- csskit_derives: rewrite derive(SemanticEq) (#1494) ([#1494](https://github.com/csskit/csskit/pull/1494))
+- csskit_derives: rewrite derive(Visitable) (#1495) ([#1495](https://github.com/csskit/csskit/pull/1495))
+- csskit_derives: derive(NodeWithMetadata) metadata body (#1496) ([#1496](https://github.com/csskit/csskit/pull/1496))
+- csskit_derives: rewrite derive(Peek) (#1497) ([#1497](https://github.com/csskit/csskit/pull/1497))
+- csskit_derives: drop synstructure (#1498) ([#1498](https://github.com/csskit/csskit/pull/1498))
+
+
+### Csskit_vscode
+- chore(deps): update dependency @types/vscode to v1.134.0 (#1483) ([#1483](https://github.com/csskit/csskit/pull/1483))
+- chore(deps): update dependency oxlint to v1.79.0 (#1485) ([#1485](https://github.com/csskit/csskit/pull/1485))
+- chore(deps): update dependency mocha to v12 (#1488) ([#1488](https://github.com/csskit/csskit/pull/1488))
+
 ## [0.0.31] - 2026-08-28
+
+### Other Changes
+- Release: re-add `@release comments` (#1475) ([#1475](https://github.com/csskit/csskit/pull/1475))
+
 
 ### Bytescan
 - bytescan/css_lexer: Factor out SIMD scanning into new library (#1466) ([#1466](https://github.com/csskit/csskit/pull/1466))
@@ -16,9 +56,14 @@
 - css_ast/csskit_spec_generator: Complete shorthand/longhand metadata (#1470) ([#1470](https://github.com/csskit/csskit/pull/1470))
 
 
+### Css_parse
+- css_parse/csskit_arena/source_tools: Move Vec/Box/String into csskit_arena (#1473) ([#1473](https://github.com/csskit/csskit/pull/1473))
+
+
 ### Csskit
 - csskit: separate parse/check failures, add find --group (#1460) ([#1460](https://github.com/csskit/csskit/pull/1460))
 - chore(deps): update dependencies (patch) (#1458) ([#1458](https://github.com/csskit/csskit/pull/1458))
+- Release v0.0.31 (#1456) ([#1456](https://github.com/csskit/csskit/pull/1456))
 
 
 ### Csskit_arena
@@ -28,6 +73,7 @@
 ### Csskit_napi
 - chore(deps): update dependency @napi-rs/cli to v3.8.6 (#1459) ([#1459](https://github.com/csskit/csskit/pull/1459))
 - csskit_napi: Add binary to cargo.toml (#1468) ([#1468](https://github.com/csskit/csskit/pull/1468))
+- csskit_napi: Don't publish to registry (#1477) ([#1477](https://github.com/csskit/csskit/pull/1477))
 
 
 ### Csskit_proc_macro
@@ -38,6 +84,8 @@
 - coverage: update css-minify-tests (#1469) ([#1469](https://github.com/csskit/csskit/pull/1469))
 - csskit_transform: Introduce RemoveOveriddenDeclarations transform (#1471) ([#1471](https://github.com/csskit/csskit/pull/1471))
 - csskit_transform: Introduce ReduceShorthandValues (#1472) ([#1472](https://github.com/csskit/csskit/pull/1472))
+- release: re-add `@release comments` (#1474) ([#1474](https://github.com/csskit/csskit/pull/1474))
+- coverage: update css-minify-tests (#1476) ([#1476](https://github.com/csskit/csskit/pull/1476))
 
 ## [0.0.30] - 2026-08-23
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/*"]
 exclude = ["packages/csskit_zed"]
 
 [workspace.package]
-version = "0.0.31"                                     # @release
+version = "0.0.32"                                     # @release
 authors = ["Keith Cirkel (https://keithcirkel.co.uk)"]
 edition = "2024"
 description = "Refreshing CSS!"
@@ -19,29 +19,29 @@ warnings = { level = "deny", priority = -1 }
 unsafe_code = "deny"
 
 [workspace.dependencies]
-chromashift = { path = "crates/chromashift", version = "0.0.31" }                                                                    # @release
-css_ast = { path = "crates/css_ast", version = "0.0.31" }                                                                            # @release
-css_feature_data = { path = "crates/css_feature_data", version = "0.0.31" }                                                          # @release
-css_lexer = { path = "crates/css_lexer", version = "0.0.31" }                                                                        # @release
-css_parse = { path = "crates/css_parse", version = "0.0.31" }                                                                        # @release
-css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.31" }                                    # @release
-csskit = { path = "crates/csskit", version = "0.0.31" }                                                                              # @release
-csskit_arena = { path = "crates/csskit_arena", version = "0.0.31" }                                                                  # @release
-csskit_ast = { path = "crates/csskit_ast", version = "0.0.31" }                                                                      # @release
-csskit_derives = { path = "crates/csskit_derives", version = "0.0.31" }                                                              # @release
-csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.31" }                                                          # @release
-csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.31" }                                                                      # @release
-csskit_napi = { path = "crates/csskit_napi", version = "0.0.31" }                                                                    # @release
-csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.31" }                                                        # @release
-csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.31" }                                                  # @release
-csskit_spec_generator = { path = "tools/csskit_spec_generator", version = "0.0.0" }                                                  # @release
-csskit_transform = { path = "crates/csskit_transform", version = "0.0.31" }                                                          # @release
-derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.31" }                                                            # @release
-bytescan = { path = "crates/bytescan", version = "0.0.31" }                                                                          # @release
-source_tools = { path = "crates/source_tools", version = "0.0.31" }                                                                  # @release
-stable_type_layout = { package = "stable-type-layout", path = "crates/stable_type_layout", version = "0.0.31" }                      # @release
-stable_type_layout_derive = { package = "stable-type-layout-derive", path = "crates/stable_type_layout_derive", version = "0.0.31" } # @release
-visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.31" }                                              # @release
+chromashift = { path = "crates/chromashift", version = "0.0.32" }                                                                    # @release
+css_ast = { path = "crates/css_ast", version = "0.0.32" }                                                                            # @release
+css_feature_data = { path = "crates/css_feature_data", version = "0.0.32" }                                                          # @release
+css_lexer = { path = "crates/css_lexer", version = "0.0.32" }                                                                        # @release
+css_parse = { path = "crates/css_parse", version = "0.0.32" }                                                                        # @release
+css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.32" }                                    # @release
+csskit = { path = "crates/csskit", version = "0.0.32" }                                                                              # @release
+csskit_arena = { path = "crates/csskit_arena", version = "0.0.32" }                                                                  # @release
+csskit_ast = { path = "crates/csskit_ast", version = "0.0.32" }                                                                      # @release
+csskit_derives = { path = "crates/csskit_derives", version = "0.0.32" }                                                              # @release
+csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.32" }                                                          # @release
+csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.32" }                                                                      # @release
+csskit_napi = { path = "crates/csskit_napi", version = "0.0.32" }                                                                    # @release
+csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.32" }                                                        # @release
+csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.32" }                                                  # @release
+csskit_spec_generator = { path = "tools/csskit_spec_generator", version = "0.0.32" }                                                  # @release
+csskit_transform = { path = "crates/csskit_transform", version = "0.0.32" }                                                          # @release
+derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.32" }                                                            # @release
+bytescan = { path = "crates/bytescan", version = "0.0.32" }                                                                          # @release
+source_tools = { path = "crates/source_tools", version = "0.0.32" }                                                                  # @release
+stable_type_layout = { package = "stable-type-layout", path = "crates/stable_type_layout", version = "0.0.32" }                      # @release
+stable_type_layout_derive = { package = "stable-type-layout-derive", path = "crates/stable_type_layout_derive", version = "0.0.32" } # @release
+visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.32" }                                              # @release
 # Memory
 allocator-api2 = { version = "0.4.0" }
 inventory = { version = "0.3.24" }

--- a/packages/csskit-darwin-arm64/package.json
+++ b/packages/csskit-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-arm64",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "description": "Refreshing CSS - macOS arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-darwin-x64/package.json
+++ b/packages/csskit-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-x64",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "description": "Refreshing CSS - macOS x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-arm64/package.json
+++ b/packages/csskit-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-arm64",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "description": "Refreshing CSS - Linux arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-x64/package.json
+++ b/packages/csskit-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-x64",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "description": "Refreshing CSS - Linux x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-arm64/package.json
+++ b/packages/csskit-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-arm64",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "description": "Refreshing CSS - Windows arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-x64/package.json
+++ b/packages/csskit-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-x64",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "description": "Refreshing CSS - Windows x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit/package-lock.json
+++ b/packages/csskit/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "csskit",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "csskit",
-            "version": "0.0.31",
+            "version": "0.0.32",
             "license": "MIT",
             "dependencies": {
                 "csskit-darwin-arm64": "^0.0.31",

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "description": "Refreshing CSS",
     "keywords": [],
     "repository": "https://github.com/csskit/csskit",
@@ -47,11 +47,11 @@
         "./bundle"
     ],
     "optionalDependencies": {
-        "csskit-darwin-arm64": "0.0.31",
-        "csskit-darwin-x64": "0.0.31",
-        "csskit-linux-arm64": "0.0.31",
-        "csskit-linux-x64": "0.0.31",
-        "csskit-win32-arm64": "0.0.31",
-        "csskit-win32-x64": "0.0.31"
+        "csskit-darwin-arm64": "0.0.32",
+        "csskit-darwin-x64": "0.0.32",
+        "csskit-linux-arm64": "0.0.32",
+        "csskit-linux-x64": "0.0.32",
+        "csskit-win32-arm64": "0.0.32",
+        "csskit-win32-x64": "0.0.32"
     }
 }


### PR DESCRIPTION
## [0.0.32] - 2026-09-19

### Atom_set
- atom_set: Split & separately publish `atom_set` (#1521) ([#1521](https://github.com/csskit/csskit/pull/1521))


### Css_ast
- csskit_spec_generator: Ensure longhand emission is ordered (#1478) ([#1478](https://github.com/csskit/csskit/pull/1478))
- Regenerate css_ast/src/values from csswg drafts (#1480) ([#1480](https://github.com/csskit/csskit/pull/1480))
- csskit_spec_generator/csskit_derives/csskit_ast: Rewrite shorthand/longhand meta (#1486) ([#1486](https://github.com/csskit/csskit/pull/1486))
- css_lexer: keep the `--` of a dashed ident in its atom (#1489) ([#1489](https://github.com/csskit/csskit/pull/1489))
- css_parse: compare SemanticEq nodes through their source text (#1490) ([#1490](https://github.com/csskit/csskit/pull/1490))
- csskit_derives/css_parse: rewrite derive(ToSpan) (#1492) ([#1492](https://github.com/csskit/csskit/pull/1492))
- csskit_derives: rewrite derive(Parse) (#1499) ([#1499](https://github.com/csskit/csskit/pull/1499))
- css_ast: Drop mathml extended elements (#1502) ([#1502](https://github.com/csskit/csskit/pull/1502))
- csskit_spec_generator/csskit_derives: more shorthands metadata improvements (#1504) ([#1504](https://github.com/csskit/csskit/pull/1504))
- css_parse: move AttributeOperator down from css_ast (#1514) ([#1514](https://github.com/csskit/csskit/pull/1514))


### Css_lexer
- css_lexer: DRY up token parsing with ParsedChars iterator (#1487) ([#1487](https://github.com/csskit/csskit/pull/1487))
- css_lexer: Mark KindSet::contains const (#1491) ([#1491](https://github.com/csskit/csskit/pull/1491))


### Csskit
- chore(deps): update dependencies (patch) (#1482) ([#1482](https://github.com/csskit/csskit/pull/1482))


### Csskit_derives
- csskit_derives: rewrite derive(ToCursors) (#1493) ([#1493](https://github.com/csskit/csskit/pull/1493))
- csskit_derives: rewrite derive(SemanticEq) (#1494) ([#1494](https://github.com/csskit/csskit/pull/1494))
- csskit_derives: rewrite derive(Visitable) (#1495) ([#1495](https://github.com/csskit/csskit/pull/1495))
- csskit_derives: derive(NodeWithMetadata) metadata body (#1496) ([#1496](https://github.com/csskit/csskit/pull/1496))
- csskit_derives: rewrite derive(Peek) (#1497) ([#1497](https://github.com/csskit/csskit/pull/1497))
- csskit_derives: drop synstructure (#1498) ([#1498](https://github.com/csskit/csskit/pull/1498))


### Csskit_napi
- chore(deps): update dependency @napi-rs/cli to v3.9.0 (#1508) ([#1508](https://github.com/csskit/csskit/pull/1508))


### Csskit_transform
- coverage: update css-minify-tests (#1505) ([#1505](https://github.com/csskit/csskit/pull/1505))


### Csskit_vscode
- chore(deps): update dependency @types/vscode to v1.134.0 (#1483) ([#1483](https://github.com/csskit/csskit/pull/1483))
- chore(deps): update dependency oxlint to v1.79.0 (#1485) ([#1485](https://github.com/csskit/csskit/pull/1485))
- chore(deps): update dependency mocha to v12 (#1488) ([#1488](https://github.com/csskit/csskit/pull/1488))
- chore(deps): update dependency @types/vscode to v1.136.0 (#1510) ([#1510](https://github.com/csskit/csskit/pull/1510))
- chore(deps): update dependency oxlint to v1.81.0 (#1513) ([#1513](https://github.com/csskit/csskit/pull/1513))
- chore(deps): update dependency oxlint to v1.82.0 (#1520) ([#1520](https://github.com/csskit/csskit/pull/1520))
- chore(deps): update dependency @types/vscode to v1.137.0 (#1516) ([#1516](https://github.com/csskit/csskit/pull/1516))