### PR TITLE
css_lexer: keep the `--` of a dashed ident in its atom

### DIFF
--- a/coverage/basic/many-rules.json.2.txt
+++ b/coverage/basic/many-rules.json.2.txt
@@ -17,7 +17,7 @@ check coverage/basic/warn-many-rules.cks --format json
       ],
       "stats": [
         {
-          "name": "rule-count",
+          "name": "--rule-count",
           "value": 3,
           "unit": null
         }
@@ -26,7 +26,7 @@ check coverage/basic/warn-many-rules.cks --format json
   ],
   "aggregate_stats": [
     {
-      "name": "rule-count",
+      "name": "--rule-count",
       "value": 3,
       "unit": null
     }

--- a/coverage/basic/rule.json.3.txt
+++ b/coverage/basic/rule.json.3.txt
@@ -8,7 +8,7 @@ check coverage/basic/basic-stats.cks --format json
       "diagnostics": [],
       "stats": [
         {
-          "name": "total-rules",
+          "name": "--total-rules",
           "value": 1,
           "unit": null
         }
@@ -17,7 +17,7 @@ check coverage/basic/basic-stats.cks --format json
   ],
   "aggregate_stats": [
     {
-      "name": "total-rules",
+      "name": "--total-rules",
       "value": 1,
       "unit": null
     }

--- a/crates/css_ast/src/functions/math_function.rs
+++ b/crates/css_ast/src/functions/math_function.rs
@@ -896,7 +896,7 @@ pub enum RoundingStrategy {
 mod tests {
 	use super::*;
 	use crate::{CssAtomSet, Length};
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	type LengthMathFunction<'a> = MathFunction<'a, Length>;
 
@@ -999,5 +999,6 @@ mod tests {
 		assert_parse_error!(CssAtomSet::ATOMS, LengthMathFunction, "calc()");
 		assert_parse_error!(CssAtomSet::ATOMS, LengthMathFunction, "clamp(1px, 2px)");
 		assert_parse_error!(CssAtomSet::ATOMS, LengthMathFunction, "calc(1px + 10%)");
+		assert_peek_false!(CssAtomSet::ATOMS, LengthMathFunction, "--calc(1px)");
 	}
 }

--- a/crates/css_lexer/src/private.rs
+++ b/crates/css_lexer/src/private.rs
@@ -228,8 +228,7 @@ impl<'a> ByteCursor<'a> {
 					// SAFETY: the fast path only scans ASCII ident bytes, which are valid UTF-8.
 					let ident_str = unsafe { std::str::from_utf8_unchecked(&bytes[..i]) };
 					self.advance_n(i);
-					let atom_bits =
-						if dashed_ident { atoms.str_to_bits(&ident_str[2..]) } else { atoms.str_to_bits(ident_str) };
+					let atom_bits = atoms.str_to_bits(ident_str);
 					return (
 						len,
 						contains_non_lower_ascii,
@@ -261,15 +260,14 @@ impl<'a> ByteCursor<'a> {
 				let next = self.peek_char_at(1);
 				self.pos += 1;
 				len += 1;
+				small_ident.append(c);
 				if next == '-' {
 					self.pos += 1;
 					len += 1;
 					dashed_ident = true;
-					// Reset the small_ident buffer as dashed_idents always begin with two dashes.
-					small_ident = SmallStrBuf::<MAX_SMALL_IDENT_SIZE>::new();
+					small_ident.append(next);
 					continue;
 				}
-				small_ident.append(c);
 			} else if is_ident(c) {
 				let clen = c.len_utf8();
 				self.advance_n(clen);
@@ -305,10 +303,6 @@ impl<'a> ByteCursor<'a> {
 		// so it should be used over the str slice as it will have parsed escape sequences
 		let (is_url, atom_bits) = if let Some(ident) = small_ident.as_str() {
 			(is_url_ident(ident), atoms.str_to_bits(ident))
-		} else if dashed_ident {
-			// For dashed identifiers, skip the leading "--" for atom lookup
-			let slice = &str[2..len as usize];
-			(false, atoms.str_to_bits(slice))
 		} else {
 			// We intentionally make the small_ident buffer large enough to capture the `url` ident an unescape it,
 			// so this branch would never be hit with a valid URL, we can guarantee this ident is not a URL.

--- a/crates/css_lexer/tests/tests.rs
+++ b/crates/css_lexer/tests/tests.rs
@@ -1458,11 +1458,16 @@ fn tokenizes_atoms_correctly() {
 
 	let mut lexer = Lexer::new(&CUSTOM_ATOMS, "--baz");
 	let token = lexer.advance();
-	assert_eq!(CustomAtom::from_bits(token.atom_bits()), CustomAtom::Baz);
+	assert!(token.is_dashed_ident());
+	assert_eq!(token.atom_bits(), 0);
 
 	let mut lexer = Lexer::new(&CUSTOM_ATOMS, "18foo");
 	let token = lexer.advance();
 	assert_eq!(CustomAtom::from_bits(token.atom_bits()), CustomAtom::Foo);
+
+	let mut lexer = Lexer::new(&CUSTOM_ATOMS, "18--foo");
+	let token = lexer.advance();
+	assert_eq!(token.atom_bits(), 0);
 }
 
 #[test]

--- a/crates/csskit/src/commands/check.rs
+++ b/crates/csskit/src/commands/check.rs
@@ -276,7 +276,7 @@ impl Check {
 							StatType::Bytes => " bytes",
 							StatType::Lines => " lines",
 						};
-						println!("  --{}: {}{}", name, count, type_label);
+						println!("  {}: {}{}", name, count, type_label);
 					}
 				}
 			}
@@ -293,7 +293,7 @@ fn print_stats_text(stats: &[StatRecord]) {
 	println!("\nStatistics:");
 	for stat in stats {
 		let unit = stat.unit.map(|u| format!(" {u}")).unwrap_or_default();
-		println!("  --{}: {}{}", stat.name, stat.value, unit);
+		println!("  {}: {}{}", stat.name, stat.value, unit);
 	}
 }
 

--- a/crates/csskit_ast/src/collector/tests.rs
+++ b/crates/csskit_ast/src/collector/tests.rs
@@ -36,7 +36,7 @@ fn test_basic() {
 		.baz {}
 	"#;
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let a = CsskitAtomSet::get_dyn_set().atom_from_str("total-rules");
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("--total-rules");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
 }
@@ -53,7 +53,7 @@ fn test_implicit_counter() {
 		.baz {}
 	"#;
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let a = CsskitAtomSet::get_dyn_set().atom_from_str("total-rules");
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("--total-rules");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
 }
@@ -68,7 +68,7 @@ fn test_bytes() {
 	let css_source = ".a{}.bb{}";
 	let (counters, diagnostics) = run(&alloc, source, css_source);
 	// .a{} = 4 bytes, .bb{} = 5 bytes, total = 9 bytes
-	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rule-bytes");
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("--rule-bytes");
 	assert_eq!(counters.get(&a), Some(&(StatType::Bytes, 9)));
 	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
 }
@@ -86,7 +86,7 @@ fn test_lines() {
 }
 .bb{}";
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rule-lines");
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("--rule-lines");
 	assert_eq!(counters.get(&a), Some(&(StatType::Lines, 4)));
 	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
 }
@@ -182,7 +182,7 @@ fn test_diagnostics_with_stat_reference() {
 	let css_source = ".a {} .b {} .c {}";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let a = CsskitAtomSet::get_dyn_set().atom_from_str("total");
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("--total");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
 
 	assert_eq!(diagnostics.len(), 3);
@@ -204,7 +204,7 @@ fn test_when_rule_true_condition() {
 	let css_source = ".a {} .b {} .c {}";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("--rules");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 1);
 	assert_eq!(diagnostics[0].message, "Too many rules: 3");
@@ -224,7 +224,7 @@ fn test_when_rule_false_condition() {
 	let css_source = ".a {} .b {}";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("--rules");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 2)));
 	assert_eq!(diagnostics.len(), 0);
 }
@@ -245,8 +245,8 @@ fn test_when_rule_with_nested_selector() {
 	let css_source = ".a {} #foo {} .b {}";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
-	let ids = CsskitAtomSet::get_dyn_set().atom_from_str("id-selectors");
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("--rules");
+	let ids = CsskitAtomSet::get_dyn_set().atom_from_str("--id-selectors");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
 	assert_eq!(counters.get(&ids), Some(&(StatType::Counter, 1)));
 	assert_eq!(diagnostics.len(), 1);
@@ -286,7 +286,7 @@ fn test_nested_if_in_style_rule() {
 	let css_source = ".a {} .b {} .c {}";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let foo = CsskitAtomSet::get_dyn_set().atom_from_str("foo");
+	let foo = CsskitAtomSet::get_dyn_set().atom_from_str("--foo");
 	assert_eq!(counters.get(&foo), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 1);
 	assert_eq!(diagnostics[0].message, "bar");
@@ -311,7 +311,7 @@ fn test_nested_selector_in_style_rule() {
 	let (counters, diagnostics) = run(&alloc, source, css_source);
 
 	// Verify stats - only color declarations should be counted
-	let color_decls = CsskitAtomSet::get_dyn_set().atom_from_str("color-decls");
+	let color_decls = CsskitAtomSet::get_dyn_set().atom_from_str("--color-decls");
 	assert_eq!(counters.get(&color_decls), Some(&(StatType::Counter, 2)));
 
 	// Verify diagnostics for each color declaration
@@ -338,8 +338,8 @@ fn test_nested_if_with_combined_conditions() {
 	let css_source = ".a { color: red; } .b { background: blue; font-size: 12px; }";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
-	let decls = CsskitAtomSet::get_dyn_set().atom_from_str("decls");
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("--rules");
+	let decls = CsskitAtomSet::get_dyn_set().atom_from_str("--decls");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 2)));
 	assert_eq!(counters.get(&decls), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 1);
@@ -366,8 +366,8 @@ fn test_conditional_nested_selector() {
 	let css_source = ".a { color: red; } .b { background: blue; } .c { color: green; }";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
-	let color_decls = CsskitAtomSet::get_dyn_set().atom_from_str("color-decls");
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("--rules");
+	let color_decls = CsskitAtomSet::get_dyn_set().atom_from_str("--color-decls");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
 	assert_eq!(counters.get(&color_decls), Some(&(StatType::Counter, 2)));
 	assert_eq!(diagnostics.len(), 2);
@@ -404,9 +404,9 @@ fn test_reactive_conditional_chain() {
 	let css_source = ".a {} .b {} .c {}";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
-	let warnings = CsskitAtomSet::get_dyn_set().atom_from_str("warnings");
-	let critical = CsskitAtomSet::get_dyn_set().atom_from_str("critical");
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("--rules");
+	let warnings = CsskitAtomSet::get_dyn_set().atom_from_str("--warnings");
+	let critical = CsskitAtomSet::get_dyn_set().atom_from_str("--critical");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
 	assert_eq!(counters.get(&warnings), Some(&(StatType::Counter, 3)));
 	assert_eq!(counters.get(&critical), Some(&(StatType::Counter, 3)));
@@ -440,8 +440,8 @@ fn test_nested_not_condition_preserved() {
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
 
-	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
-	let nested = CsskitAtomSet::get_dyn_set().atom_from_str("nested-matches");
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("--rules");
+	let nested = CsskitAtomSet::get_dyn_set().atom_from_str("--nested-matches");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
 	assert_eq!(counters.get(&nested), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 3);
@@ -467,8 +467,8 @@ fn test_nested_not_condition_unmatched() {
 	let css_source = ".a {} .b {} .c {}";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
-	let nested = CsskitAtomSet::get_dyn_set().atom_from_str("nested-matches");
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("--rules");
+	let nested = CsskitAtomSet::get_dyn_set().atom_from_str("--nested-matches");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
 	assert_eq!(counters.get(&nested), Some(&(StatType::Counter, 0)));
 	assert_eq!(diagnostics.len(), 0);
@@ -489,8 +489,8 @@ fn test_cycles_direct() {
 	let css_source = ".x {} .y {} .z {}";
 
 	let (counters, _diagnostics) = run(&alloc, source, css_source);
-	let a = CsskitAtomSet::get_dyn_set().atom_from_str("a");
-	let b = CsskitAtomSet::get_dyn_set().atom_from_str("b");
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("--a");
+	let b = CsskitAtomSet::get_dyn_set().atom_from_str("--b");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 6))); // 3 unconditional + 3 from second @when
 	assert_eq!(counters.get(&b), Some(&(StatType::Counter, 3))); // 3 from first @when
 }
@@ -513,9 +513,9 @@ fn test_cycle_prevention_indirect() {
 	let css_source = ".x {} .y {}";
 
 	let (counters, _diagnostics) = run(&alloc, source, css_source);
-	let a = CsskitAtomSet::get_dyn_set().atom_from_str("a");
-	let b = CsskitAtomSet::get_dyn_set().atom_from_str("b");
-	let c = CsskitAtomSet::get_dyn_set().atom_from_str("c");
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("--a");
+	let b = CsskitAtomSet::get_dyn_set().atom_from_str("--b");
+	let c = CsskitAtomSet::get_dyn_set().atom_from_str("--c");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 4)));
 	assert_eq!(counters.get(&b), Some(&(StatType::Counter, 2)));
 	assert_eq!(counters.get(&c), Some(&(StatType::Counter, 2)));
@@ -533,7 +533,7 @@ fn test_cycle_prevention_self_referential() {
 	let css_source = ".a {} .b {} .c {}";
 
 	let (counters, _diagnostics) = run(&alloc, source, css_source);
-	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("--count");
 	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 6)));
 }
 
@@ -552,9 +552,9 @@ fn test_equality_vs_range_semantics() {
 	let css_source = ".a {} .b {}";
 
 	let (counters, _diagnostics) = run(&alloc, source, css_source);
-	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
-	let equal = CsskitAtomSet::get_dyn_set().atom_from_str("equal-triggered");
-	let greater = CsskitAtomSet::get_dyn_set().atom_from_str("greater-triggered");
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("--rules");
+	let equal = CsskitAtomSet::get_dyn_set().atom_from_str("--equal-triggered");
+	let greater = CsskitAtomSet::get_dyn_set().atom_from_str("--greater-triggered");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 2)));
 	assert_eq!(counters.get(&equal), Some(&(StatType::Counter, 0))); // Created but never triggered
 	assert_eq!(counters.get(&greater), Some(&(StatType::Counter, 2)));
@@ -572,8 +572,8 @@ fn test_equality_intermediate_value_does_not_trigger() {
 	let css_source = ".a {} .b {} .c {}";
 
 	let (counters, _diagnostics) = run(&alloc, source, css_source);
-	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
-	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("triggered");
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("--count");
+	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("--triggered");
 	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 3)));
 	assert_eq!(counters.get(&triggered), Some(&(StatType::Counter, 0))); // Never triggered
 }
@@ -590,8 +590,8 @@ fn test_equality_does_trigger_on_exact_match() {
 	let css_source = ".a {} .b {}"; // Exactly 2 rules
 
 	let (counters, _diagnostics) = run(&alloc, source, css_source);
-	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
-	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("triggered");
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("--count");
+	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("--triggered");
 	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 2)));
 	assert_eq!(counters.get(&triggered), Some(&(StatType::Counter, 2)));
 }
@@ -621,8 +621,8 @@ fn test_equality_triggers_once_then_becomes_false() {
 	let css_source = ".a {} .b {}";
 
 	let (counters, diagnostics) = run(&alloc, source, css_source);
-	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
-	let hit = CsskitAtomSet::get_dyn_set().atom_from_str("hit");
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("--count");
+	let hit = CsskitAtomSet::get_dyn_set().atom_from_str("--hit");
 	assert_eq!(counters.get(&hit), Some(&(StatType::Counter, 0)));
 	assert_eq!(diagnostics.len(), 0);
 	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 3)));
@@ -648,10 +648,10 @@ fn test_when_only_rules_with_bytes_and_lines() {
 	let css_source = ".a {} .b {}";
 
 	let (counters, _diagnostics) = run(&alloc, source, css_source);
-	let trigger = CsskitAtomSet::get_dyn_set().atom_from_str("trigger");
-	let bytes = CsskitAtomSet::get_dyn_set().atom_from_str("byte-count");
-	let lines = CsskitAtomSet::get_dyn_set().atom_from_str("line-count");
-	let counter = CsskitAtomSet::get_dyn_set().atom_from_str("counter");
+	let trigger = CsskitAtomSet::get_dyn_set().atom_from_str("--trigger");
+	let bytes = CsskitAtomSet::get_dyn_set().atom_from_str("--byte-count");
+	let lines = CsskitAtomSet::get_dyn_set().atom_from_str("--line-count");
+	let counter = CsskitAtomSet::get_dyn_set().atom_from_str("--counter");
 
 	assert_eq!(counters.get(&trigger), Some(&(StatType::Counter, 2)));
 	// For @when-only rules without selectors:
@@ -679,8 +679,8 @@ fn test_invalid_when_threshold_skipped() {
 	let css_source = ".a {} .b {}";
 
 	let (counters, _diagnostics) = run(&alloc, source, css_source);
-	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
-	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("triggered");
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("--count");
+	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("--triggered");
 
 	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 2)));
 	// Invalid threshold should skip the @when rule entirely, so --triggered should not exist or be 0


### PR DESCRIPTION
Previously, in https://github.com/csskit/csskit/pull/481 introduced atoms, it
was decided to encode dashed idents as their value ignoring the `--`, this
increases the ability to have dashed idents be in the static set (guaranteed not
to be otherwise) but it creates a lot of additional work for us having to check
if an ident (or dimension's ident) is dashed or not. Turns out there are some
gnarly bugs to do with this where e.g. `1--px` could be read as `1px`. Oops

This changes the lexer so a dashed ident keeps its dashed when being atomized,
this simplified a lot of atom equality, but it does mean dynamic atoms need to
intern with their dashes, so some changes effect e.g. csskit.
