### PR TITLE
csskit_derives/css_parse: rewrite derive(ToSpan)

### DIFF
--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -188,7 +188,7 @@ impl ToSpan for Nth {
 			Nth::Even(c) => c.to_span(),
 			Nth::Integer(c) => c.to_span(),
 			Nth::Anb(_, _, cursors) => {
-				let mut span = Span::ZERO;
+				let mut span = Span::DUMMY;
 				for c in cursors {
 					if *c != Cursor::EMPTY {
 						span = span + (*c).into()
@@ -204,7 +204,7 @@ impl ToSpan for Nth {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_parse_span};
 
 	#[test]
 	fn test_writes() {
@@ -249,6 +249,50 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, Nth, "n- 10");
 		assert_parse!(CssAtomSet::ATOMS, Nth, "-n\n- 1");
 		assert_parse!(CssAtomSet::ATOMS, Nth, " 23n\n\n+\n\n123 ");
+	}
+
+	#[test]
+	fn test_spans() {
+		assert_parse_span!(
+			CssAtomSet::ATOMS,
+			Nth,
+			r#"
+			odd
+			^^^
+		"#
+		);
+		assert_parse_span!(
+			CssAtomSet::ATOMS,
+			Nth,
+			r#"
+			5
+			^
+		"#
+		);
+		assert_parse_span!(
+			CssAtomSet::ATOMS,
+			Nth,
+			r#"
+			2n
+			^^
+		"#
+		);
+		assert_parse_span!(
+			CssAtomSet::ATOMS,
+			Nth,
+			r#"
+			-2n+1 foo
+			^^^^^
+		"#
+		);
+		assert_parse_span!(
+			CssAtomSet::ATOMS,
+			Nth,
+			r#"
+			n- 10
+			^^^^^
+		"#
+		);
 	}
 
 	#[test]

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -128,7 +128,7 @@ impl<'a> Parse<'a> for NestedGroupRule<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::assert_parse;
+	use css_parse::{assert_parse, assert_parse_span};
 
 	#[cfg(feature = "visitable")]
 	use crate::assert_visits;
@@ -155,6 +155,34 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, StyleRule, "a{@container (width>0){color:red;}}");
 		assert_parse!(CssAtomSet::ATOMS, StyleRule, "a{@layer foo{color:red;}}");
 		assert_parse!(CssAtomSet::ATOMS, StyleRule, "a{@scope(.card) to (img){color:red;}}");
+	}
+
+	#[test]
+	fn test_spans() {
+		assert_parse_span!(
+			CssAtomSet::ATOMS,
+			StyleRule,
+			r#"
+			body{} a{}
+			^^^^^^
+		"#
+		);
+		assert_parse_span!(
+			CssAtomSet::ATOMS,
+			StyleRule,
+			r#"
+			ul li:nth-of-type(2n) {} a{}
+			^^^^^^^^^^^^^^^^^^^^^^^^
+		"#
+		);
+		assert_parse_span!(
+			CssAtomSet::ATOMS,
+			StyleRule,
+			r#"
+			:nth-child(-2n+1){opacity:0;}
+			^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+		"#
+		);
 	}
 
 	#[test]

--- a/crates/css_parse/src/syntax/comma_separated.rs
+++ b/crates/css_parse/src/syntax/comma_separated.rs
@@ -98,7 +98,7 @@ impl<'a, T: ToCursors, const MIN: usize> ToCursors for CommaSeparated<'a, T, MIN
 impl<'a, T: ToSpan, const MIN: usize> ToSpan for CommaSeparated<'a, T, MIN> {
 	fn to_span(&self) -> Span {
 		let Some(first) = self.items.first().map(ToSpan::to_span) else {
-			return Span::ZERO;
+			return Span::DUMMY;
 		};
 		first + self.items.last().map(|t| t.to_span()).unwrap_or(first)
 	}
@@ -190,6 +190,13 @@ mod tests {
 			^^^^^^^^^^^^^
 		"#
 		);
+	}
+
+	#[test]
+	fn test_empty_span_is_dummy() {
+		let alloc = Arena::default();
+		let empty = CommaSeparated::<T![Ident], 0>::new_in(&alloc);
+		assert_eq!(empty.to_span(), Span::DUMMY);
 	}
 
 	#[test]

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_all_optional_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_all_optional_struct.snap
@@ -3,12 +3,10 @@ source: crates/csskit_derives/src/test/test_to_span.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl ::css_parse::ToSpan for BorderStyle {
+impl ::css_parse::ToSpan for Sides {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
-        match self {
-            BorderStyle::Solid => Span::DUMMY,
-            BorderStyle::Dashed { width, .. } => ToSpan::to_span(width),
-        }
+        ToSpan::to_span(&self.top) + ToSpan::to_span(&self.right)
+            + ToSpan::to_span(&self.bottom)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_mixed_variants.snap
@@ -7,12 +7,12 @@ impl ::css_parse::ToSpan for FlexWrap {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
         match self {
-            FlexWrap::Nowrap(val) => val.to_span(),
-            FlexWrap::Wrap { wrap: first, balance: last } => {
-                first.to_span() + last.to_span()
+            FlexWrap::Nowrap(v0) => ToSpan::to_span(v0),
+            FlexWrap::Wrap { wrap, balance, .. } => {
+                ToSpan::to_span(wrap) + ToSpan::to_span(balance)
             }
-            FlexWrap::WrapReverse { wrap_reverse: first, balance: last } => {
-                first.to_span() + last.to_span()
+            FlexWrap::WrapReverse { wrap_reverse, balance, .. } => {
+                ToSpan::to_span(wrap_reverse) + ToSpan::to_span(balance)
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_single_field_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_single_field_variants.snap
@@ -7,9 +7,9 @@ impl ::css_parse::ToSpan for Display {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
         match self {
-            Display::Block(val) => val.to_span(),
-            Display::Inline(val) => val.to_span(),
-            Display::None(val) => val.to_span(),
+            Display::Block(v0) => ToSpan::to_span(v0),
+            Display::Inline(v0) => ToSpan::to_span(v0),
+            Display::None(v0) => ToSpan::to_span(v0),
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_variant_with_fields_named_first_and_last.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_variant_with_fields_named_first_and_last.snap
@@ -3,12 +3,13 @@ source: crates/csskit_derives/src/test/test_to_span.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl ::css_parse::ToSpan for BorderStyle {
+impl ::css_parse::ToSpan for BaselinePosition {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
         match self {
-            BorderStyle::Solid => Span::DUMMY,
-            BorderStyle::Dashed { width, .. } => ToSpan::to_span(width),
+            BaselinePosition::Both { last, first, .. } => {
+                ToSpan::to_span(last) + ToSpan::to_span(first)
+            }
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_variant_with_optional_middle_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_variant_with_optional_middle_field.snap
@@ -1,0 +1,16 @@
+---
+source: crates/csskit_derives/src/test/test_to_span.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::ToSpan for VerticalAlign {
+    fn to_span(&self) -> ::css_parse::Span {
+        use ::css_parse::{Span, ToSpan};
+        match self {
+            VerticalAlign::First { first, alignment_baseline, baseline_shift, .. } => {
+                ToSpan::to_span(first) + ToSpan::to_span(alignment_baseline)
+                    + ToSpan::to_span(baseline_shift)
+            }
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_variant_with_required_middle_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_variant_with_required_middle_field.snap
@@ -3,12 +3,13 @@ source: crates/csskit_derives/src/test/test_to_span.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl ::css_parse::ToSpan for BorderStyle {
+impl ::css_parse::ToSpan for Rule {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
         match self {
-            BorderStyle::Solid => Span::DUMMY,
-            BorderStyle::Dashed { width, .. } => ToSpan::to_span(width),
+            Rule::Block { open, close, .. } => {
+                ToSpan::to_span(open) + ToSpan::to_span(close)
+            }
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_with_named_struct_variant_multiple_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_enum_with_named_struct_variant_multiple_fields.snap
@@ -7,9 +7,9 @@ impl ::css_parse::ToSpan for BorderStyle {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
         match self {
-            BorderStyle::Solid(first, last) => first.to_span() + last.to_span(),
-            BorderStyle::Dotted { radius: first, spacing: last } => {
-                first.to_span() + last.to_span()
+            BorderStyle::Solid => Span::DUMMY,
+            BorderStyle::Dotted { radius, spacing, .. } => {
+                ToSpan::to_span(radius) + ToSpan::to_span(spacing)
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_generic_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_generic_struct.snap
@@ -3,12 +3,13 @@ source: crates/csskit_derives/src/test/test_to_span.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl ::css_parse::ToSpan for BorderStyle {
+impl<T, U> ::css_parse::ToSpan for Pair<T, U>
+where
+    T: ::css_parse::ToSpan,
+    U: ::css_parse::ToSpan,
+{
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
-        match self {
-            BorderStyle::Solid => Span::DUMMY,
-            BorderStyle::Dashed { width, .. } => ToSpan::to_span(width),
-        }
+        ToSpan::to_span(&self.left) + ToSpan::to_span(&self.right)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_struct_with_required_middle_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_struct_with_required_middle_field.snap
@@ -3,12 +3,9 @@ source: crates/csskit_derives/src/test/test_to_span.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl ::css_parse::ToSpan for BorderStyle {
+impl ::css_parse::ToSpan for Block {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
-        match self {
-            BorderStyle::Solid => Span::DUMMY,
-            BorderStyle::Dashed { width, .. } => ToSpan::to_span(width),
-        }
+        ToSpan::to_span(&self.open) + ToSpan::to_span(&self.close)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_multiple_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_multiple_fields.snap
@@ -6,7 +6,6 @@ expression: pretty
 impl ::css_parse::ToSpan for Range {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
-        let first = self.0.to_span();
-        first + self.1.to_span()
+        ToSpan::to_span(&self.0) + ToSpan::to_span(&self.1)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_optional_first_and_last.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_optional_first_and_last.snap
@@ -3,12 +3,9 @@ source: crates/csskit_derives/src/test/test_to_span.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl ::css_parse::ToSpan for BorderStyle {
+impl ::css_parse::ToSpan for Ratio {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
-        match self {
-            BorderStyle::Solid => Span::DUMMY,
-            BorderStyle::Dashed { width, .. } => ToSpan::to_span(width),
-        }
+        ToSpan::to_span(&self.0) + ToSpan::to_span(&self.1) + ToSpan::to_span(&self.2)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_tuple_struct_single_field.snap
@@ -6,6 +6,6 @@ expression: pretty
 impl ::css_parse::ToSpan for Length {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
-        self.0.to_span()
+        ToSpan::to_span(&self.0)
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_unit_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_span__to_span_unit_struct.snap
@@ -3,12 +3,9 @@ source: crates/csskit_derives/src/test/test_to_span.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl ::css_parse::ToSpan for BorderStyle {
+impl ::css_parse::ToSpan for Nothing {
     fn to_span(&self) -> ::css_parse::Span {
         use ::css_parse::{Span, ToSpan};
-        match self {
-            BorderStyle::Solid => Span::DUMMY,
-            BorderStyle::Dashed { width, .. } => ToSpan::to_span(width),
-        }
+        Span::DUMMY
     }
 }

--- a/crates/csskit_derives/src/test/test_to_span.rs
+++ b/crates/csskit_derives/src/test/test_to_span.rs
@@ -68,3 +68,73 @@ fn to_span_enum_mixed_variants() {
 	};
 	assert_to_span_snapshot!(data, "to_span_enum_mixed_variants");
 }
+
+#[test]
+fn to_span_enum_variant_with_optional_middle_field() {
+	let data = to_deriveinput! {
+		enum VerticalAlign {
+			First { first: Option<Ident>, alignment_baseline: Option<Ident>, baseline_shift: Option<Length> },
+		}
+	};
+	assert_to_span_snapshot!(data, "to_span_enum_variant_with_optional_middle_field");
+}
+
+#[test]
+fn to_span_unit_struct() {
+	let data = to_deriveinput! {
+		struct Nothing;
+	};
+	assert_to_span_snapshot!(data, "to_span_unit_struct");
+}
+
+#[test]
+fn to_span_all_optional_struct() {
+	let data = to_deriveinput! {
+		struct Sides { top: Option<Length>, right: Option<Length>, bottom: Option<Length> }
+	};
+	assert_to_span_snapshot!(data, "to_span_all_optional_struct");
+}
+
+#[test]
+fn to_span_struct_with_required_middle_field() {
+	let data = to_deriveinput! {
+		struct Block { open: Curly, items: Vec<Item>, close: Curly }
+	};
+	assert_to_span_snapshot!(data, "to_span_struct_with_required_middle_field");
+}
+
+#[test]
+fn to_span_enum_variant_with_required_middle_field() {
+	let data = to_deriveinput! {
+		enum Rule {
+			Block { open: Curly, items: Vec<Item>, close: Curly },
+		}
+	};
+	assert_to_span_snapshot!(data, "to_span_enum_variant_with_required_middle_field");
+}
+
+#[test]
+fn to_span_enum_variant_with_fields_named_first_and_last() {
+	let data = to_deriveinput! {
+		enum BaselinePosition {
+			Both { last: Ident, spread: Option<Length>, first: Ident },
+		}
+	};
+	assert_to_span_snapshot!(data, "to_span_enum_variant_with_fields_named_first_and_last");
+}
+
+#[test]
+fn to_span_tuple_struct_optional_first_and_last() {
+	let data = to_deriveinput! {
+		struct Ratio(Option<Number>, Slash, Option<Number>);
+	};
+	assert_to_span_snapshot!(data, "to_span_tuple_struct_optional_first_and_last");
+}
+
+#[test]
+fn to_span_generic_struct() {
+	let data = to_deriveinput! {
+		struct Pair<T, U> { left: T, right: U }
+	};
+	assert_to_span_snapshot!(data, "to_span_generic_struct");
+}

--- a/crates/csskit_derives/src/to_span.rs
+++ b/crates/csskit_derives/src/to_span.rs
@@ -1,8 +1,28 @@
 use crate::{FieldsExt, WhereCollector};
-use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Result, parse_quote};
+
+/// Indexes of the fields which can bound a node's span: the leading run of optional fields up to and
+/// including the first field which is always present, and the same run taken from the end.
+///
+/// Span addition takes the lowest start and the highest end, and absorbs `Span::DUMMY`, which is what
+/// an absent field gives. Adding these fields therefore gives the whole node's span without visiting
+/// the fields between them.
+fn bounding(optional: &[bool]) -> impl Iterator<Item = usize> {
+	let head = optional.iter().position(|optional| !optional).map_or(optional.len(), |i| i + 1);
+	let tail = optional.iter().rposition(|optional| !optional).unwrap_or(0).max(head);
+	(0..head).chain(tail..optional.len())
+}
+
+/// Builds the expression for the span a node covers, from the accessors for its bounding fields.
+fn span_of(accesses: &[TokenStream]) -> TokenStream {
+	if accesses.is_empty() {
+		quote! { Span::DUMMY }
+	} else {
+		quote! { #(ToSpan::to_span(#accesses))+* }
+	}
+}
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let mut where_collector = WhereCollector::new();
@@ -16,69 +36,15 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 			for syn_field in fields.iter() {
 				where_collector.add(&syn_field.ty);
 			}
-			let members: Vec<_> = fields.views().into_iter().map(|v| (v.member, v.is_option)).collect();
-
-			if members.len() == 1 || members.iter().all(|(_, is_option)| *is_option) {
-				let members = members.iter().map(|(m, _)| m);
-				quote! { #(self.#members.to_span())+* }
-			} else {
-				members
-					.iter()
-					.take_while_inclusive(|(_, is_option)| *is_option)
-					.with_position()
-					.map(|(position, (member, _))| {
-						if position.is_exactly_one() {
-							quote! { let first = self.#member.to_span(); }
-						} else if position.is_first {
-							quote! {
-								let first = if let Some(ref value) = self.#member {
-									value.to_span()
-								}
-							}
-						} else if position.is_last() {
-							quote! {
-								else {
-									self.#member.to_span()
-								};
-							}
-						} else {
-							debug_assert!(position.is_middle());
-							quote! {
-							   else if let Some(ref value) = self.#member {
-								   value.to_span()
-							   }
-							}
-						}
-					})
-					.chain(members.iter().rev().take_while_inclusive(|(_, is_option)| *is_option).with_position().map(
-						|(position, (member, _))| {
-							if position.is_exactly_one() {
-								quote! { first + self.#member.to_span() }
-							} else if position.is_first() {
-								quote! {
-									let last = if let Some(ref value) = self.#member {
-										value.to_span()
-									}
-								}
-							} else if position.is_last() {
-								quote! {
-									else {
-										self.#member.to_span()
-									};
-									first + last
-								}
-							} else {
-								debug_assert!(position.is_middle());
-								quote! {
-									else if let Some(ref value) = self.#member {
-										value.to_span()
-									}
-								}
-							}
-						},
-					))
-					.collect()
-			}
+			let views = fields.views();
+			let optional: Vec<bool> = views.iter().map(|view| view.is_option).collect();
+			let accesses: Vec<_> = bounding(&optional)
+				.map(|i| {
+					let member = &views[i].member;
+					quote! { &self.#member }
+				})
+				.collect();
+			span_of(&accesses)
 		}
 
 		Data::Enum(DataEnum { variants, .. }) => {
@@ -86,38 +52,36 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 				.iter()
 				.map(|variant| {
 					let variant_ident = &variant.ident;
-					let views = variant.fields.views();
-					let len = views.len();
 					for syn_field in variant.fields.iter() {
 						where_collector.add(&syn_field.ty);
 					}
+					let views = variant.fields.views();
+					let optional: Vec<bool> = views.iter().map(|view| view.is_option).collect();
+					let bound: Vec<usize> = bounding(&optional).collect();
+					let accesses: Vec<_> = bound
+						.iter()
+						.map(|&i| {
+							let binding = &views[i].binding;
+							quote! { #binding }
+						})
+						.collect();
+					let body = span_of(&accesses);
 					match &variant.fields {
+						Fields::Unit => quote! { #ident::#variant_ident => #body, },
 						Fields::Named(_) => {
-							if len == 1 {
-								let m = &views[0].member;
-								quote! { #ident::#variant_ident { #m: val } => val.to_span(), }
-							} else {
-								let first_m = &views[0].member;
-								let last_m = &views[len - 1].member;
-								let rest_pats = views[1..len - 1].iter().map(|v| {
-									let m = &v.member;
-									quote! { #m: _ }
-								});
-								quote! {
-									#ident::#variant_ident { #first_m: first, #(#rest_pats,)* #last_m: last }
-										=> first.to_span() + last.to_span(),
-								}
-							}
+							let bindings = bound.iter().map(|&i| &views[i].binding);
+							quote! { #ident::#variant_ident { #(#bindings,)* .. } => #body, }
 						}
-						_ => {
-							if len == 1 {
-								quote! { #ident::#variant_ident(val) => val.to_span(), }
-							} else {
-								let rest = (2..len).map(|_| quote! { _ }).chain([quote! { last }]);
-								quote! {
-									#ident::#variant_ident(first, #(#rest),*) => first.to_span() + last.to_span(),
+						Fields::Unnamed(_) => {
+							let bindings = views.iter().enumerate().map(|(i, view)| {
+								let binding = &view.binding;
+								if bound.contains(&i) {
+									quote! { #binding }
+								} else {
+									quote! { _ }
 								}
-							}
+							});
+							quote! { #ident::#variant_ident(#(#bindings),*) => #body, }
 						}
 					}
 				})

--- a/crates/csskit_transform/src/remove_inert_nodes.rs
+++ b/crates/csskit_transform/src/remove_inert_nodes.rs
@@ -58,6 +58,17 @@ mod tests {
 	}
 
 	#[test]
+	fn removes_consecutive_empty_style_rules() {
+		assert_transform!(
+			CssMinifierFeature::RemoveInertNodes,
+			CssAtomSet,
+			StyleSheet,
+			"kbd {}\nul li:nth-of-type(2n) {}\nfieldset > legend {}",
+			""
+		);
+	}
+
+	#[test]
 	fn removes_empty_media_rule() {
 		assert_transform!(
 			CssMinifierFeature::RemoveInertNodes,


### PR DESCRIPTION
When adding spans, Spans they take the lowest start and highest end. Span::DUMMY gets ignored. A node's bounding fields added together give the same span as adding all fields.

This change drastically simplifies the derive to do this operation more simply.