### PR TITLE
csskit_derives: rewrite derive(ToCursors)

### DIFF
--- a/crates/csskit_derives/src/field_view.rs
+++ b/crates/csskit_derives/src/field_view.rs
@@ -1,6 +1,6 @@
-use proc_macro2::{Ident, Span};
-use quote::format_ident;
-use syn::{Fields, GenericArgument, Index, Member, PathArguments, Type};
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::{Attribute, Data, DeriveInput, Error, Fields, GenericArgument, Index, Member, PathArguments, Result, Type};
 
 /// A normalised view of a single struct or variant field.
 #[derive(Debug)]
@@ -39,6 +39,61 @@ impl FieldsExt for Fields {
 				FieldView { binding, member, ty, is_option }
 			})
 			.collect()
+	}
+}
+
+/// A struct, or one variant of an enum: the path which names it in a pattern, its attributes, and
+/// its fields.
+pub struct Arm<'a> {
+	pub path: TokenStream,
+	#[allow(dead_code)]
+	pub attrs: &'a [Attribute],
+	pub fields: &'a Fields,
+}
+
+impl<'a> Arm<'a> {
+	/// Every arm of a derive input: one for a struct, one per variant for an enum.
+	pub fn all(input: &'a DeriveInput) -> Result<Vec<Self>> {
+		match &input.data {
+			Data::Union(_) => Err(Error::new(input.ident.span(), "Cannot derive on a Union")),
+			Data::Struct(data) => Ok(vec![Self { path: quote! { Self }, attrs: &input.attrs, fields: &data.fields }]),
+			Data::Enum(data) => Ok(data
+				.variants
+				.iter()
+				.map(|variant| {
+					let ident = &variant.ident;
+					Self { path: quote! { Self::#ident }, attrs: &variant.attrs, fields: &variant.fields }
+				})
+				.collect()),
+		}
+	}
+
+	/// The pattern which binds each field to the identifier `bind` gives it, and ignores the fields
+	/// `bind` gives none.
+	pub fn pattern(&self, bind: impl Fn(usize, &FieldView) -> Option<Ident>) -> TokenStream {
+		let path = &self.path;
+		let views = self.fields.views();
+		let bindings = views.iter().enumerate().map(|(i, view)| bind(i, view));
+		match self.fields {
+			Fields::Unit => quote! { #path },
+			Fields::Named(_) => {
+				let fields = views.iter().zip(bindings).filter_map(|(view, binding)| {
+					let binding = binding?;
+					let name = &view.member;
+					Some(if view.binding == binding {
+						quote! { #binding }
+					} else {
+						quote! { #name: #binding }
+					})
+				});
+				quote! { #path { #(#fields,)* .. } }
+			}
+			Fields::Unnamed(_) => {
+				let bindings =
+					bindings.map(|binding| binding.map_or_else(|| quote! { _ }, |binding| quote! { #binding }));
+				quote! { #path(#(#bindings),*) }
+			}
+		}
 	}
 }
 

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_mixed_variants.snap
@@ -5,21 +5,14 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for BorderStyle {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        match *self {
-            BorderStyle::Solid => {}
-            BorderStyle::Dashed { width: ref __binding_0 } => {
-                ::css_parse::ToCursors::to_cursors(__binding_0, s);
+        match self {
+            Self::Solid => {}
+            Self::Dashed { width, .. } => {
+                ::css_parse::ToCursors::to_cursors(width, s);
             }
-            BorderStyle::Dotted {
-                radius: ref __binding_0,
-                spacing: ref __binding_1,
-            } => {
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
-                }
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
-                }
+            Self::Dotted { radius, spacing, .. } => {
+                ::css_parse::ToCursors::to_cursors(radius, s);
+                ::css_parse::ToCursors::to_cursors(spacing, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_multiple_field_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_multiple_field_variants.snap
@@ -5,25 +5,17 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Value {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        match *self {
-            Value::Length(ref __binding_0, ref __binding_1) => {
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
-                }
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
-                }
+        match self {
+            Self::Length(v0, v1) => {
+                ::css_parse::ToCursors::to_cursors(v0, s);
+                ::css_parse::ToCursors::to_cursors(v1, s);
             }
-            Value::Percentage(ref __binding_0) => {
-                ::css_parse::ToCursors::to_cursors(__binding_0, s);
+            Self::Percentage(v0) => {
+                ::css_parse::ToCursors::to_cursors(v0, s);
             }
-            Value::Function(ref __binding_0, ref __binding_1) => {
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
-                }
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
-                }
+            Self::Function(v0, v1) => {
+                ::css_parse::ToCursors::to_cursors(v0, s);
+                ::css_parse::ToCursors::to_cursors(v1, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_single_field_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_single_field_variants.snap
@@ -5,15 +5,15 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Display {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        match *self {
-            Display::Block(ref __binding_0) => {
-                ::css_parse::ToCursors::to_cursors(__binding_0, s);
+        match self {
+            Self::Block(v0) => {
+                ::css_parse::ToCursors::to_cursors(v0, s);
             }
-            Display::Inline(ref __binding_0) => {
-                ::css_parse::ToCursors::to_cursors(__binding_0, s);
+            Self::Inline(v0) => {
+                ::css_parse::ToCursors::to_cursors(v0, s);
             }
-            Display::None(ref __binding_0) => {
-                ::css_parse::ToCursors::to_cursors(__binding_0, s);
+            Self::None(v0) => {
+                ::css_parse::ToCursors::to_cursors(v0, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_enum_with_lifetime.snap
@@ -5,17 +5,13 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::ToCursors for CssValue<'a> {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        match *self {
-            CssValue::Keyword(ref __binding_0) => {
-                ::css_parse::ToCursors::to_cursors(__binding_0, s);
+        match self {
+            Self::Keyword(v0) => {
+                ::css_parse::ToCursors::to_cursors(v0, s);
             }
-            CssValue::Function { name: ref __binding_0, args: ref __binding_1 } => {
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
-                }
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
-                }
+            Self::Function { name, args, .. } => {
+                ::css_parse::ToCursors::to_cursors(name, s);
+                ::css_parse::ToCursors::to_cursors(args, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_named_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_named_struct.snap
@@ -5,21 +5,11 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Color {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        match *self {
-            Color {
-                red: ref __binding_0,
-                green: ref __binding_1,
-                blue: ref __binding_2,
-            } => {
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
-                }
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
-                }
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_2, s);
-                }
+        match self {
+            Self { red, green, blue, .. } => {
+                ::css_parse::ToCursors::to_cursors(red, s);
+                ::css_parse::ToCursors::to_cursors(green, s);
+                ::css_parse::ToCursors::to_cursors(blue, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_named_struct_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_named_struct_with_lifetime.snap
@@ -5,14 +5,10 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::ToCursors for Value<'a> {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        match *self {
-            Value { content: ref __binding_0, unit: ref __binding_1 } => {
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
-                }
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
-                }
+        match self {
+            Self { content, unit, .. } => {
+                ::css_parse::ToCursors::to_cursors(content, s);
+                ::css_parse::ToCursors::to_cursors(unit, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_tuple_struct_multiple_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_tuple_struct_multiple_fields.snap
@@ -5,17 +5,11 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Position {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        match *self {
-            Position(ref __binding_0, ref __binding_1, ref __binding_2) => {
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_0, s);
-                }
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_1, s);
-                }
-                {
-                    ::css_parse::ToCursors::to_cursors(__binding_2, s);
-                }
+        match self {
+            Self(v0, v1, v2) => {
+                ::css_parse::ToCursors::to_cursors(v0, s);
+                ::css_parse::ToCursors::to_cursors(v1, s);
+                ::css_parse::ToCursors::to_cursors(v2, s);
             }
         }
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_tuple_struct_single_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_to_cursors__to_cursors_tuple_struct_single_field.snap
@@ -5,9 +5,9 @@ expression: pretty
 #[automatically_derived]
 impl ::css_parse::ToCursors for Length {
     fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-        match *self {
-            Length(ref __binding_0) => {
-                ::css_parse::ToCursors::to_cursors(__binding_0, s);
+        match self {
+            Self(v0) => {
+                ::css_parse::ToCursors::to_cursors(v0, s);
             }
         }
     }

--- a/crates/csskit_derives/src/to_cursors.rs
+++ b/crates/csskit_derives/src/to_cursors.rs
@@ -1,45 +1,39 @@
+use crate::{FieldsExt, WhereCollector, field_view::Arm};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Error, Fields, Result, parse_quote};
-use synstructure::{AddBounds, BindStyle, Structure};
-
-use crate::WhereCollector;
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream> {
-	if let Data::Struct(ref s) = input.data
+	if let Data::Struct(s) = &input.data
 		&& matches!(s.fields, Fields::Unit)
 	{
 		return Err(Error::new(input.ident.span(), "Cannot derive ToCursors on this struct"));
 	}
-	if matches!(input.data, Data::Union(_)) {
-		return Err(Error::new(input.ident.span(), "Cannot derive ToCursors on a Union"));
-	}
-
-	let mut s = Structure::try_new(&input)?;
-	s.add_bounds(AddBounds::None);
-	s.bind_with(|_| BindStyle::Ref);
-
-	let body = s.each(|bi| {
-		quote! { ::css_parse::ToCursors::to_cursors(#bi, s); }
-	});
+	let arms = Arm::all(&input)?;
 
 	let mut wc = WhereCollector::new();
-	for variant in s.variants() {
-		for binding in variant.bindings() {
-			wc.add(&binding.ast().ty);
-		}
-	}
-	let where_clause = wc.extend_where_clause(&input.generics, parse_quote! { ::css_parse::ToCursors });
+	let arms: Vec<TokenStream> = arms
+		.iter()
+		.map(|arm| {
+			for field in arm.fields.iter() {
+				wc.add(&field.ty);
+			}
+			let pattern = arm.pattern(|_, view| Some(view.binding.clone()));
+			let bindings = arm.fields.views().into_iter().map(|view| view.binding);
+			quote! { #pattern => { #(::css_parse::ToCursors::to_cursors(#bindings, s);)* } }
+		})
+		.collect();
+	let body = quote! { match self { #(#arms)* } };
 
+	let where_clause = wc.extend_where_clause(&input.generics, parse_quote! { ::css_parse::ToCursors });
 	let ident = &input.ident;
-	let generics = &input.generics;
-	let (impl_generics, type_generics, _) = generics.split_for_impl();
+	let (impl_generics, type_generics, _) = input.generics.split_for_impl();
 
 	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics ::css_parse::ToCursors for #ident #type_generics #where_clause {
 			fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
-				match *self { #body }
+				#body
 			}
 		}
 	})


### PR DESCRIPTION
A node writes every field in order. We can simplify this pattern by using an Arm strict struct which maps over a struct or one enum variant and builds its match pattern, so the derive is one loop over arms with no requirement to synstructure.