### PR TITLE
csskit_derives: rewrite derive(Peek)

### DIFF
--- a/crates/csskit_derives/src/attributes.rs
+++ b/crates/csskit_derives/src/attributes.rs
@@ -41,7 +41,7 @@ pub fn extract_field_parse_mode(attrs: &[Attribute]) -> Result<FieldParseMode> {
 	})
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Atom(ExprPath);
 
 impl Atom {

--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -5,13 +5,12 @@ use crate::{
 	field_view::option_inner,
 };
 use proc_macro2::{Span, TokenStream};
-use quote::{ToTokens, quote};
-use std::collections::{HashMap, hash_map::Entry};
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Ident, Result, Type, parse_quote};
+use quote::quote;
+use syn::{Attribute, Data, DeriveInput, Error, Fields, Ident, Result, Type, parse_quote};
 
-/// Map indivudal type names to a Kind, if possible.
-fn map_type_to_kind(ty: &Type) -> Option<&'static str> {
-	if let Type::Path(path) = option_inner(ty).unwrap_or(ty)
+/// The lexer kind which always starts a token type, if it is one.
+fn kind_of(ty: &Type) -> Option<&'static str> {
+	if let Type::Path(path) = ty
 		&& let Some(seg) = path.path.segments.last()
 	{
 		match seg.ident.to_string().as_str() {
@@ -30,19 +29,27 @@ fn map_type_to_kind(ty: &Type) -> Option<&'static str> {
 	}
 }
 
-/// Build a peek check for a single type, optionally constrained to a set of atoms.
-/// `atoms` empty means unconstrained (just `peek`); non-empty means `peek && (atom || atom || ...)`.
-fn generate_type_peek(ty: &Type, atoms: &[Atom], where_collector: &mut WhereCollector) -> TokenStream {
-	where_collector.add(ty);
-	if atoms.is_empty() {
-		quote! { <#ty>::peek(p, c) }
-	} else {
-		let atom_checks = atoms.iter().map(|a| {
-			let path = a.path();
-			quote! { p.equals_atom(c.into(), &#path) }
-		});
-		quote! { (<#ty>::peek(p, c) && (#(#atom_checks)||*)) }
+/// The types which can start a node, each with the atom it must equal: the leading run of optional
+/// fields up to and including the first field which is always present, or every field when the parse
+/// mode lets any field come first. An atom on the whole node takes precedence over a field's own.
+fn starts<'f>(attrs: &[Attribute], fields: &'f Fields) -> Result<Vec<(&'f Type, Option<Atom>)>> {
+	let any_field_can_start = extract_field_parse_mode(attrs)?.any_field_can_start();
+	let atom = extract_atom(attrs)?;
+	let mut starts = vec![];
+	for (view, field) in fields.views().into_iter().zip(fields.iter()) {
+		if extract_peek_skip(&field.attrs) {
+			continue;
+		}
+		let atom = match &atom {
+			Some(atom) => Some(atom.clone()),
+			None => extract_atom(&field.attrs)?,
+		};
+		starts.push((option_inner(view.ty).unwrap_or(view.ty), atom));
+		if !any_field_can_start && !view.is_option {
+			break;
+		}
 	}
+	Ok(starts)
 }
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream> {
@@ -52,139 +59,73 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let generic_with_a = ensure_lifetime_a(generics);
 	let (impl_generics, _, _) = generic_with_a.split_for_impl();
 	let (_, type_generics, _) = generics.split_for_impl();
-	let mut kinds = vec![];
-	let body = match input.data {
+
+	let starts = match &input.data {
 		Data::Union(_) => return Err(Error::new(ident.span(), "Cannot derive Peek on a Union")),
+		Data::Struct(data) => starts(&input.attrs, &data.fields)?,
+		Data::Enum(data) => {
+			let mut starts = vec![];
+			for variant in data.variants.iter().filter(|variant| !extract_peek_skip(&variant.attrs)) {
+				starts.extend(self::starts(&variant.attrs, &variant.fields)?);
+			}
+			starts
+		}
+	};
 
-		Data::Struct(DataStruct { ref fields, .. }) => {
-			let parse_mode = extract_field_parse_mode(&input.attrs)?;
-			let mut checks: Vec<TokenStream> = vec![];
-			for (view, syn_field) in fields.views().into_iter().zip(fields.iter()) {
-				if extract_peek_skip(&syn_field.attrs) {
-					continue;
-				}
-				let atom = extract_atom(&syn_field.attrs)?;
-				let atoms = atom.map(|a| vec![a]).unwrap_or_default();
-				let peek_ty = option_inner(view.ty).unwrap_or(view.ty);
-				if atoms.is_empty()
-					&& let Some(kind) = map_type_to_kind(peek_ty)
-				{
-					let ident = Ident::new(kind, Span::call_site());
-					kinds.push(quote! { ::css_lexer::Kind::#ident });
-				} else {
-					checks.push(generate_type_peek(peek_ty, &atoms, &mut where_collector));
-				}
-				if !parse_mode.any_field_can_start() && !view.is_option {
-					break;
+	// Bare token types collapse into one kind set. Other types check `peek`, once per type, with any
+	// atoms the type was given unioned; a type which appears once without an atom is unconstrained.
+	let mut kinds: Vec<Ident> = vec![];
+	let mut checks: Vec<(&Type, Option<Vec<Atom>>)> = vec![];
+	for (ty, atom) in starts {
+		match (kind_of(ty), atom) {
+			(Some(kind), None) => {
+				let kind = Ident::new(kind, Span::call_site());
+				if !kinds.contains(&kind) {
+					kinds.push(kind);
 				}
 			}
-			quote! { #(#checks)||* }
-		}
-
-		Data::Enum(DataEnum { variants, .. }) => {
-			let mut seen: Vec<String> = vec![];
-			let mut by_type: HashMap<String, Option<Vec<Atom>>> = HashMap::new();
-
-			let mut register = |peek_ty: &Type, atom: Option<Atom>| {
-				let key = peek_ty.to_token_stream().to_string();
-				if atom.is_none()
-					&& let Some(kind) = map_type_to_kind(peek_ty)
-				{
-					if !seen.contains(&kind.to_string()) {
-						seen.push(kind.to_string());
-						let ident = Ident::new(kind, Span::call_site());
-						kinds.push(quote! { ::css_lexer::Kind::#ident });
-					}
-					return;
-				}
-				match by_type.entry(key.clone()) {
-					Entry::Vacant(e) => {
-						seen.push(key);
-						e.insert(atom.map(|a| vec![a]));
-					}
-					Entry::Occupied(mut e) => match (e.get_mut(), atom) {
-						(None, _) => {}
-						(slot @ Some(_), None) => *slot = None,
-						(Some(existing), Some(a)) => {
-							let path = a.path().to_token_stream().to_string();
-							if !existing.iter().any(|x| x.path().to_token_stream().to_string() == path) {
-								existing.push(a);
-							}
+			(_, atom) => match checks.iter_mut().find(|(seen, _)| *seen == ty) {
+				None => checks.push((ty, atom.map(|atom| vec![atom]))),
+				Some((_, atoms)) => match (atoms, atom) {
+					(Some(atoms), Some(atom)) => {
+						if !atoms.contains(&atom) {
+							atoms.push(atom);
 						}
-					},
-				}
-			};
-
-			for variant in variants.iter() {
-				if extract_peek_skip(&variant.attrs) {
-					continue;
-				}
-				let views = variant.fields.views();
-				let parse_mode = extract_field_parse_mode(&variant.attrs)?;
-				for (view, syn_field) in views.iter().zip(variant.fields.iter()) {
-					if extract_peek_skip(&syn_field.attrs) {
-						continue;
 					}
-					let atom = match extract_atom(&variant.attrs)? {
-						Some(a) => Some(a),
-						None => extract_atom(&syn_field.attrs)?,
-					};
-					let option = option_inner(view.ty);
-					let peek_ty = option.unwrap_or(view.ty);
-					register(peek_ty, atom);
-					if !parse_mode.any_field_can_start() && option.is_none() {
-						break;
-					}
-				}
-			}
-
-			let mut type_checks: Vec<TokenStream> = vec![];
-			for key in &seen {
-				let Some(entry) = by_type.remove(key) else {
-					continue;
-				};
-				let ty = variants
-					.iter()
-					.find_map(|v| {
-						v.fields.views().into_iter().find_map(|vw| {
-							let peek_ty = option_inner(vw.ty).unwrap_or(vw.ty);
-							if peek_ty.to_token_stream().to_string() == *key { Some(peek_ty.clone()) } else { None }
-						})
-					})
-					.unwrap();
-				let atoms = entry.unwrap_or_default();
-				type_checks.push(generate_type_peek(&ty, &atoms, &mut where_collector));
-			}
-			quote! { #(#type_checks)||* }
+					(atoms, None) => *atoms = None,
+					(None, _) => {}
+				},
+			},
 		}
-	};
+	}
 
-	let generics = input.generics.clone();
-	let where_clause = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::Peek<'a> });
-	let (peek_kindset, kindset_cond) = if kinds.is_empty() {
-		(None, None)
-	} else {
-		(
-			Some(quote! {
-			  const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(&[ #(#kinds),* ]);
-			}),
-			Some(quote! { c == Self::PEEK_KINDSET ||  }),
-		)
-	};
-	let peek_fn = if body.is_empty() {
-		None
-	} else {
-		Some(quote! {
+	let peek_kindset = (!kinds.is_empty()).then(|| {
+		quote! {
+			const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(&[ #(::css_lexer::Kind::#kinds),* ]);
+		}
+	});
+	let peek_fn = (!checks.is_empty()).then(|| {
+		let kindset_cond = peek_kindset.is_some().then(|| quote! { c == Self::PEEK_KINDSET || });
+		let checks = checks.iter().map(|(ty, atoms)| {
+			where_collector.add(ty);
+			match atoms {
+				None => quote! { <#ty>::peek(p, c) },
+				Some(atoms) => quote! { (<#ty>::peek(p, c) && (#(p.equals_atom(c.into(), &#atoms))||*)) },
+			}
+		});
+		quote! {
 			#[inline(always)]
 			fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
 			where
 				I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
 				{
 				use ::css_parse::{Peek};
-				#kindset_cond #body
+				#kindset_cond #(#checks)||*
 			}
-		})
-	};
+		}
+	});
+
+	let where_clause = where_collector.extend_where_clause(generics, parse_quote! { ::css_parse::Peek<'a> });
 
 	Ok(quote! {
 		#[automatically_derived]


### PR DESCRIPTION
A node can start wherever one of its start fields can start: the leading
optional fields through the first required one, or every field when the parse
mode is unordered; an enum is the union over variants.

This change drastically rewrites derive(Peek) following this core principle.
