### PR TITLE
css_parse: compare SemanticEq nodes through their source text

### DIFF
--- a/crates/css_ast/src/functions/math_function.rs
+++ b/crates/css_ast/src/functions/math_function.rs
@@ -643,109 +643,132 @@ pub enum CalcOperand<'a, T> {
 crate::values::impl_value_slot_parse!(CalcOperand, CalcOperandSubstitutionFunction, CalcValue<T>);
 
 impl<'a, T: SemanticEq> SemanticEq for CalcOperand<'a, T> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		calc_operand_eq(self, other)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		calc_operand_eq(self, other, source_text)
 	}
 }
 
-fn calc_operand_eq<'a, T: SemanticEq>(a: &CalcOperand<'a, T>, b: &CalcOperand<'a, T>) -> bool {
+fn calc_operand_eq<'a, T: SemanticEq>(a: &CalcOperand<'a, T>, b: &CalcOperand<'a, T>, source_text: &str) -> bool {
 	match (a, b) {
-		(CalcOperand::Literal(a), CalcOperand::Literal(b)) => calc_value_eq(a, b),
-		(CalcOperand::Substituted(a), CalcOperand::Substituted(b)) => calc_operand_substitution_eq(a, b),
-		(CalcOperand::Unresolved(a), CalcOperand::Unresolved(b)) => a.semantic_eq(b),
+		(CalcOperand::Literal(a), CalcOperand::Literal(b)) => calc_value_eq(a, b, source_text),
+		(CalcOperand::Substituted(a), CalcOperand::Substituted(b)) => calc_operand_substitution_eq(a, b, source_text),
+		(CalcOperand::Unresolved(a), CalcOperand::Unresolved(b)) => a.semantic_eq(b, source_text),
 		_ => false,
 	}
 }
 
-fn calc_value_eq<'a, T: SemanticEq>(a: &CalcValue<'a, T>, b: &CalcValue<'a, T>) -> bool {
+fn calc_value_eq<'a, T: SemanticEq>(a: &CalcValue<'a, T>, b: &CalcValue<'a, T>, source_text: &str) -> bool {
 	match (a, b) {
-		(CalcValue::Number(a), CalcValue::Number(b)) => a.semantic_eq(b),
-		(CalcValue::Typed(a), CalcValue::Typed(b)) => a.semantic_eq(b),
-		(CalcValue::Keyword(a), CalcValue::Keyword(b)) => a.semantic_eq(b),
-		(CalcValue::TreeCounting(a), CalcValue::TreeCounting(b)) => a.semantic_eq(b),
-		(CalcValue::Parenthesized(a), CalcValue::Parenthesized(b)) => calc_in_parens_eq(a, b),
+		(CalcValue::Number(a), CalcValue::Number(b)) => a.semantic_eq(b, source_text),
+		(CalcValue::Typed(a), CalcValue::Typed(b)) => a.semantic_eq(b, source_text),
+		(CalcValue::Keyword(a), CalcValue::Keyword(b)) => a.semantic_eq(b, source_text),
+		(CalcValue::TreeCounting(a), CalcValue::TreeCounting(b)) => a.semantic_eq(b, source_text),
+		(CalcValue::Parenthesized(a), CalcValue::Parenthesized(b)) => calc_in_parens_eq(a, b, source_text),
 		_ => false,
 	}
 }
 
-fn calc_in_parens_eq<'a, T: SemanticEq>(a: &CalcInParens<'a, T>, b: &CalcInParens<'a, T>) -> bool {
-	a.open.semantic_eq(&b.open) && calc_sum_eq(&a.sum, &b.sum)
+fn calc_in_parens_eq<'a, T: SemanticEq>(a: &CalcInParens<'a, T>, b: &CalcInParens<'a, T>, source_text: &str) -> bool {
+	a.open.semantic_eq(&b.open, source_text) && calc_sum_eq(&a.sum, &b.sum, source_text)
 }
 
-fn calc_sum_eq<'a, T: SemanticEq>(a: &CalcSum<'a, T>, b: &CalcSum<'a, T>) -> bool {
+fn calc_sum_eq<'a, T: SemanticEq>(a: &CalcSum<'a, T>, b: &CalcSum<'a, T>, source_text: &str) -> bool {
 	if a.rest.len() != b.rest.len() {
 		return false;
 	}
-	calc_product_eq(&a.first, &b.first)
-		&& a.rest.iter().zip(b.rest.iter()).all(|((op_a, p_a), (op_b, p_b))| op_a == op_b && calc_product_eq(p_a, p_b))
+	calc_product_eq(&a.first, &b.first, source_text)
+		&& a.rest
+			.iter()
+			.zip(b.rest.iter())
+			.all(|((op_a, p_a), (op_b, p_b))| op_a == op_b && calc_product_eq(p_a, p_b, source_text))
 }
 
-fn calc_product_eq<'a, T: SemanticEq>(a: &CalcProduct<'a, T>, b: &CalcProduct<'a, T>) -> bool {
+fn calc_product_eq<'a, T: SemanticEq>(a: &CalcProduct<'a, T>, b: &CalcProduct<'a, T>, source_text: &str) -> bool {
 	if a.rest.len() != b.rest.len() {
 		return false;
 	}
-	calc_operand_eq(&a.first, &b.first)
-		&& a.rest.iter().zip(b.rest.iter()).all(|((op_a, p_a), (op_b, p_b))| op_a == op_b && calc_operand_eq(p_a, p_b))
+	calc_operand_eq(&a.first, &b.first, source_text)
+		&& a.rest
+			.iter()
+			.zip(b.rest.iter())
+			.all(|((op_a, p_a), (op_b, p_b))| op_a == op_b && calc_operand_eq(p_a, p_b, source_text))
 }
 
 fn calc_operand_substitution_eq<'a, T: SemanticEq>(
 	a: &CalcOperandSubstitutionFunction<'a, T>,
 	b: &CalcOperandSubstitutionFunction<'a, T>,
+	source_text: &str,
 ) -> bool {
 	match (a, b) {
-		(CalcOperandSubstitutionFunction::Math(a), CalcOperandSubstitutionFunction::Math(b)) => math_function_eq(a, b),
-		(CalcOperandSubstitutionFunction::Var(a), CalcOperandSubstitutionFunction::Var(b)) => a.semantic_eq(b),
-		(CalcOperandSubstitutionFunction::Env(a), CalcOperandSubstitutionFunction::Env(b)) => a.semantic_eq(b),
-		(CalcOperandSubstitutionFunction::Attr(a), CalcOperandSubstitutionFunction::Attr(b)) => a.semantic_eq(b),
-		(CalcOperandSubstitutionFunction::If(a), CalcOperandSubstitutionFunction::If(b)) => a.semantic_eq(b),
+		(CalcOperandSubstitutionFunction::Math(a), CalcOperandSubstitutionFunction::Math(b)) => {
+			math_function_eq(a, b, source_text)
+		}
+		(CalcOperandSubstitutionFunction::Var(a), CalcOperandSubstitutionFunction::Var(b)) => {
+			a.semantic_eq(b, source_text)
+		}
+		(CalcOperandSubstitutionFunction::Env(a), CalcOperandSubstitutionFunction::Env(b)) => {
+			a.semantic_eq(b, source_text)
+		}
+		(CalcOperandSubstitutionFunction::Attr(a), CalcOperandSubstitutionFunction::Attr(b)) => {
+			a.semantic_eq(b, source_text)
+		}
+		(CalcOperandSubstitutionFunction::If(a), CalcOperandSubstitutionFunction::If(b)) => {
+			a.semantic_eq(b, source_text)
+		}
 		(CalcOperandSubstitutionFunction::FirstValid(a), CalcOperandSubstitutionFunction::FirstValid(b)) => {
-			a.semantic_eq(b)
+			a.semantic_eq(b, source_text)
 		}
 		_ => false,
 	}
 }
 
-fn math_function_eq<'a, T: SemanticEq>(a: &MathFunction<'a, T>, b: &MathFunction<'a, T>) -> bool {
+fn math_function_eq<'a, T: SemanticEq>(a: &MathFunction<'a, T>, b: &MathFunction<'a, T>, source_text: &str) -> bool {
 	use MathFunction::*;
 	match (a, b) {
-		(CalcFunction(a), CalcFunction(b)) => calc_sum_eq(&a.params, &b.params),
-		(MinFunction(a), MinFunction(b)) => a.params.semantic_eq(&b.params),
-		(MaxFunction(a), MaxFunction(b)) => a.params.semantic_eq(&b.params),
+		(CalcFunction(a), CalcFunction(b)) => calc_sum_eq(&a.params, &b.params, source_text),
+		(MinFunction(a), MinFunction(b)) => a.params.semantic_eq(&b.params, source_text),
+		(MaxFunction(a), MaxFunction(b)) => a.params.semantic_eq(&b.params, source_text),
 		(ClampFunction(a), ClampFunction(b)) => {
-			calc_sum_or_none_eq(&a.min, &b.min)
-				&& calc_sum_eq(&a.value, &b.value)
-				&& calc_sum_or_none_eq(&a.max, &b.max)
+			calc_sum_or_none_eq(&a.min, &b.min, source_text)
+				&& calc_sum_eq(&a.value, &b.value, source_text)
+				&& calc_sum_or_none_eq(&a.max, &b.max, source_text)
 		}
 		(RoundFunction(a), RoundFunction(b)) => {
-			a.strategy == b.strategy && calc_sum_eq(&a.value, &b.value) && calc_sum_opt_eq(&a.step, &b.step)
+			a.strategy == b.strategy
+				&& calc_sum_eq(&a.value, &b.value, source_text)
+				&& calc_sum_opt_eq(&a.step, &b.step, source_text)
 		}
 		(ModFunction(a), ModFunction(b)) => {
-			calc_sum_eq(&a.dividend, &b.dividend) && calc_sum_eq(&a.divisor, &b.divisor)
+			calc_sum_eq(&a.dividend, &b.dividend, source_text) && calc_sum_eq(&a.divisor, &b.divisor, source_text)
 		}
 		(RemFunction(a), RemFunction(b)) => {
-			calc_sum_eq(&a.dividend, &b.dividend) && calc_sum_eq(&a.divisor, &b.divisor)
+			calc_sum_eq(&a.dividend, &b.dividend, source_text) && calc_sum_eq(&a.divisor, &b.divisor, source_text)
 		}
-		(SinFunction(a), SinFunction(b)) => a.semantic_eq(b),
-		(CosFunction(a), CosFunction(b)) => a.semantic_eq(b),
-		(TanFunction(a), TanFunction(b)) => a.semantic_eq(b),
-		(AsinFunction(a), AsinFunction(b)) => a.semantic_eq(b),
-		(AcosFunction(a), AcosFunction(b)) => a.semantic_eq(b),
-		(AtanFunction(a), AtanFunction(b)) => a.semantic_eq(b),
-		(Atan2Function(a), Atan2Function(b)) => a.semantic_eq(b),
-		(PowFunction(a), PowFunction(b)) => a.semantic_eq(b),
-		(SqrtFunction(a), SqrtFunction(b)) => a.semantic_eq(b),
-		(HypotFunction(a), HypotFunction(b)) => a.semantic_eq(b),
-		(LogFunction(a), LogFunction(b)) => a.semantic_eq(b),
-		(ExpFunction(a), ExpFunction(b)) => a.semantic_eq(b),
-		(AbsFunction(a), AbsFunction(b)) => a.semantic_eq(b),
-		(SignFunction(a), SignFunction(b)) => calc_sum_eq(&a.params, &b.params),
+		(SinFunction(a), SinFunction(b)) => a.semantic_eq(b, source_text),
+		(CosFunction(a), CosFunction(b)) => a.semantic_eq(b, source_text),
+		(TanFunction(a), TanFunction(b)) => a.semantic_eq(b, source_text),
+		(AsinFunction(a), AsinFunction(b)) => a.semantic_eq(b, source_text),
+		(AcosFunction(a), AcosFunction(b)) => a.semantic_eq(b, source_text),
+		(AtanFunction(a), AtanFunction(b)) => a.semantic_eq(b, source_text),
+		(Atan2Function(a), Atan2Function(b)) => a.semantic_eq(b, source_text),
+		(PowFunction(a), PowFunction(b)) => a.semantic_eq(b, source_text),
+		(SqrtFunction(a), SqrtFunction(b)) => a.semantic_eq(b, source_text),
+		(HypotFunction(a), HypotFunction(b)) => a.semantic_eq(b, source_text),
+		(LogFunction(a), LogFunction(b)) => a.semantic_eq(b, source_text),
+		(ExpFunction(a), ExpFunction(b)) => a.semantic_eq(b, source_text),
+		(AbsFunction(a), AbsFunction(b)) => a.semantic_eq(b, source_text),
+		(SignFunction(a), SignFunction(b)) => calc_sum_eq(&a.params, &b.params, source_text),
 		_ => false,
 	}
 }
 
-fn calc_sum_or_none_eq<'a, T: SemanticEq>(a: &NoneOr<CalcSum<'a, T>>, b: &NoneOr<CalcSum<'a, T>>) -> bool {
+fn calc_sum_or_none_eq<'a, T: SemanticEq>(
+	a: &NoneOr<CalcSum<'a, T>>,
+	b: &NoneOr<CalcSum<'a, T>>,
+	source_text: &str,
+) -> bool {
 	match (a, b) {
-		(NoneOr::Some(a), NoneOr::Some(b)) => calc_sum_eq(a, b),
+		(NoneOr::Some(a), NoneOr::Some(b)) => calc_sum_eq(a, b, source_text),
 		(NoneOr::None(_), NoneOr::None(_)) => true,
 		_ => false,
 	}
@@ -754,10 +777,11 @@ fn calc_sum_or_none_eq<'a, T: SemanticEq>(a: &NoneOr<CalcSum<'a, T>>, b: &NoneOr
 fn calc_sum_opt_eq<'a, T: SemanticEq>(
 	a: &Option<Box<'a, CalcSum<'a, T>>>,
 	b: &Option<Box<'a, CalcSum<'a, T>>>,
+	source_text: &str,
 ) -> bool {
 	match (a, b) {
 		(None, None) => true,
-		(Some(a), Some(b)) => calc_sum_eq(a, b),
+		(Some(a), Some(b)) => calc_sum_eq(a, b, source_text),
 		_ => false,
 	}
 }
@@ -794,8 +818,8 @@ pub struct CalcProduct<'a, T> {
 }
 
 impl<'a, T: SemanticEq> SemanticEq for CalcProduct<'a, T> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		calc_product_eq(self, other)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		calc_product_eq(self, other, source_text)
 	}
 }
 

--- a/crates/css_ast/src/functions/transform_functions.rs
+++ b/crates/css_ast/src/functions/transform_functions.rs
@@ -243,7 +243,6 @@ pub struct TranslatezFunction<'a> {
 pub struct ScaleFunction<'a> {
 	#[atom(CssAtomSet::Scale)]
 	pub name: T![Function],
-	#[semantic_eq(skip)]
 	pub params: (NumericValue<'a, NumberOrPercentage>, Option<T![,]>, Option<NumericValue<'a, NumberOrPercentage>>),
 	#[semantic_eq(skip)]
 	pub close: T![')'],
@@ -450,7 +449,6 @@ pub struct RotatezFunction<'a> {
 pub struct SkewFunction<'a> {
 	#[atom(CssAtomSet::Skew)]
 	pub name: T![Function],
-	#[semantic_eq(skip)]
 	pub params: (CalcableValue<'a, AngleOrZero>, Option<T![,]>, Option<CalcableValue<'a, AngleOrZero>>),
 	#[semantic_eq(skip)]
 	pub close: T![')'],
@@ -514,7 +512,7 @@ pub struct PerspectiveFunction<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error, assert_parse_span};
+	use css_parse::{assert_parse, assert_parse_error, assert_parse_span, assert_semantic_eq, assert_semantic_ne};
 
 	#[test]
 	fn test_writes() {
@@ -632,5 +630,16 @@ mod tests {
 		assert_parse_error!(CssAtomSet::ATOMS, TransformFunction, "skewX(foo)");
 		assert_parse_error!(CssAtomSet::ATOMS, TransformFunction, "skewY()");
 		assert_parse_error!(CssAtomSet::ATOMS, TransformFunction, "skewY(foo)");
+	}
+
+	#[test]
+	fn test_semantic_eq_reads_parameters() {
+		assert_semantic_eq!(CssAtomSet::ATOMS, TransformFunction, "scale(2)", "scale(2)");
+		assert_semantic_ne!(CssAtomSet::ATOMS, TransformFunction, "scale(.5)", "scale(1.5)");
+		assert_semantic_ne!(CssAtomSet::ATOMS, TransformFunction, "scale(2,3)", "scale(3,2)");
+		assert_semantic_ne!(CssAtomSet::ATOMS, TransformFunction, "scale(-1,-1)", "scale(1,-1)");
+		assert_semantic_ne!(CssAtomSet::ATOMS, TransformFunction, "scale(1)", "scale(1,2)");
+		assert_semantic_eq!(CssAtomSet::ATOMS, TransformFunction, "skew(1deg)", "skew(1deg)");
+		assert_semantic_ne!(CssAtomSet::ATOMS, TransformFunction, "skew(1deg)", "skew(2deg)");
 	}
 }

--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -522,13 +522,13 @@ impl ToSpan for CssTypes {
 	}
 }
 impl SemanticEq for CssTypes {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, _source_text: &str) -> bool {
 		self == other
 	}
 }
 
 impl SemanticEq for CssMetadata {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, _source_text: &str) -> bool {
 		self == other
 	}
 }

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -392,7 +392,7 @@ impl<'a> DeclarationValue<'a, CssMetadata> for StyleValue<'a> {
 }
 
 impl<'a> SemanticEqTrait for crate::StyleValue<'a> {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
 		macro_rules! semantic_eq {
 			( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $str: tt,)+ ) => {
 				match (self, other) {
@@ -402,10 +402,10 @@ impl<'a> SemanticEqTrait for crate::StyleValue<'a> {
 					(Self::Revert(_), Self::Revert(_)) => true,
 					(Self::RevertLayer(_), Self::RevertLayer(_)) => true,
 					(Self::RevertRule(_), Self::RevertRule(_)) => true,
-					(Self::Custom(a), Self::Custom(b)) => a.semantic_eq(b),
-					(Self::Unresolved(a), Self::Unresolved(b)) => a.semantic_eq(b),
-					(Self::Unknown(a), Self::Unknown(b)) => a.semantic_eq(b),
-					$((Self::$name(a), Self::$name(b)) => a.semantic_eq(b),)+
+					(Self::Custom(a), Self::Custom(b)) => a.semantic_eq(b, source_text),
+					(Self::Unresolved(a), Self::Unresolved(b)) => a.semantic_eq(b, source_text),
+					(Self::Unknown(a), Self::Unknown(b)) => a.semantic_eq(b, source_text),
+					$((Self::$name(a), Self::$name(b)) => a.semantic_eq(b, source_text),)+
 					(_, _) => false,
 				}
 			};

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -170,11 +170,11 @@ impl Nth {
 }
 
 impl SemanticEq for Nth {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
 		match (self, other) {
-			(Self::Odd(a), Self::Odd(b)) => a.semantic_eq(b),
-			(Self::Even(a), Self::Even(b)) => a.semantic_eq(b),
-			(Self::Integer(a), Self::Integer(b)) => a.semantic_eq(b),
+			(Self::Odd(a), Self::Odd(b)) => a.semantic_eq(b, source_text),
+			(Self::Even(a), Self::Even(b)) => a.semantic_eq(b, source_text),
+			(Self::Integer(a), Self::Integer(b)) => a.semantic_eq(b, source_text),
 			(Self::Anb(a1, b1, _), Self::Anb(a2, b2, _)) => a1 == a2 && b1 == b2,
 			_ => false,
 		}

--- a/crates/css_ast/src/types/position_and_size.rs
+++ b/crates/css_ast/src/types/position_and_size.rs
@@ -16,7 +16,6 @@ use crate::{BgSize, Position};
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct PositionAndSize<'a> {
 	pub position: Position<'a>,
-	#[semantic_eq(skip)]
 	pub size: Option<(T![/], BgSize<'a>)>,
 }
 
@@ -24,7 +23,7 @@ pub struct PositionAndSize<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_peek_false};
+	use css_parse::{assert_parse, assert_peek_false, assert_semantic_eq, assert_semantic_ne};
 
 	#[test]
 	fn test_writes() {
@@ -37,5 +36,11 @@ mod tests {
 	#[test]
 	fn test_errors() {
 		assert_peek_false!(CssAtomSet::ATOMS, PositionAndSize, "");
+	}
+
+	#[test]
+	fn test_semantic_eq_reads_the_size() {
+		assert_semantic_ne!(CssAtomSet::ATOMS, PositionAndSize, "center/cover", "center/contain");
+		assert_semantic_eq!(CssAtomSet::ATOMS, PositionAndSize, "center/cover", "center/cover");
 	}
 }

--- a/crates/css_lexer/src/associated_whitespace_rules.rs
+++ b/crates/css_lexer/src/associated_whitespace_rules.rs
@@ -34,6 +34,8 @@ pub enum AssociatedWhitespaceRules {
 }
 
 impl AssociatedWhitespaceRules {
+	pub const NONE: AssociatedWhitespaceRules = AssociatedWhitespaceRules::none();
+
 	pub(crate) const fn from_bits(bits: u8) -> Self {
 		Self { bits: bits & 0b111 }
 	}

--- a/crates/css_lexer/src/kindset.rs
+++ b/crates/css_lexer/src/kindset.rs
@@ -65,6 +65,28 @@ impl KindSet {
 	/// [Token::atom_bits][crate::Token::atom_bits] may return a non-zero value.
 	pub const ATOM_LIKE: KindSet = KindSet::new(&[Kind::Ident, Kind::Function, Kind::AtKeyword, Kind::Dimension]);
 
+	/// A [KindSet] that matches the kinds which name something, such as [Kind::Ident] or
+	/// [Kind::String].
+	pub const NAMED: KindSet = KindSet::new(&[
+		Kind::Ident,
+		Kind::Function,
+		Kind::AtKeyword,
+		Kind::Hash,
+		Kind::String,
+		Kind::Url,
+		Kind::Comment,
+		Kind::UnicodeRange,
+		Kind::Dimension,
+		Kind::BadIdent,
+		Kind::BadFunction,
+		Kind::BadAtKeyword,
+		Kind::BadHash,
+		Kind::BadString,
+		Kind::BadUrl,
+		Kind::BadComment,
+		Kind::BadDimension,
+	]);
+
 	/// A [KindSet] that matches any single character token, such as [Kind::Delim] or [Kind::Colon] - [Kind::RightCurly].
 	pub const DELIM_LIKE: KindSet = KindSet::new(&[
 		Kind::Delim,

--- a/crates/css_lexer/src/source_cursor.rs
+++ b/crates/css_lexer/src/source_cursor.rs
@@ -512,6 +512,41 @@ impl<'a> SourceCursor<'a> {
 		Ok(())
 	}
 
+	/// Returns `true` if `self` and `other` have the same content, with escape codes parsed out.
+	///
+	/// The content of a [SourceCursor] is its source text, ignoring characters that make this token kind, such as the
+	/// quotes of a [Kind::String], the `#` of a [Kind::Hash], the `url(` and `)` of a [Kind::Url], or the number of a
+	/// [Kind::Dimension].
+	///
+	/// All content is parsed, and escape codes resolved, So `'a'` and `"\61"` hold the same content.
+	pub fn eq_parsed(&self, other: &SourceCursor) -> bool {
+		if !self.token().contains_escape_chars() && !other.token().contains_escape_chars() {
+			return self.content_slice() == other.content_slice();
+		}
+		self.content_chars().eq(other.content_chars())
+	}
+
+	/// Like [SourceCursor::eq_parsed], but ASCII letters compare without case, so `1Px` and `1px` would return `true`.
+	pub fn eq_parsed_ignore_ascii_case(&self, other: &SourceCursor) -> bool {
+		if !self.token().contains_escape_chars() && !other.token().contains_escape_chars() {
+			let a = self.content_slice();
+			let b = other.content_slice();
+			if self.token().is_lower_case() && other.token().is_lower_case() {
+				return a == b;
+			}
+			return a.eq_ignore_ascii_case(b);
+		}
+		let mut a = self.content_chars();
+		let mut b = other.content_chars();
+		loop {
+			match (a.next(), b.next()) {
+				(None, None) => return true,
+				(Some(x), Some(y)) if x.eq_ignore_ascii_case(&y) => {}
+				_ => return false,
+			}
+		}
+	}
+
 	pub fn eq_ignore_ascii_case(&self, other: &str) -> bool {
 		debug_assert!(self.token() != Kind::Delim && self.token() != Kind::Url);
 		debug_assert!(other.to_ascii_lowercase() == other);
@@ -601,6 +636,10 @@ impl<'a> SourceCursor<'a> {
 
 	fn parsed_chars(&self) -> ParsedChars<'a> {
 		ParsedChars::new(self.content_slice(), self.token().kind() == Kind::String)
+	}
+
+	fn content_chars(&self) -> impl Iterator<Item = char> + 'a {
+		self.parsed_chars().map(|(c, _)| c)
 	}
 }
 
@@ -715,6 +754,44 @@ mod test {
 
 		let c = Cursor::new(SourceOffset(3), Token::new_ident(false, false, true, 0, 7));
 		assert!(SourceCursor::from(c, "b\\41\\52").eq_ignore_ascii_case("bar"));
+	}
+
+	#[test]
+	fn eq_parsed() {
+		let ident = Cursor::new(SourceOffset(0), Token::new_ident(false, false, false, 0, 3));
+		let hash = Cursor::new(SourceOffset(0), Token::new_hash(false, true, false, 4, 0));
+		assert!(SourceCursor::from(hash, "#foo").eq_parsed(&SourceCursor::from(ident, "foo")));
+		let dimension = Cursor::new(SourceOffset(0), Token::new_dimension(true, false, 3, 2, 1.0, 0));
+		let px_hash = Cursor::new(SourceOffset(0), Token::new_hash(false, true, false, 3, 0));
+		assert!(SourceCursor::from(dimension, "1.0px").eq_parsed(&SourceCursor::from(px_hash, "#px")));
+
+		let url = Cursor::new(SourceOffset(0), Token::new_url(true, false, false, 4, 1, 6));
+		assert!(SourceCursor::from(url, "URL(a)").eq_parsed(&SourceCursor::from(url, "url(a)")));
+
+		let single = Cursor::new(SourceOffset(0), Token::new_string(QuoteStyle::Single, true, false, 3));
+		let double = Cursor::new(SourceOffset(0), Token::new_string(QuoteStyle::Double, true, false, 3));
+		assert!(SourceCursor::from(single, "'a'").eq_parsed(&SourceCursor::from(double, "\"a\"")));
+		let open = Cursor::new(SourceOffset(0), Token::new_string(QuoteStyle::Single, false, false, 2));
+		assert!(SourceCursor::from(open, "'a").eq_parsed(&SourceCursor::from(single, "'a'")));
+
+		let escaped = Cursor::new(SourceOffset(0), Token::new_ident(false, false, true, 0, 5));
+		assert!(SourceCursor::from(escaped, "b\\61r").eq_parsed(&SourceCursor::from(ident, "bar")));
+		let escaped = Cursor::new(SourceOffset(0), Token::new_string(QuoteStyle::Single, true, true, 5));
+		assert!(SourceCursor::from(escaped, "'\\61'").eq_parsed(&SourceCursor::from(single, "'a'")));
+
+		assert!(!SourceCursor::from(ident, "bar").eq_parsed(&SourceCursor::from(ident, "foo")));
+	}
+
+	#[test]
+	fn eq_parsed_ignore_ascii_case() {
+		let upper = Cursor::new(SourceOffset(0), Token::new_ident(true, false, false, 0, 3));
+		let lower = Cursor::new(SourceOffset(9), Token::new_ident(false, false, false, 0, 3));
+		assert!(SourceCursor::from(upper, "FoO").eq_parsed_ignore_ascii_case(&SourceCursor::from(lower, "foo")));
+		assert!(!SourceCursor::from(upper, "FoO").eq_parsed(&SourceCursor::from(lower, "foo")));
+
+		let escaped = Cursor::new(SourceOffset(0), Token::new_ident(false, false, true, 0, 5));
+		assert!(SourceCursor::from(escaped, "b\\41r").eq_parsed_ignore_ascii_case(&SourceCursor::from(lower, "bar")));
+		assert!(!SourceCursor::from(escaped, "b\\41r").eq_parsed(&SourceCursor::from(lower, "bar")));
 	}
 
 	#[test]

--- a/crates/css_parse/src/arena_impls.rs
+++ b/crates/css_parse/src/arena_impls.rs
@@ -10,8 +10,8 @@ impl<'a, T: ToCursors, A: Allocator> ToCursors for Box<'a, T, A> {
 }
 
 impl<'a, T: SemanticEq, A: Allocator> SemanticEq for Box<'a, T, A> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		(**self).semantic_eq(other)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		(**self).semantic_eq(other, source_text)
 	}
 }
 

--- a/crates/css_parse/src/comparison.rs
+++ b/crates/css_parse/src/comparison.rs
@@ -93,13 +93,13 @@ impl ToSpan for Comparison {
 }
 
 impl SemanticEq for Comparison {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
 		match (self, other) {
-			(Self::LessThan(a), Self::LessThan(b)) => a.semantic_eq(b),
-			(Self::GreaterThan(a), Self::GreaterThan(b)) => a.semantic_eq(b),
-			(Self::GreaterThanEqual(a), Self::GreaterThanEqual(b)) => a.semantic_eq(b),
-			(Self::LessThanEqual(a), Self::LessThanEqual(b)) => a.semantic_eq(b),
-			(Self::Equal(a), Self::Equal(b)) => a.semantic_eq(b),
+			(Self::LessThan(a), Self::LessThan(b)) => a.semantic_eq(b, source_text),
+			(Self::GreaterThan(a), Self::GreaterThan(b)) => a.semantic_eq(b, source_text),
+			(Self::GreaterThanEqual(a), Self::GreaterThanEqual(b)) => a.semantic_eq(b, source_text),
+			(Self::LessThanEqual(a), Self::LessThanEqual(b)) => a.semantic_eq(b, source_text),
+			(Self::Equal(a), Self::Equal(b)) => a.semantic_eq(b, source_text),
 			_ => false,
 		}
 	}

--- a/crates/css_parse/src/macros/optionals.rs
+++ b/crates/css_parse/src/macros/optionals.rs
@@ -56,10 +56,10 @@ macro_rules! impl_optionals {
 			where
 				$($T: SemanticEq,)+
 			{
-				fn semantic_eq(&self, o: &Self) -> bool {
+				fn semantic_eq(&self, o: &Self, source_text: &str) -> bool {
 					let $name($($A),+) = self;
 					let $name($($B),+) = o;
-					$($A.semantic_eq($B))&&+
+					$($A.semantic_eq($B, source_text))&&+
 				}
 			}
 

--- a/crates/css_parse/src/syntax/bad_declaration.rs
+++ b/crates/css_parse/src/syntax/bad_declaration.rs
@@ -65,8 +65,8 @@ impl<'a> ToCursors for BadDeclaration<'a> {
 }
 
 impl<'a> SemanticEq for BadDeclaration<'a> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.0.semantic_eq(&other.0)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.0.semantic_eq(&other.0, source_text)
 	}
 }
 

--- a/crates/css_parse/src/syntax/bang_important.rs
+++ b/crates/css_parse/src/syntax/bang_important.rs
@@ -71,7 +71,7 @@ impl ToSpan for BangImportant {
 }
 
 impl SemanticEq for BangImportant {
-	fn semantic_eq(&self, _: &Self) -> bool {
+	fn semantic_eq(&self, _: &Self, _source_text: &str) -> bool {
 		// The presence of !important is semantic in of itself, so this is just always true
 		true
 	}

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -226,11 +226,11 @@ where
 	R: SemanticEq,
 	M: NodeMetadata,
 {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.open_curly.semantic_eq(&other.open_curly)
-			&& self.close_curly.semantic_eq(&other.close_curly)
-			&& self.declarations.semantic_eq(&other.declarations)
-			&& self.rules.semantic_eq(&other.rules)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.open_curly.semantic_eq(&other.open_curly, source_text)
+			&& self.close_curly.semantic_eq(&other.close_curly, source_text)
+			&& self.declarations.semantic_eq(&other.declarations, source_text)
+			&& self.rules.semantic_eq(&other.rules, source_text)
 	}
 }
 
@@ -271,8 +271,8 @@ mod tests {
 	}
 
 	impl SemanticEq for Decl {
-		fn semantic_eq(&self, other: &Self) -> bool {
-			self.0.semantic_eq(&other.0)
+		fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+			self.0.semantic_eq(&other.0, source_text)
 		}
 	}
 

--- a/crates/css_parse/src/syntax/comma_separated.rs
+++ b/crates/css_parse/src/syntax/comma_separated.rs
@@ -105,8 +105,8 @@ impl<'a, T: ToSpan, const MIN: usize> ToSpan for CommaSeparated<'a, T, MIN> {
 }
 
 impl<'a, T: SemanticEq, const MIN: usize> SemanticEq for CommaSeparated<'a, T, MIN> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.items.semantic_eq(&other.items)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.items.semantic_eq(&other.items, source_text)
 	}
 }
 

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -155,21 +155,21 @@ impl<'a> ToSpan for ComponentValue<'a> {
 }
 
 impl<'a> SemanticEq for ComponentValue<'a> {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
 		match (self, other) {
-			(Self::SimpleBlock(a), Self::SimpleBlock(b)) => a.semantic_eq(b),
-			(Self::Function(a), Self::Function(b)) => a.semantic_eq(b),
-			(Self::Number(a), Self::Number(b)) => a.semantic_eq(b),
-			(Self::Dimension(a), Self::Dimension(b)) => a.semantic_eq(b),
-			(Self::Ident(a), Self::Ident(b)) => a.semantic_eq(b),
-			(Self::AtKeyword(a), Self::AtKeyword(b)) => a.semantic_eq(b),
-			(Self::Hash(a), Self::Hash(b)) => a.semantic_eq(b),
-			(Self::String(a), Self::String(b)) => a.semantic_eq(b),
-			(Self::Url(a), Self::Url(b)) => a.semantic_eq(b),
-			(Self::Delim(a), Self::Delim(b)) => a.semantic_eq(b),
-			(Self::Colon(a), Self::Colon(b)) => a.semantic_eq(b),
-			(Self::Semicolon(a), Self::Semicolon(b)) => a.semantic_eq(b),
-			(Self::Comma(a), Self::Comma(b)) => a.semantic_eq(b),
+			(Self::SimpleBlock(a), Self::SimpleBlock(b)) => a.semantic_eq(b, source_text),
+			(Self::Function(a), Self::Function(b)) => a.semantic_eq(b, source_text),
+			(Self::Number(a), Self::Number(b)) => a.semantic_eq(b, source_text),
+			(Self::Dimension(a), Self::Dimension(b)) => a.semantic_eq(b, source_text),
+			(Self::Ident(a), Self::Ident(b)) => a.semantic_eq(b, source_text),
+			(Self::AtKeyword(a), Self::AtKeyword(b)) => a.semantic_eq(b, source_text),
+			(Self::Hash(a), Self::Hash(b)) => a.semantic_eq(b, source_text),
+			(Self::String(a), Self::String(b)) => a.semantic_eq(b, source_text),
+			(Self::Url(a), Self::Url(b)) => a.semantic_eq(b, source_text),
+			(Self::Delim(a), Self::Delim(b)) => a.semantic_eq(b, source_text),
+			(Self::Colon(a), Self::Colon(b)) => a.semantic_eq(b, source_text),
+			(Self::Semicolon(a), Self::Semicolon(b)) => a.semantic_eq(b, source_text),
+			(Self::Comma(a), Self::Comma(b)) => a.semantic_eq(b, source_text),
 			// Whitespace has no semantic relevance, other than its presence, so it should always be true
 			(Self::Whitespace(_), Self::Whitespace(_)) => true,
 			_ => false, // Different variants are never equal

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -124,8 +124,8 @@ impl<'a> ToSpan for ComponentValues<'a> {
 
 // Implement for ComponentValues - compare sequences, ignoring whitespace
 impl<'a> SemanticEq for ComponentValues<'a> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.values.semantic_eq(&other.values)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.values.semantic_eq(&other.values, source_text)
 	}
 }
 

--- a/crates/css_parse/src/syntax/declaration.rs
+++ b/crates/css_parse/src/syntax/declaration.rs
@@ -171,11 +171,11 @@ where
 	V: DeclarationValue<'a, M>,
 	M: NodeMetadata,
 {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
 		// Semicolon is not semantically relevant!
-		self.name.semantic_eq(&other.name)
-			&& self.value.semantic_eq(&other.value)
-			&& self.important.semantic_eq(&other.important)
+		self.name.semantic_eq(&other.name, source_text)
+			&& self.value.semantic_eq(&other.value, source_text)
+			&& self.important.semantic_eq(&other.important, source_text)
 	}
 }
 
@@ -217,8 +217,8 @@ mod tests {
 	}
 
 	impl SemanticEq for Decl {
-		fn semantic_eq(&self, other: &Self) -> bool {
-			self.0.semantic_eq(&other.0)
+		fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+			self.0.semantic_eq(&other.0, source_text)
 		}
 	}
 

--- a/crates/css_parse/src/syntax/declaration_group.rs
+++ b/crates/css_parse/src/syntax/declaration_group.rs
@@ -47,8 +47,8 @@ where
 	D: DeclarationValue<'a, M>,
 	M: NodeMetadata,
 {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.declarations.semantic_eq(&other.declarations)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.declarations.semantic_eq(&other.declarations, source_text)
 	}
 }
 

--- a/crates/css_parse/src/syntax/declaration_list.rs
+++ b/crates/css_parse/src/syntax/declaration_list.rs
@@ -113,9 +113,9 @@ where
 	V: DeclarationValue<'a, M>,
 	M: NodeMetadata,
 {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.open_curly.semantic_eq(&other.open_curly)
-			&& self.declarations.semantic_eq(&other.declarations)
-			&& self.close_curly.semantic_eq(&other.close_curly)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.open_curly.semantic_eq(&other.open_curly, source_text)
+			&& self.declarations.semantic_eq(&other.declarations, source_text)
+			&& self.close_curly.semantic_eq(&other.close_curly, source_text)
 	}
 }

--- a/crates/css_parse/src/syntax/declaration_or_bad.rs
+++ b/crates/css_parse/src/syntax/declaration_or_bad.rs
@@ -48,10 +48,10 @@ where
 	D: DeclarationValue<'a, M>,
 	M: NodeMetadata,
 {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
 		match (self, other) {
-			(Self::Declaration(a), Self::Declaration(b)) => a.semantic_eq(b),
-			(Self::Bad(a), Self::Bad(b)) => a.semantic_eq(b),
+			(Self::Declaration(a), Self::Declaration(b)) => a.semantic_eq(b, source_text),
+			(Self::Bad(a), Self::Bad(b)) => a.semantic_eq(b, source_text),
 			_ => false,
 		}
 	}

--- a/crates/css_parse/src/syntax/either.rs
+++ b/crates/css_parse/src/syntax/either.rs
@@ -81,10 +81,10 @@ where
 }
 
 impl<Left: SemanticEq, Right: SemanticEq> SemanticEq for Either<Left, Right> {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
 		match (self, other) {
-			(Self::Left(a), Self::Left(b)) => a.semantic_eq(b),
-			(Self::Right(a), Self::Right(b)) => a.semantic_eq(b),
+			(Self::Left(a), Self::Left(b)) => a.semantic_eq(b, source_text),
+			(Self::Right(a), Self::Right(b)) => a.semantic_eq(b, source_text),
 			_ => false,
 		}
 	}

--- a/crates/css_parse/src/syntax/function_block.rs
+++ b/crates/css_parse/src/syntax/function_block.rs
@@ -42,10 +42,10 @@ impl<'a> ToSpan for FunctionBlock<'a> {
 }
 
 impl<'a> SemanticEq for FunctionBlock<'a> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.name.semantic_eq(&other.name)
-			&& self.params.semantic_eq(&other.params)
-			&& self.close.semantic_eq(&other.close)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.name.semantic_eq(&other.name, source_text)
+			&& self.params.semantic_eq(&other.params, source_text)
+			&& self.close.semantic_eq(&other.close, source_text)
 	}
 }
 

--- a/crates/css_parse/src/syntax/no_block_allowed.rs
+++ b/crates/css_parse/src/syntax/no_block_allowed.rs
@@ -51,8 +51,8 @@ impl<D, M> ToSpan for NoBlockAllowed<D, M> {
 }
 
 impl<D, M> SemanticEq for NoBlockAllowed<D, M> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.semicolon.semantic_eq(&other.semicolon)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.semicolon.semantic_eq(&other.semicolon, source_text)
 	}
 }
 

--- a/crates/css_parse/src/syntax/qualified_rule.rs
+++ b/crates/css_parse/src/syntax/qualified_rule.rs
@@ -151,8 +151,8 @@ where
 	R: SemanticEq,
 	M: NodeMetadata,
 {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.prelude.semantic_eq(&other.prelude) && self.block.semantic_eq(&other.block)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.prelude.semantic_eq(&other.prelude, source_text) && self.block.semantic_eq(&other.block, source_text)
 	}
 }
 
@@ -190,8 +190,8 @@ mod tests {
 	}
 
 	impl SemanticEq for Decl {
-		fn semantic_eq(&self, other: &Self) -> bool {
-			self.0.semantic_eq(&other.0)
+		fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+			self.0.semantic_eq(&other.0, source_text)
 		}
 	}
 

--- a/crates/css_parse/src/syntax/rule_list.rs
+++ b/crates/css_parse/src/syntax/rule_list.rs
@@ -111,9 +111,9 @@ where
 	R: NodeWithMetadata<M> + SemanticEq,
 	M: NodeMetadata,
 {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.open_curly.semantic_eq(&other.open_curly)
-			&& self.rules.semantic_eq(&other.rules)
-			&& self.close_curly.semantic_eq(&other.close_curly)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.open_curly.semantic_eq(&other.open_curly, source_text)
+			&& self.rules.semantic_eq(&other.rules, source_text)
+			&& self.close_curly.semantic_eq(&other.close_curly, source_text)
 	}
 }

--- a/crates/css_parse/src/syntax/simple_block.rs
+++ b/crates/css_parse/src/syntax/simple_block.rs
@@ -47,10 +47,10 @@ impl<'a> ToSpan for SimpleBlock<'a> {
 }
 
 impl<'a> SemanticEq for SimpleBlock<'a> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.open.semantic_eq(&other.open)
-			&& self.values.semantic_eq(&other.values)
-			&& self.close.semantic_eq(&other.close)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.open.semantic_eq(&other.open, source_text)
+			&& self.values.semantic_eq(&other.values, source_text)
+			&& self.close.semantic_eq(&other.close, source_text)
 	}
 }
 

--- a/crates/css_parse/src/syntax/unknown_rule_block.rs
+++ b/crates/css_parse/src/syntax/unknown_rule_block.rs
@@ -39,8 +39,8 @@ impl<'a, D, M> ToSpan for UnknownRuleBlock<'a, D, M> {
 }
 
 impl<'a, D, M> SemanticEq for UnknownRuleBlock<'a, D, M> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.values.semantic_eq(&other.values)
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		self.values.semantic_eq(&other.values, source_text)
 	}
 }
 

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -244,3 +244,69 @@ macro_rules! assert_parse_span {
 }
 #[cfg(test)]
 pub(crate) use assert_parse_span;
+
+/// (Requires feature "testing") Given a Node and two strings, this will expand to code that sets up a parser, parses
+/// both strings as the given Node from a single source text, and asserts that the two parsed Nodes are equal according
+/// to [SemanticEq][crate::SemanticEq]. If either parse fails, or the nodes are not semantically equal, this macro will
+/// [panic] with a readable failure.
+///
+/// ```
+/// use css_parse::*;
+/// assert_semantic_eq!(EmptyAtomSet::ATOMS, T![Ident], "foo", "FoO");
+/// ```
+#[macro_export]
+macro_rules! assert_semantic_eq {
+	($atomset: path, $ty: ty, $a: literal, $b: literal) => {
+		$crate::__assert_semantic!($atomset, $ty, $a, $b, true);
+	};
+}
+
+/// (Requires feature "testing") Given a Node and two strings, this will expand to code that sets up a parser, parses
+/// both strings as the given Node from a single source text, and asserts that the two parsed Nodes are _not_ equal
+/// according to [SemanticEq][crate::SemanticEq]. If either parse fails, or the nodes are semantically equal, this
+/// macro will [panic] with a readable failure.
+///
+/// ```
+/// use css_parse::*;
+/// assert_semantic_ne!(EmptyAtomSet::ATOMS, T![Ident], "foo", "bar");
+/// ```
+#[macro_export]
+macro_rules! assert_semantic_ne {
+	($atomset: path, $ty: ty, $a: literal, $b: literal) => {
+		$crate::__assert_semantic!($atomset, $ty, $a, $b, false);
+	};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __assert_semantic {
+	($atomset: path, $ty: ty, $a: literal, $b: literal, $expected: literal) => {{
+		let source_text = concat!($a, ",", $b);
+		let alloc = $crate::Arena::default();
+		let lexer = css_lexer::Lexer::new(&$atomset, source_text);
+		let mut parser = $crate::Parser::new(&alloc, source_text, lexer);
+		let result = parser.parse_entirely::<$crate::CommaSeparated<$ty>>();
+		if !result.errors.is_empty() {
+			panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
+		}
+		let list = result.output.expect("parse succeeded");
+		if list.len() != 2 {
+			panic!("\n\nExpected exactly two nodes but {:?} parsed as {} nodes.", source_text, list.len());
+		}
+		use $crate::SemanticEq;
+		let semantically_equal = list[0].0.semantic_eq(&list[1].0, source_text);
+		if semantically_equal != $expected {
+			if $expected {
+				panic!(
+					"\n\nExpected nodes to be semantically equal, but they were not:\n\n   left: {:?}\n  right: {:?}\n",
+					$a, $b
+				);
+			} else {
+				panic!(
+					"\n\nExpected nodes to be semantically unequal, but they were equal:\n\n   left: {:?}\n  right: {:?}\n",
+					$a, $b
+				);
+			}
+		}
+	}};
+}

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -29,8 +29,8 @@ macro_rules! cursor_wrapped {
 		}
 
 		impl $crate::SemanticEq for $ident {
-			fn semantic_eq(&self, s: &Self) -> bool {
-				self.0.semantic_eq(&s.0)
+			fn semantic_eq(&self, s: &Self, source_text: &str) -> bool {
+				self.0.semantic_eq(&s.0, source_text)
 			}
 		}
 	};
@@ -106,8 +106,8 @@ macro_rules! define_kinds {
 		define_kind_common!($(#[$meta])* $ident);
 
 		impl $crate::SemanticEq for $ident {
-			fn semantic_eq(&self, s: &Self) -> bool {
-				self.0.semantic_eq(&s.0)
+			fn semantic_eq(&self, s: &Self, source_text: &str) -> bool {
+				self.0.semantic_eq(&s.0, source_text)
 			}
 		}
 		)*
@@ -126,7 +126,7 @@ macro_rules! define_fixed_kinds {
 
 		impl $crate::SemanticEq for $ident {
 			#[inline(always)]
-			fn semantic_eq(&self, _: &Self) -> bool {
+			fn semantic_eq(&self, _: &Self, _source_text: &str) -> bool {
 				true
 			}
 		}
@@ -188,8 +188,8 @@ macro_rules! define_kind_idents {
 		}
 
 		impl $crate::SemanticEq for $ident {
-			fn semantic_eq(&self, s: &Self) -> bool {
-				self.0.semantic_eq(&s.0)
+			fn semantic_eq(&self, s: &Self, source_text: &str) -> bool {
+				self.0.semantic_eq(&s.0, source_text)
 			}
 		}
 
@@ -290,7 +290,7 @@ macro_rules! custom_delim {
 
 		impl $crate::SemanticEq for $ident {
 			#[inline(always)]
-			fn semantic_eq(&self, _: &Self) -> bool {
+			fn semantic_eq(&self, _: &Self, _source_text: &str) -> bool {
 				// The character is fixed by the type itself (parsing only succeeds for
 				// `$ch`), so there is nothing left to compare.
 				true
@@ -373,7 +373,7 @@ macro_rules! custom_double_delim {
 
 		impl $crate::SemanticEq for $ident {
 			#[inline(always)]
-			fn semantic_eq(&self, _: &Self) -> bool {
+			fn semantic_eq(&self, _: &Self, _source_text: &str) -> bool {
 				// Both characters are fixed by the type itself (`$first` then `$second`), so
 				// there is nothing left to compare.
 				true
@@ -889,7 +889,7 @@ pub mod double {
 
 	impl SemanticEq for ColonColon {
 		#[inline(always)]
-		fn semantic_eq(&self, _: &Self) -> bool {
+		fn semantic_eq(&self, _: &Self, _source_text: &str) -> bool {
 			// Both `:` characters are fixed by the type itself, so there is nothing left to
 			// compare.
 			true
@@ -1077,7 +1077,7 @@ mod fixed_kind_semantic_eq_tests {
 					stringify!($ty)
 				);
 				assert!(
-					plain.semantic_eq(&with_rule),
+					plain.semantic_eq(&with_rule, ""),
 					"{} should always be semantic_eq regardless of associated whitespace",
 					stringify!($ty)
 				);

--- a/crates/css_parse/src/traits/semantic_eq.rs
+++ b/crates/css_parse/src/traits/semantic_eq.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use css_lexer::AssociatedWhitespaceRules;
+use css_lexer::{AssociatedWhitespaceRules, Kind, KindSet, SourceCursor};
 
 /// Trait for semantic equality comparison that ignores source positions and whitespace.
 ///
@@ -7,20 +7,72 @@ use css_lexer::AssociatedWhitespaceRules;
 /// content and meaning rather than their exact representation in source code. Two nodes
 /// are semantically equal if they represent the same CSS construct, regardless of source
 /// position or trivia.
+///
+/// Both nodes must come from `source_text`, because a [Cursor] keeps only the facts which fit in a
+/// [Token][css_lexer::Token] and a name too large for an atom stays in the source text.
 pub trait SemanticEq {
-	/// Returns `true` if `self` and `other` are semantically equal.
-	fn semantic_eq(&self, other: &Self) -> bool;
+	/// Returns `true` if `self` and `other`, both read from `source_text`, are semantically equal.
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool;
 }
 
-// Implement for Cursor - compare tokens without considering source offset
 impl SemanticEq for Cursor {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		// Associated whitespace rules are formatting hints, not semantic content, so ignore
-		// them. `with_associated_whitespace` is a no-op for kinds that don't carry such rules
-		// (only "delim-like" kinds do: Delim, Colon, Semicolon, Comma, and the paren/curly/
-		// square brackets), so this is safe to apply unconditionally.
-		self.token().with_associated_whitespace(AssociatedWhitespaceRules::none())
-			== other.token().with_associated_whitespace(AssociatedWhitespaceRules::none())
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
+		let kind = self.token().kind();
+		if kind != other.token().kind() {
+			return false;
+		}
+		if KindSet::NAMED.contains(kind) {
+			// Only a named token needs its source text, so only a named token pays for the slice.
+			let this = SourceCursor::from(*self, self.str_slice(source_text));
+			let other = SourceCursor::from(*other, other.str_slice(source_text));
+			return this.semantic_eq(&other, source_text);
+		}
+		self.token().with_associated_whitespace(AssociatedWhitespaceRules::NONE)
+			== other.token().with_associated_whitespace(AssociatedWhitespaceRules::NONE)
+	}
+}
+
+impl SemanticEq for SourceCursor<'_> {
+	fn semantic_eq(&self, other: &Self, _source_text: &str) -> bool {
+		let token = self.token();
+		let other_token = other.token();
+		let kind = token.kind();
+		if kind != other_token.kind() {
+			return false;
+		}
+		match kind {
+			Kind::Ident | Kind::Function | Kind::AtKeyword => {
+				token.is_dashed_ident() == other_token.is_dashed_ident()
+					&& match (token.atom_bits(), other_token.atom_bits()) {
+						(0, 0) => self.eq_parsed_ignore_ascii_case(other),
+						(a, b) => a == b,
+					}
+			}
+			Kind::Dimension => {
+				token.value() == other_token.value()
+					&& match (token.atom_bits(), other_token.atom_bits()) {
+						(0, 0) => self.eq_parsed_ignore_ascii_case(other),
+						// The token does not keep the dashed-ness of a unit, and the atom lookup for a
+						// dashed unit skips the leading `--`, so equal atoms must also have equal unit
+						// lengths to tell `1--px` from `1px`.
+						(a, b) => {
+							a == b && token.len() - token.leading_len() == other_token.len() - other_token.leading_len()
+						}
+					}
+			}
+			Kind::String | Kind::Url | Kind::Hash => self.eq_parsed(other),
+			Kind::UnicodeRange => {
+				token.unicode_range_start() == other_token.unicode_range_start()
+					&& token.unicode_range_end() == other_token.unicode_range_end()
+			}
+			// The remaining named kinds, such as comments and the `Bad` kinds, keep no facts of what
+			// they hold, so only their whole source text tells them apart.
+			_ if KindSet::NAMED.contains(kind) => self.source() == other.source(),
+			_ => {
+				self.token().with_associated_whitespace(AssociatedWhitespaceRules::NONE)
+					== other.token().with_associated_whitespace(AssociatedWhitespaceRules::NONE)
+			}
+		}
 	}
 }
 
@@ -28,9 +80,9 @@ impl<T> SemanticEq for Option<T>
 where
 	T: SemanticEq,
 {
-	fn semantic_eq(&self, s: &Self) -> bool {
+	fn semantic_eq(&self, s: &Self, source_text: &str) -> bool {
 		match (self, s) {
-			(Some(a), Some(b)) => a.semantic_eq(b),
+			(Some(a), Some(b)) => a.semantic_eq(b, source_text),
 			(None, None) => true,
 			(_, _) => false,
 		}
@@ -41,12 +93,12 @@ impl<'a, T, A: Allocator> SemanticEq for Vec<'a, T, A>
 where
 	T: SemanticEq,
 {
-	fn semantic_eq(&self, s: &Self) -> bool {
+	fn semantic_eq(&self, s: &Self, source_text: &str) -> bool {
 		if self.len() != s.len() {
 			return false;
 		}
 		for i in 0..self.len() {
-			if !self[i].semantic_eq(&s[i]) {
+			if !self[i].semantic_eq(&s[i], source_text) {
 				return false;
 			}
 		}
@@ -60,10 +112,10 @@ macro_rules! impl_tuple {
         where
             $($T: SemanticEq,)*
         {
-            fn semantic_eq(&self, o: &Self) -> bool {
+            fn semantic_eq(&self, o: &Self, source_text: &str) -> bool {
                 let ($($A),*) = self;
                 let ($($B),*) = o;
-                $($A.semantic_eq(&$B))&&*
+                $($A.semantic_eq(&$B, source_text))&&*
             }
         }
     };
@@ -85,8 +137,8 @@ impl_tuple!(A[sa,oa], B[sb,ob], C[sc,oc], D[sd,od], E[se,oe], F[sf,of], G[sg,og]
 mod tests {
 	use super::*;
 	use crate::Arena;
-	use crate::{ComponentValues, Parse, Parser, ToCursors};
-	use css_lexer::EmptyAtomSet;
+	use crate::{ComponentValues, Parse, Parser, SimpleBlock, T, ToCursors, assert_semantic_eq, assert_semantic_ne};
+	use css_lexer::{AtomSet, EmptyAtomSet};
 
 	fn parse<'a, T: Parse<'a> + ToCursors>(alloc: &'a Arena, source: &'a str) -> T {
 		let lexer = css_lexer::Lexer::new(&EmptyAtomSet::ATOMS, source);
@@ -102,7 +154,7 @@ mod tests {
 		let cursor2 = Cursor::new(css_lexer::SourceOffset(100), token);
 
 		// Should be semantically equal despite different offsets
-		assert!(cursor1.semantic_eq(&cursor2));
+		assert!(cursor1.semantic_eq(&cursor2, ""));
 
 		// Standard PartialEq should distinguish them
 		assert_ne!(cursor1, cursor2);
@@ -130,36 +182,130 @@ mod tests {
 				token.with_associated_whitespace(css_lexer::AssociatedWhitespaceRules::EnforceBefore),
 			);
 			assert!(
-				plain.semantic_eq(&with_whitespace_rule),
+				plain.semantic_eq(&with_whitespace_rule, ""),
 				"{:?} should be semantic_eq regardless of associated whitespace",
 				token.kind()
 			);
 		}
 	}
 
+	fn pair<'a>(alloc: &'a Arena, source: &'a str) -> (ComponentValues<'a>, ComponentValues<'a>) {
+		let (first, second) = parse::<(SimpleBlock, SimpleBlock)>(alloc, source);
+		(first.values, second.values)
+	}
+
 	#[test]
 	fn test_component_values_ignores_whitespace() {
-		let source1 = "1px solid red";
-		let source2 = "1px  solid  red"; // Extra whitespace
-
 		let alloc = Arena::new();
-		let values1 = parse::<ComponentValues>(&alloc, source1);
-		let values2 = parse::<ComponentValues>(&alloc, source2);
-
-		// Semantically equal despite whitespace
-		assert!(values1.semantic_eq(&values2));
+		let source = "(1px solid red)(1px  solid  red)";
+		let (first, second) = pair(&alloc, source);
+		assert!(first.semantic_eq(&second, source));
 	}
 
 	#[test]
 	fn test_component_values_different_values() {
-		let source1 = "1px solid red";
-		let source2 = "2px solid red";
-
 		let alloc = Arena::new();
-		let values1 = parse::<ComponentValues>(&alloc, source1);
-		let values2 = parse::<ComponentValues>(&alloc, source2);
+		let source = "(1px solid red)(2px solid red)";
+		let (first, second) = pair(&alloc, source);
+		assert!(!first.semantic_eq(&second, source));
+	}
 
-		// Should NOT be equal due to different values
-		assert!(!values1.semantic_eq(&values2));
+	#[test]
+	fn test_idents_of_equal_length_are_told_apart() {
+		let alloc = Arena::new();
+		let source = "(foo)(bar)";
+		let (first, second) = pair(&alloc, source);
+		assert!(!first.semantic_eq(&second, source));
+
+		let source = "(foo)(foo)";
+		let (first, second) = pair(&alloc, source);
+		assert!(first.semantic_eq(&second, source));
+	}
+
+	#[test]
+	fn test_strings_of_equal_length_are_told_apart() {
+		let alloc = Arena::new();
+		let source = "(\"i\")(\"j\")";
+		let (first, second) = pair(&alloc, source);
+		assert!(!first.semantic_eq(&second, source));
+	}
+
+	#[test]
+	fn test_ident_spellings_are_equal() {
+		let alloc = Arena::new();
+		let source = "(Foo)(foo)";
+		let (first, second) = pair(&alloc, source);
+		assert!(first.semantic_eq(&second, source));
+
+		let source = "(b\\61r)(bar)";
+		let (first, second) = pair(&alloc, source);
+		assert!(first.semantic_eq(&second, source));
+	}
+
+	#[test]
+	fn test_string_spellings() {
+		let alloc = Arena::new();
+		let source = "(\"A\")(\"a\")";
+		let (first, second) = pair(&alloc, source);
+		assert!(!first.semantic_eq(&second, source));
+
+		let source = "(\"a\")('a')";
+		let (first, second) = pair(&alloc, source);
+		assert!(first.semantic_eq(&second, source));
+
+		let source = "(\"\\61\")(\"a\")";
+		let (first, second) = pair(&alloc, source);
+		assert!(first.semantic_eq(&second, source));
+	}
+
+	#[test]
+	fn test_hashes_are_case_sensitive() {
+		let alloc = Arena::new();
+		let source = "(#Foo)(#foo)";
+		let (first, second) = pair(&alloc, source);
+		assert!(!first.semantic_eq(&second, source));
+	}
+
+	#[test]
+	fn test_dimension_spellings_are_equal() {
+		let alloc = Arena::new();
+		let source = "(1.0Px)(1px)";
+		let (first, second) = pair(&alloc, source);
+		assert!(first.semantic_eq(&second, source));
+
+		let source = "(1px)(2px)";
+		let (first, second) = pair(&alloc, source);
+		assert!(!first.semantic_eq(&second, source));
+	}
+
+	// The tests above use an empty atom set, so every ident and unit compares through the source
+	// text. An atom set which holds them compares by atom instead.
+	#[derive(Debug, Default, derive_atom_set::AtomSet, Copy, Clone, PartialEq)]
+	pub enum TestAtomSet {
+		#[default]
+		_None,
+		Foo,
+		Bar,
+		Px,
+	}
+
+	impl TestAtomSet {
+		const ATOMS: TestAtomSet = TestAtomSet::_None;
+	}
+
+	#[test]
+	fn test_ident_atoms() {
+		assert_semantic_eq!(TestAtomSet::ATOMS, T![Ident], "Foo", "foo");
+		assert_semantic_ne!(TestAtomSet::ATOMS, T![Ident], "foo", "bar");
+		// A dashed ident is not the plain ident of the same atom.
+		assert_semantic_ne!(TestAtomSet::ATOMS, T![Ident], "--foo", "foo");
+	}
+
+	#[test]
+	fn test_dimension_unit_atoms() {
+		assert_semantic_eq!(TestAtomSet::ATOMS, T![Dimension], "1.0Px", "1px");
+		assert_semantic_ne!(TestAtomSet::ATOMS, T![Dimension], "1px", "2px");
+		// The atom of a dashed unit skips the leading `--`, so the units must also be equally long.
+		assert_semantic_ne!(TestAtomSet::ATOMS, T![Dimension], "1--px", "1px");
 	}
 }

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -126,7 +126,7 @@ impl ToSpan for QueryCompoundSelector<'_> {
 }
 
 impl SemanticEq for QueryCompoundSelector<'_> {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, _source_text: &str) -> bool {
 		self.parts == other.parts && self.segments == other.segments
 	}
 }

--- a/crates/csskit_ast/src/sheet.rs
+++ b/crates/csskit_ast/src/sheet.rs
@@ -46,11 +46,11 @@ impl ToSpan for Sheet<'_> {
 }
 
 impl SemanticEq for Sheet<'_> {
-	fn semantic_eq(&self, other: &Self) -> bool {
+	fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
 		if self.rules.len() != other.rules.len() {
 			return false;
 		}
-		self.rules.iter().zip(other.rules.iter()).all(|(a, b)| a.semantic_eq(b))
+		self.rules.iter().zip(other.rules.iter()).all(|(a, b)| a.semantic_eq(b, source_text))
 	}
 }
 

--- a/crates/csskit_derives/src/semantic_eq.rs
+++ b/crates/csskit_derives/src/semantic_eq.rs
@@ -48,7 +48,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 			.map(|(a, b)| {
 				let a_name = &a.binding;
 				let b_name = &b.binding;
-				quote! { #a_name.semantic_eq(&#b_name) }
+				quote! { #a_name.semantic_eq(&#b_name, source_text) }
 			})
 			.collect();
 		let a_pat = s_a.variants()[0].pat();
@@ -74,7 +74,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 					.map(|(a, b)| {
 						let a_name = &a.binding;
 						let b_name = &b.binding;
-						quote! { #a_name.semantic_eq(&#b_name) }
+						quote! { #a_name.semantic_eq(&#b_name, source_text) }
 					})
 					.collect();
 				let body = steps.into_iter().reduce(|acc, item| quote! { #acc && #item }).unwrap_or(quote! { true });
@@ -94,7 +94,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics ::css_parse::SemanticEq for #ident #type_generics #where_clause {
-			fn semantic_eq(&self, other: &Self) -> bool {
+			fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
 				use ::css_parse::SemanticEq;
 				#body
 			}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_mixed_variants.snap
@@ -4,14 +4,19 @@ expression: pretty
 ---
 #[automatically_derived]
 impl ::css_parse::SemanticEq for FlexWrap {
-    fn semantic_eq(&self, other: &Self) -> bool {
+    fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
         use ::css_parse::SemanticEq;
         match (self, other) {
-            (FlexWrap::Nowrap(a0), FlexWrap::Nowrap(b0)) => a0.semantic_eq(&b0),
+            (FlexWrap::Nowrap(a0), FlexWrap::Nowrap(b0)) => {
+                a0.semantic_eq(&b0, source_text)
+            }
             (
                 FlexWrap::Wrap { wrap: a_wrap, balance: a_balance },
                 FlexWrap::Wrap { wrap: b_wrap, balance: b_balance },
-            ) => a_wrap.semantic_eq(&b_wrap) && a_balance.semantic_eq(&b_balance),
+            ) => {
+                a_wrap.semantic_eq(&b_wrap, source_text)
+                    && a_balance.semantic_eq(&b_balance, source_text)
+            }
             (
                 FlexWrap::WrapReverse {
                     wrap_reverse: a_wrap_reverse,
@@ -22,8 +27,8 @@ impl ::css_parse::SemanticEq for FlexWrap {
                     balance: b_balance,
                 },
             ) => {
-                a_wrap_reverse.semantic_eq(&b_wrap_reverse)
-                    && a_balance.semantic_eq(&b_balance)
+                a_wrap_reverse.semantic_eq(&b_wrap_reverse, source_text)
+                    && a_balance.semantic_eq(&b_balance, source_text)
             }
             _ => false,
         }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_single_field_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_single_field_variants.snap
@@ -4,12 +4,14 @@ expression: pretty
 ---
 #[automatically_derived]
 impl ::css_parse::SemanticEq for Display {
-    fn semantic_eq(&self, other: &Self) -> bool {
+    fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
         use ::css_parse::SemanticEq;
         match (self, other) {
-            (Display::Block(a0), Display::Block(b0)) => a0.semantic_eq(&b0),
-            (Display::Inline(a0), Display::Inline(b0)) => a0.semantic_eq(&b0),
-            (Display::None(a0), Display::None(b0)) => a0.semantic_eq(&b0),
+            (Display::Block(a0), Display::Block(b0)) => a0.semantic_eq(&b0, source_text),
+            (Display::Inline(a0), Display::Inline(b0)) => {
+                a0.semantic_eq(&b0, source_text)
+            }
+            (Display::None(a0), Display::None(b0)) => a0.semantic_eq(&b0, source_text),
             _ => false,
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_skip_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_skip_field.snap
@@ -4,11 +4,11 @@ expression: pretty
 ---
 #[automatically_derived]
 impl ::css_parse::SemanticEq for Foo {
-    fn semantic_eq(&self, other: &Self) -> bool {
+    fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
         use ::css_parse::SemanticEq;
         match (self, other) {
             (Foo::Bar { name: a_name, .. }, Foo::Bar { name: b_name, .. }) => {
-                a_name.semantic_eq(&b_name)
+                a_name.semantic_eq(&b_name, source_text)
             }
             _ => false,
         }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_multiple_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_multiple_fields.snap
@@ -4,14 +4,17 @@ expression: pretty
 ---
 #[automatically_derived]
 impl ::css_parse::SemanticEq for BorderStyle {
-    fn semantic_eq(&self, other: &Self) -> bool {
+    fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
         use ::css_parse::SemanticEq;
         match (self, other) {
             (BorderStyle::Solid, BorderStyle::Solid) => true,
             (
                 BorderStyle::Dotted { radius: a_radius, spacing: a_spacing },
                 BorderStyle::Dotted { radius: b_radius, spacing: b_spacing },
-            ) => a_radius.semantic_eq(&b_radius) && a_spacing.semantic_eq(&b_spacing),
+            ) => {
+                a_radius.semantic_eq(&b_radius, source_text)
+                    && a_spacing.semantic_eq(&b_spacing, source_text)
+            }
             _ => false,
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_with_named_struct_variant_single_field.snap
@@ -4,14 +4,14 @@ expression: pretty
 ---
 #[automatically_derived]
 impl ::css_parse::SemanticEq for BorderStyle {
-    fn semantic_eq(&self, other: &Self) -> bool {
+    fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
         use ::css_parse::SemanticEq;
         match (self, other) {
             (BorderStyle::Solid, BorderStyle::Solid) => true,
             (
                 BorderStyle::Dashed { width: a_width },
                 BorderStyle::Dashed { width: b_width },
-            ) => a_width.semantic_eq(&b_width),
+            ) => a_width.semantic_eq(&b_width, source_text),
             _ => false,
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_struct_skip_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_struct_skip_field.snap
@@ -4,10 +4,10 @@ expression: pretty
 ---
 #[automatically_derived]
 impl ::css_parse::SemanticEq for StringFunction {
-    fn semantic_eq(&self, other: &Self) -> bool {
+    fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
         use ::css_parse::SemanticEq;
         let StringFunction { name: a_name, .. } = self;
         let StringFunction { name: b_name, .. } = other;
-        a_name.semantic_eq(&b_name)
+        a_name.semantic_eq(&b_name, source_text)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_tuple_struct_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_tuple_struct_single_field.snap
@@ -4,10 +4,10 @@ expression: pretty
 ---
 #[automatically_derived]
 impl ::css_parse::SemanticEq for Length {
-    fn semantic_eq(&self, other: &Self) -> bool {
+    fn semantic_eq(&self, other: &Self, source_text: &str) -> bool {
         use ::css_parse::SemanticEq;
         let Length(a0) = self;
         let Length(b0) = other;
-        a0.semantic_eq(&b0)
+        a0.semantic_eq(&b0, source_text)
     }
 }

--- a/crates/csskit_transform/src/reduce_shorthand_values.rs
+++ b/crates/csskit_transform/src/reduce_shorthand_values.rs
@@ -27,7 +27,7 @@ where
 		T: SemanticEq + ToSpan,
 	{
 		if let Some(second) = second
-			&& second.semantic_eq(first)
+			&& second.semantic_eq(first, self.transformer.source_text)
 		{
 			self.delete(second);
 		}
@@ -39,13 +39,13 @@ where
 	{
 		if let Some(fourth) = fourth {
 			let Some(second) = second else { return };
-			if !fourth.semantic_eq(second) {
+			if !fourth.semantic_eq(second, self.transformer.source_text) {
 				return;
 			}
 			self.delete(fourth);
 		}
 		if let Some(third) = third {
-			if !third.semantic_eq(first) {
+			if !third.semantic_eq(first, self.transformer.source_text) {
 				return;
 			}
 			self.delete(third);
@@ -115,7 +115,7 @@ where
 
 	fn visit_gap_style_value(&mut self, value: &GapStyleValue) {
 		if let Some(second) = &value.1
-			&& gap_values_equal(&value.0, second)
+			&& gap_values_equal(&value.0, second, self.transformer.source_text)
 		{
 			self.delete(second);
 		}
@@ -126,13 +126,21 @@ where
 	}
 }
 
-pub(crate) fn gap_values_equal<'a>(first: &RowGapStyleValue<'a>, second: &ColumnGapStyleValue<'a>) -> bool {
+pub(crate) fn gap_values_equal<'a>(
+	first: &RowGapStyleValue<'a>,
+	second: &ColumnGapStyleValue<'a>,
+	source_text: &str,
+) -> bool {
 	match (first, second) {
-		(RowGapStyleValue::Normal(first), ColumnGapStyleValue::Normal(second)) => first.semantic_eq(second),
-		(RowGapStyleValue::LengthPercentage(first), ColumnGapStyleValue::LengthPercentage(second)) => {
-			first.semantic_eq(second)
+		(RowGapStyleValue::Normal(first), ColumnGapStyleValue::Normal(second)) => {
+			first.semantic_eq(second, source_text)
 		}
-		(RowGapStyleValue::LineWidth(first), ColumnGapStyleValue::LineWidth(second)) => first.semantic_eq(second),
+		(RowGapStyleValue::LengthPercentage(first), ColumnGapStyleValue::LengthPercentage(second)) => {
+			first.semantic_eq(second, source_text)
+		}
+		(RowGapStyleValue::LineWidth(first), ColumnGapStyleValue::LineWidth(second)) => {
+			first.semantic_eq(second, source_text)
+		}
 		_ => false,
 	}
 }


### PR DESCRIPTION
SemanticEq had some pretty bad bugs in its implementation, as it didnt check the
underlying source text meaning generic idents, strings, or urls would always be
semantically equal.

This change now makes SemanticEq take the source text so it can compare e.g. two
idents without an atom set. Comparison of "named" tokens (idents, strings, urls,
hashes, dimension units and so on) now all go through through
`SourceCursor::semantic_eq`, which compares atoms if present, falling back to
source text otherwise. It compares case-sensitively for strings, urls and
hashes - so spellings such as Foo/foo, b\61r/bar, "a"/'a' and 1.0px/1px compare
equal while foo/bar no longer do.
