### PR TITLE
csskit_derives: rewrite derive(Parse)

### DIFF
--- a/crates/css_ast/src/types/display_listitem.rs
+++ b/crates/css_ast/src/types/display_listitem.rs
@@ -15,6 +15,7 @@ use css_parse::parse_optionals;
 pub struct DisplayListitem {
 	pub outside: Option<DisplayOutside>,
 	pub inside: Option<DisplayListitemInside>,
+	#[atom(CssAtomSet::ListItem)]
 	pub list_item: T![Ident],
 }
 
@@ -78,13 +79,13 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayListitem, "foo");
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "list-item list-item");
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "flow flow list-item");
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "block inline list-item");
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "list-item flow flow-root");
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "list item"); // missing hyphen
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "listitem"); // missing hyphen
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayListitem, "list item"); // missing hyphen
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayListitem, "listitem"); // missing hyphen
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "block flow-root flow list-item");
 		assert_peek_false!(CssAtomSet::ATOMS, DisplayListitemInside, "foo");
 		assert_peek_false!(CssAtomSet::ATOMS, DisplayListitemInside, "list-item");

--- a/crates/css_ast/src/values/display/impls.rs
+++ b/crates/css_ast/src/values/display/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn test_writes() {
@@ -57,6 +57,6 @@ mod tests {
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayStyleValue, "flex flex");
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayStyleValue, "flow flex");
 
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayStyleValue, "inherit");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayStyleValue, "inherit");
 	}
 }

--- a/crates/css_ast/tests/snapshots/popular_snapshots__960.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__960.snap
@@ -11000,11 +11000,11 @@ StyleSheet(
                 offset: SourceOffset(9701),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(9703),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__blueprint.1.0.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__blueprint.1.0.1.snap
@@ -3555,11 +3555,11 @@ StyleSheet(
                 offset: SourceOffset(3285),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(3287),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
@@ -3356,11 +3356,11 @@ StyleSheet(
                 offset: SourceOffset(2743),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(2745),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -105944,7 +105944,7 @@ StyleSheet(
                 offset: SourceOffset(82500),
                 len: 1,
               )),
-              value: ContentList(Substituted(Attr(AttrFunction(
+              value: ContentReplacement(Substituted(Attr(AttrFunction(
                 name: Function(Cursor(
                   kind: "Function",
                   offset: SourceOffset(82502),
@@ -142242,11 +142242,11 @@ StyleSheet(
                 offset: SourceOffset(112040),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(112042),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -248188,11 +248188,11 @@ StyleSheet(
                 kind: "Delim",
                 offset: SourceOffset(198775),
                 len: 1,
-              ))), LengthPercentage(Literal(Zero(Number(Cursor(
+              ))), Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(198776),
                 len: 1,
-              ))))))), [
+              )))))), [
                 (FontFamilyStyleValue([
                   (Left(Literal(CustomIdents([
                     Literal(CustomIdent(Ident(Cursor(

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
@@ -10850,11 +10850,11 @@ StyleSheet(
                 offset: SourceOffset(8462),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(8464),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__foundation.6.7.5.snap
@@ -1196,11 +1196,11 @@ StyleSheet(
                 offset: SourceOffset(1025),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(1027),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -80670,11 +80670,11 @@ StyleSheet(
                 offset: SourceOffset(62720),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(62722),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -207507,11 +207507,11 @@ StyleSheet(
                 offset: SourceOffset(160614),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(160616),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -208021,7 +208021,7 @@ StyleSheet(
               offset: SourceOffset(161039),
               len: 1,
             )))),
-            Tag(Mathml(Image(Ident(Cursor(
+            Tag(Svg(Image(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(161040),
               len: 5,

--- a/crates/css_ast/tests/snapshots/popular_snapshots__inuitcss.6.0.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__inuitcss.6.0.0.snap
@@ -1563,11 +1563,11 @@ StyleSheet(
                 offset: SourceOffset(13796),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(13798),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
@@ -4995,11 +4995,11 @@ StyleSheet(
                 offset: SourceOffset(4049),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(4051),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",
@@ -43977,7 +43977,7 @@ StyleSheet(
                       offset: SourceOffset(32661),
                       len: 1,
                     )),
-                    value: ContentList(Substituted(Attr(AttrFunction(
+                    value: ContentReplacement(Substituted(Attr(AttrFunction(
                       name: Function(Cursor(
                         kind: "Function",
                         offset: SourceOffset(32663),
@@ -47991,7 +47991,7 @@ StyleSheet(
                 offset: SourceOffset(35675),
                 len: 1,
               )),
-              value: ContentList(Substituted(Attr(AttrFunction(
+              value: ContentReplacement(Substituted(Attr(AttrFunction(
                 name: Function(Cursor(
                   kind: "Function",
                   offset: SourceOffset(35677),

--- a/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
@@ -38820,7 +38820,7 @@ StyleSheet(
                                 offset: SourceOffset(28921),
                                 len: 1,
                               )),
-                              value: ContentList(Substituted(Var(VarFunction(
+                              value: ContentReplacement(Substituted(Var(VarFunction(
                                 function: Function(Cursor(
                                   kind: "Function",
                                   offset: SourceOffset(28923),
@@ -38889,7 +38889,7 @@ StyleSheet(
                                 offset: SourceOffset(28983),
                                 len: 1,
                               )),
-                              value: ContentList(Substituted(Var(VarFunction(
+                              value: ContentReplacement(Substituted(Var(VarFunction(
                                 function: Function(Cursor(
                                   kind: "Function",
                                   offset: SourceOffset(28985),

--- a/crates/css_ast/tests/snapshots/popular_snapshots__pure.2.0.3.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__pure.2.0.3.snap
@@ -988,11 +988,11 @@ StyleSheet(
                 offset: SourceOffset(2684),
                 len: 1,
               )),
-              value: LengthPercentage(Literal(Zero(Number(Cursor(
+              value: Number(Literal(Number(Cursor(
                 kind: "Number",
                 offset: SourceOffset(2686),
                 len: 1,
-              ))))),
+              )))),
               important: None,
               semicolon: Some(Semicolon(Cursor(
                 kind: "Semicolon",

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -831,18 +831,20 @@ pub struct SizeComparison {
 	pub value: T![Number],
 }
 
+/// Variants are tried in order, so the two-token operators come before the one-token operators
+/// which start them.
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SizeOperator {
 	/// `!=` operator (not equal)
 	NotEqual(#[semantic_eq(skip)] T![!=]),
-	/// `>` operator (greater than)
-	GreaterThan(#[semantic_eq(skip)] T![>]),
-	/// `<` operator (less than)
-	LessThan(#[semantic_eq(skip)] T![<]),
 	/// `>=` operator (greater than or equal)
 	GreaterThanOrEqual(#[semantic_eq(skip)] T![>=]),
 	/// `<=` operator (less than or equal)
 	LessThanOrEqual(#[semantic_eq(skip)] T![<=]),
+	/// `>` operator (greater than)
+	GreaterThan(#[semantic_eq(skip)] T![>]),
+	/// `<` operator (less than)
+	LessThan(#[semantic_eq(skip)] T![<]),
 }
 
 impl QuerySizePseudo {

--- a/crates/csskit_derives/src/attributes.rs
+++ b/crates/csskit_derives/src/attributes.rs
@@ -54,11 +54,6 @@ impl Atom {
 		quote! { p.equals_atom(#cursor.into(), &#atom) }
 	}
 
-	pub fn to_atom(&self, cursor: Ident) -> TokenStream {
-		let atom_set = self.first_segment();
-		quote! { p.to_atom::<#atom_set>(#cursor) }
-	}
-
 	pub fn first_segment(&self) -> Ident {
 		self.0.path.segments.first().expect("atom path must have at least one segment").ident.clone()
 	}

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -1,3 +1,12 @@
+//! `derive(Parse)`.
+//!
+//! A struct parses its fields: in order, or for `#[parse(all_must_occur)]` / `one_must_occur` in
+//! any order until no field matches. An enum parses as the first variant whose leading tokens
+//! match. Variants are keyed by their start, the type and atom of their next field; variants which
+//! share a start are told apart after consuming it, on the field after, and a variant with no field
+//! left is the fallback for the ones which go on. Variants whose fields come in any order have no
+//! single start, so they are tried in turn, rewinding after each failure.
+
 use crate::{
 	FieldsExt, WhereCollector,
 	attributes::{Atom, FieldParseMode, extract_atom},
@@ -6,29 +15,9 @@ use crate::{
 	field_view::option_inner,
 };
 use darling::FromAttributes;
-use itertools::{Itertools, Position};
 use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote};
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, ExprPath, Fields, Result, Type, Variant, parse_quote};
-
-trait Plan {
-	fn render(&self, wc: &mut WhereCollector) -> TokenStream;
-}
-
-trait TypeIsOption {
-	fn is_option(&self) -> bool;
-	fn unpack_option(&self) -> Self;
-}
-
-impl TypeIsOption for Type {
-	fn is_option(&self) -> bool {
-		option_inner(self).is_some()
-	}
-
-	fn unpack_option(&self) -> Self {
-		option_inner(self).cloned().unwrap_or_else(|| self.clone())
-	}
-}
+use quote::{ToTokens, format_ident, quote};
+use syn::{Data, DeriveInput, Error, Fields, Member, Result, Type, parse_quote};
 
 #[derive(Debug, Default, FromAttributes)]
 #[darling(attributes(parse))]
@@ -51,1412 +40,482 @@ impl ParseArg {
 	}
 }
 
-#[derive(Debug)]
 struct Field {
 	var: Ident,
+	member: Member,
+	/// The type parsed, with any `Option` removed.
 	ty: Type,
-	arg: ParseArg,
+	optional: bool,
 	atom: Option<Atom>,
+	state: Option<Ident>,
 }
 
 impl Field {
-	fn parse_tokens(&self, wc: &mut WhereCollector) -> TokenStream {
-		if self.atom.is_some() {
-			self.parse_keyword_tokens(wc)
-		} else {
-			self.parse_normal_tokens(FieldParseMode::Sequential, wc)
-		}
-	}
-
-	fn parse_keyword_tokens(&self, wc: &mut WhereCollector) -> TokenStream {
-		let Field { var, ty, atom, .. } = self;
-		let atom = atom.as_ref().expect("parse_keyword_tokens called without atom");
-		let condition = atom.equals_atom(format_ident!("c"));
-		let inner_ty = ty.unpack_option();
-		wc.add(&inner_ty);
-		if ty.is_option() {
-			quote! {
-				let #var = {
-					let c = p.peek_n(1);
-					if #condition {
-						Some(p.parse::<#inner_ty>()?)
-					} else {
-						None
-					}
-				};
-			}
-		} else {
-			quote! {
-				let #var = {
-					let c = p.peek_n(1);
-					if #condition {
-						p.parse::<#inner_ty>()?
-					} else {
-						return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
-					}
-				};
-			}
-		}
-	}
-
-	fn parse_normal_tokens(&self, parse_mode: FieldParseMode, wc: &mut WhereCollector) -> TokenStream {
-		let Field { var, ty, arg, .. } = self;
-		match parse_mode {
-			FieldParseMode::Sequential => {
-				wc.add(ty);
-				if let Some(crate::darling_ext::StateArg(state_ident)) = &arg.state {
-					quote! {
-						let #var = {
-							let old_state = p.set_state(State::#state_ident);
-							let result = p.parse::<#ty>()?;
-							p.set_state(old_state);
-							result
-						};
-					}
-				} else {
-					quote! { let #var = p.parse::<#ty>()?; }
-				}
-			}
-			FieldParseMode::AllMustOccur | FieldParseMode::OneMustOccur => {
-				let inner_ty = ty.unpack_option();
-				wc.add(&inner_ty);
-				quote! {
-					if #var.is_none() && <#inner_ty>::peek(p, c) {
-						#var = Some(p.parse::<#inner_ty>()?);
-						continue;
-					}
-				}
-			}
-		}
-	}
-
-	/// Emits the atom-conditional match arm used in must-occur loops.
-	fn atom_match_arm(&self) -> TokenStream {
-		let atom = self.atom.as_ref().expect("atom_match_arm called without atom");
-		let atom_path = atom.path();
-		let atom_set = atom.first_segment();
-		let var = &self.var;
-		let inner_ty = self.ty.unpack_option();
-		quote! {
-			if #var.is_none() && p.peek::<#inner_ty>() && p.to_atom::<#atom_set>(c) == #atom_path {
-				#var = Some(p.parse::<#inner_ty>()?);
-				continue;
-			}
-		}
-	}
-
-	/// Emits a simple parse-if-peek for a single atom field.
-	fn atom_parse_if_peek(&self) -> TokenStream {
-		let atom = self.atom.as_ref().expect("atom_parse_if_peek called without atom");
-		let atom_path = atom.path();
-		let atom_set = atom.first_segment();
-		let var = &self.var;
-		let inner_ty = self.ty.unpack_option();
-		quote! {
-			if p.peek::<#inner_ty>()
-				&& p.to_atom::<#atom_set>(c) == #atom_path
-			{
-				#var = Some(p.parse::<#inner_ty>()?);
-			}
-		}
-	}
-
-	fn binding(&self) -> TokenStream {
-		let Field { var, ty, .. } = self;
-		if ty.is_option() {
-			quote! { let mut #var: #ty = None; }
-		} else {
-			quote! { let mut #var: Option<#ty> = None; }
-		}
-	}
-
-	fn none_check(&self) -> TokenStream {
-		let v = &self.var;
-		quote! { #v.is_none() }
-	}
-
-	fn from_fields(fields: &Fields) -> Result<Vec<Self>> {
+	/// Every field, with `atom` given to the first field when it has none of its own.
+	fn all(fields: &Fields, atom: Option<Atom>) -> Result<Vec<Self>> {
 		fields
 			.views()
 			.into_iter()
 			.zip(fields.iter())
-			.map(|(view, syn_field)| {
+			.enumerate()
+			.map(|(i, (view, field))| {
+				let arg = ParseArg::from_attributes(&field.attrs)?;
 				Ok(Self {
-					var: view.binding,
-					ty: view.ty.clone(),
-					arg: ParseArg::from_attributes(&syn_field.attrs)?,
-					atom: extract_atom(&syn_field.attrs)?,
+					var: format_ident!("v{i}"),
+					member: view.member,
+					ty: option_inner(view.ty).unwrap_or(view.ty).clone(),
+					optional: view.is_option,
+					atom: extract_atom(&field.attrs)?.or_else(|| if i == 0 { atom.clone() } else { None }),
+					state: arg.state.map(|StateArg(ident)| ident),
 				})
 			})
 			.collect()
 	}
 
-	fn atom_path_string(&self) -> Option<String> {
-		self.atom.as_ref().map(|a| quote!(#a).to_string())
+	/// `p.parse::<T>()?` under this field's state, if any.
+	fn parse(&self, ty: TokenStream) -> TokenStream {
+		match &self.state {
+			Some(state) => quote! {{
+				let old_state = p.set_state(State::#state);
+				let result = p.parse::<#ty>()?;
+				p.set_state(old_state);
+				result
+			}},
+			None => quote! { p.parse::<#ty>()? },
+		}
 	}
 
-	fn peek_tokens(&self) -> TokenStream {
-		let peek_ty = if self.ty.is_option() { self.ty.unpack_option() } else { self.ty.clone() };
-		if let Some(atom) = &self.atom {
-			let atom_path = atom.path();
-			let atom_set = atom.first_segment();
-			quote! { p.peek::<#peek_ty>() && p.to_atom::<#atom_set>(c) == #atom_path }
-		} else {
-			quote! { p.peek::<#peek_ty>() }
+	/// `let v = ...;` which parses this field next. With `atom_known` the atom has been matched
+	/// already and is not checked again.
+	fn step(&self, atom_known: bool, wc: &mut WhereCollector) -> TokenStream {
+		let Self { var, ty, .. } = self;
+		wc.add(ty);
+		match (&self.atom, self.optional) {
+			(Some(_), _) if atom_known => {
+				let parse = self.parse(quote! { #ty });
+				quote! { let #var = #parse; }
+			}
+			(Some(atom), true) => {
+				let condition = atom.equals_atom(format_ident!("c"));
+				let parse = self.parse(quote! { #ty });
+				quote! { let #var = { let c = p.peek_n(1); if #condition { Some(#parse) } else { None } }; }
+			}
+			(Some(atom), false) => {
+				let condition = atom.equals_atom(format_ident!("c"));
+				let parse = self.parse(quote! { #ty });
+				quote! {
+					let #var = {
+						let c = p.peek_n(1);
+						if #condition { #parse } else { return Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?; }
+					};
+				}
+			}
+			(None, true) => {
+				let parse = self.parse(quote! { Option<#ty> });
+				quote! { let #var = #parse; }
+			}
+			(None, false) => {
+				let parse = self.parse(quote! { #ty });
+				quote! { let #var = #parse; }
+			}
+		}
+	}
+
+	fn binding(&self) -> TokenStream {
+		let Self { var, ty, .. } = self;
+		quote! { let mut #var: Option<#ty> = None; }
+	}
+
+	/// Whether the cursor `c` starts this field.
+	fn peek(&self) -> TokenStream {
+		let ty = &self.ty;
+		match &self.atom {
+			Some(atom) => {
+				let path = atom.path();
+				let set = atom.first_segment();
+				quote! { p.peek::<#ty>() && p.to_atom::<#set>(c) == #path }
+			}
+			None => quote! { p.peek::<#ty>() },
+		}
+	}
+
+	/// One step of an any-order loop: parse this field if it is not yet seen and starts here.
+	fn occur(&self, wc: &mut WhereCollector) -> TokenStream {
+		let Self { var, ty, .. } = self;
+		wc.add(ty);
+		let peek = self.peek();
+		quote! {
+			if #var.is_none() && #peek {
+				#var = Some(p.parse::<#ty>()?);
+				continue;
+			}
 		}
 	}
 }
 
-fn members_tokens(fields: &Fields) -> Vec<TokenStream> {
-	fields.members().map(|m| quote! { #m }).collect()
+struct Variant {
+	path: TokenStream,
+	mode: FieldParseMode,
+	fields: Vec<Field>,
+}
+
+impl Variant {
+	fn is_ordered(&self) -> bool {
+		self.mode == FieldParseMode::Sequential
+	}
+
+	fn all_optional(&self) -> bool {
+		self.fields.iter().all(|field| field.optional)
+	}
+
+	fn construct(&self, post: &TokenStream, value: impl Fn(&Field) -> TokenStream) -> TokenStream {
+		let path = &self.path;
+		let members = self.fields.iter().map(|field| &field.member);
+		let values = self.fields.iter().map(value);
+		quote! { #post return Ok(#path { #(#members: #values),* }); }
+	}
+
+	/// Parses fields `from` onwards in order, then constructs.
+	fn ordered(&self, from: usize, post: &TokenStream, wc: &mut WhereCollector) -> TokenStream {
+		let steps = self.fields[from..].iter().map(|field| field.step(false, wc));
+		let construct = self.construct(post, |field| field.var.to_token_stream());
+		quote! { #(#steps)* #construct }
+	}
+
+	/// Parses fields in any order until none matches, checks the ones which must occur, then
+	/// constructs.
+	fn any_order(&self, post: &TokenStream, wc: &mut WhereCollector) -> TokenStream {
+		let bindings = self.fields.iter().map(Field::binding);
+		let steps = self.fields.iter().map(|field| field.occur(wc));
+		let none = |field: &Field| {
+			let var = &field.var;
+			quote! { #var.is_none() }
+		};
+		let missing = match self.mode {
+			FieldParseMode::AllMustOccur if !self.all_optional() => {
+				let required = self.fields.iter().filter(|field| !field.optional).map(none);
+				quote! { #(#required)||* }
+			}
+			_ => {
+				let all = self.fields.iter().map(none);
+				quote! { #(#all)&&* }
+			}
+		};
+		let construct = self.construct(post, |field| {
+			let var = &field.var;
+			if field.optional {
+				quote! { #var }
+			} else {
+				quote! { #var.unwrap() }
+			}
+		});
+		quote! {
+			#(#bindings)*
+			loop {
+				let c = p.peek_n(1);
+				#(#steps)*
+				break;
+			}
+			if #missing {
+				let c = p.peek_n(1);
+				Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
+			}
+			#construct
+		}
+	}
+
+	fn body(&self, post: &TokenStream, wc: &mut WhereCollector) -> TokenStream {
+		if self.is_ordered() { self.ordered(0, post, wc) } else { self.any_order(post, wc) }
+	}
 }
 
 fn unexpected_at_next() -> TokenStream {
-	quote! { return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?; }
+	quote! { return Err(::css_parse::Diagnostic::new(p.peek_n(1), ::css_parse::Diagnostic::unexpected))?; }
 }
 
-fn unexpected_at_c() -> TokenStream {
-	quote! { Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))? }
+/// The ordered variants which still compete after `depth` fields, keyed by the start of their next
+/// field. Variants keyed on the same type share one peek and are told apart by atom; a variant
+/// whose next field is optional has no single start and stands alone.
+enum Node<'a> {
+	Keyed { ty: &'a Type, set: Option<Ident>, arms: Vec<(Option<Atom>, Vec<&'a Variant>)> },
+	Alone(&'a Variant),
 }
 
-struct SequentialPlan<'a> {
-	fields: &'a [Field],
-	members: &'a [TokenStream],
-	post_parse_steps: &'a TokenStream,
-	constructor: TokenStream,
-}
-
-impl<'a> Plan for SequentialPlan<'a> {
-	fn render(&self, wc: &mut WhereCollector) -> TokenStream {
-		let parse_steps = self.fields.iter().map(|f| f.parse_tokens(wc));
-		let vars = self.fields.iter().map(|f| &f.var);
-		let members = self.members;
-		let constructor = &self.constructor;
-		let post = self.post_parse_steps;
-		quote! {
-			#( #parse_steps )*
-			#post
-			return Ok(#constructor { #(#members: #vars),* });
-		}
+/// Dispatch between ordered variants once `depth` fields are consumed. Returns or errors unless
+/// `depth` is zero, where a miss falls through.
+fn dispatch(variants: &[&Variant], depth: usize, post: &TokenStream, wc: &mut WhereCollector) -> TokenStream {
+	if let [variant] = variants
+		&& depth > 0
+	{
+		return variant.ordered(depth, post, wc);
 	}
-}
-
-struct MustOccurPlan<'a> {
-	fields: &'a [Field],
-	members: &'a [TokenStream],
-	post_parse_steps: &'a TokenStream,
-	parse_mode: FieldParseMode,
-	constructor: TokenStream,
-	hoisted: &'a [&'a Ident],
-}
-
-impl<'a> Plan for MustOccurPlan<'a> {
-	fn render(&self, wc: &mut WhereCollector) -> TokenStream {
-		let MustOccurPlan { fields, members, post_parse_steps, parse_mode, constructor, hoisted } = self;
-		let bindings: TokenStream = fields.iter().filter(|f| !hoisted.contains(&&f.var)).map(Field::binding).collect();
-
-		let parse_steps: TokenStream = fields
-			.iter()
-			.map(|f| if f.atom.is_some() { f.atom_match_arm() } else { f.parse_normal_tokens(*parse_mode, wc) })
-			.collect();
-
-		// Add where bounds for atom fields (atom_match_arm doesn't call wc.add)
-		for f in fields.iter().filter(|f| f.atom.is_some()) {
-			wc.add(&f.ty.unpack_option());
-		}
-
-		let all_checks: Vec<_> = fields.iter().map(Field::none_check).collect();
-
-		let required_checks: Vec<_> = fields.iter().filter(|f| !f.ty.is_option()).map(Field::none_check).collect();
-		let (occurance_cond, assignments): (TokenStream, Vec<TokenStream>) = match parse_mode {
-			FieldParseMode::Sequential => unreachable!(),
-			FieldParseMode::OneMustOccur => {
-				let vars = fields.iter().map(|f| &f.var);
-				(quote! { #(#all_checks)&&* }, vars.map(|v| quote! { #v }).collect())
-			}
-			FieldParseMode::AllMustOccur => {
-				let cond = if required_checks.is_empty() {
-					quote! { #(#all_checks)&&* }
-				} else {
-					quote! { #(#required_checks)||* }
+	let mut nodes: Vec<Node> = vec![];
+	let mut done: Option<&Variant> = None;
+	for &variant in variants {
+		match variant.fields.get(depth) {
+			None => done = done.or(Some(variant)),
+			Some(field) if field.optional => nodes.push(Node::Alone(variant)),
+			Some(field) => {
+				let set = field.atom.as_ref().map(Atom::first_segment);
+				let keyed = nodes.iter_mut().find_map(|node| match node {
+					Node::Keyed { ty, set: seen, arms } if **ty == field.ty && *seen == set => Some(arms),
+					_ => None,
+				});
+				let arms = match keyed {
+					Some(arms) => arms,
+					None => {
+						nodes.push(Node::Keyed { ty: &field.ty, set, arms: vec![] });
+						let Some(Node::Keyed { arms, .. }) = nodes.last_mut() else { unreachable!() };
+						arms
+					}
 				};
-				let assignments = fields
-					.iter()
-					.map(|f| {
-						let v = &f.var;
-						if f.ty.is_option() {
-							quote! { #v }
-						} else {
-							quote! { #v.unwrap() }
-						}
-					})
-					.collect();
-				(cond, assignments)
-			}
-		};
-
-		let unexpected = unexpected_at_c();
-		quote! {
-			#bindings
-			loop {
-				let c = p.peek_n(1);
-				#parse_steps
-				break;
-			}
-			#post_parse_steps
-			if #occurance_cond {
-				let c = p.peek_n(1);
-				#unexpected
-			}
-			return Ok(#constructor { #(#members: #assignments),* });
-		}
-	}
-}
-
-struct VariantPlan {
-	ident: Ident,
-	first_type: Type,
-	effective_atom: Option<Atom>,
-	parse_mode: FieldParseMode,
-	fields: Vec<Field>,
-	members: Vec<TokenStream>,
-	post_parse_steps: TokenStream,
-}
-
-impl VariantPlan {
-	fn new(variant: &Variant, post_parse_steps: &TokenStream) -> Result<Self> {
-		let ident = variant.ident.clone();
-		let parse_mode = ParseArg::from_attributes(&variant.attrs)?.parse_mode();
-		let variant_atom = extract_atom(&variant.attrs)?;
-		let fields = Field::from_fields(&variant.fields)?;
-		let first_type = fields
-			.first()
-			.map(|f| f.ty.clone())
-			.ok_or_else(|| Error::new(ident.span(), "enum variant must have at least one field"))?;
-		let members = members_tokens(&variant.fields);
-
-		// Prefer variant-level atom; fall back to first field's atom except for
-		// must-occur variants with all-optional fields.
-		let all_optional = fields.iter().all(|f| f.ty.is_option());
-		let effective_atom = if variant_atom.is_some() {
-			variant_atom
-		} else if (parse_mode == FieldParseMode::OneMustOccur || parse_mode == FieldParseMode::AllMustOccur)
-			&& all_optional
-		{
-			None
-		} else {
-			fields.first().and_then(|f| f.atom.clone())
-		};
-
-		Ok(Self {
-			ident,
-			first_type,
-			effective_atom,
-			parse_mode,
-			fields,
-			members,
-			post_parse_steps: post_parse_steps.clone(),
-		})
-	}
-
-	/// Render the body for this variant, consuming where-bounds into `wc`.
-	/// Picks `SequentialPlan` or `MustOccurPlan` based on `parse_mode`.
-	fn body(&self, wc: &mut WhereCollector) -> TokenStream {
-		let ident = &self.ident;
-		let constructor = quote! { Self::#ident };
-		if self.parse_mode == FieldParseMode::Sequential {
-			SequentialPlan {
-				fields: &self.fields,
-				members: &self.members,
-				post_parse_steps: &self.post_parse_steps,
-				constructor,
-			}
-			.render(wc)
-		} else {
-			MustOccurPlan {
-				fields: &self.fields,
-				members: &self.members,
-				post_parse_steps: &self.post_parse_steps,
-				parse_mode: self.parse_mode,
-				constructor,
-				hoisted: &[],
-			}
-			.render(wc)
-		}
-	}
-
-	fn discriminator(&self, shared_atom_paths: &[String], hoisted_type_var_names: &[&Ident]) -> TokenStream {
-		let all_optional = self.fields.iter().all(|f| f.ty.is_option());
-		let is_all_optional_must_occur =
-			matches!(self.parse_mode, FieldParseMode::OneMustOccur | FieldParseMode::AllMustOccur) && all_optional;
-		if is_all_optional_must_occur {
-			let peeks: Vec<TokenStream> = self
-				.fields
-				.iter()
-				.filter(|f| {
-					f.atom_path_string().is_none_or(|ap| !shared_atom_paths.contains(&ap))
-						&& !hoisted_type_var_names.contains(&&f.var)
-				})
-				.map(|f| f.peek_tokens())
-				.collect();
-			if !peeks.is_empty() {
-				return quote! { #(#peeks)||* };
-			}
-		}
-
-		let discriminating =
-			self.fields.iter().find(|f| f.atom_path_string().is_some_and(|ap| !shared_atom_paths.contains(&ap)));
-		if let Some(field) = discriminating {
-			return field.peek_tokens();
-		}
-
-		if let Some(field) = self.fields.iter().find(|f| f.atom.is_some()) {
-			return field.peek_tokens();
-		}
-
-		let peek_types: Vec<Type> = self
-			.fields
-			.iter()
-			.filter(|f| !hoisted_type_var_names.contains(&&f.var))
-			.scan(true, |still_optional, f| {
-				if !*still_optional {
-					return None;
+				match arms.iter_mut().find(|(atom, _)| *atom == field.atom) {
+					Some((_, group)) => group.push(variant),
+					None => arms.push((field.atom.clone(), vec![variant])),
 				}
-				if !f.ty.is_option() {
-					*still_optional = false;
-				}
-				Some(f.ty.unpack_option())
-			})
-			.collect();
-		let type_checks: Vec<TokenStream> = peek_types.iter().map(|t| quote! { p.peek::<#t>() }).collect();
-		if type_checks.len() == 1 {
-			type_checks.into_iter().next().expect("len checked")
-		} else if type_checks.is_empty() {
-			quote! { false }
-		} else {
-			quote! { #(#type_checks)||* }
-		}
-	}
-
-	fn body_with_hoisted(&self, hoisted: &[&Ident], where_collector: &mut WhereCollector) -> TokenStream {
-		let ident = &self.ident;
-		MustOccurPlan {
-			fields: &self.fields,
-			members: &self.members,
-			post_parse_steps: &self.post_parse_steps,
-			parse_mode: FieldParseMode::OneMustOccur,
-			constructor: quote! { Self::#ident },
-			hoisted,
-		}
-		.render(where_collector)
-	}
-
-	/// Emit only the occurrence check + return for hoisted-only fallback.
-	/// Used when all variant discriminants failed but hoisted shared fields
-	/// may have been consumed.
-	fn return_with_hoisted_only(&self, hoisted: &[&Ident]) -> TokenStream {
-		let ident = &self.ident;
-		let members = &self.members;
-		let post_parse_steps = &self.post_parse_steps;
-		let unexpected = unexpected_at_c();
-		let none_checks: Vec<_> =
-			self.fields.iter().filter(|f| hoisted.contains(&&f.var)).map(Field::none_check).collect();
-		let occurance_cond = if none_checks.is_empty() {
-			quote! { true }
-		} else {
-			quote! { #(#none_checks)&&* }
-		};
-		let assignments: Vec<TokenStream> = self
-			.fields
-			.iter()
-			.map(|f| {
-				if hoisted.contains(&&f.var) {
-					let v = &f.var;
-					quote! { #v }
-				} else {
-					quote! { None }
-				}
-			})
-			.collect();
-		quote! {
-			#post_parse_steps
-			if #occurance_cond {
-				let c = p.peek_n(1);
-				#unexpected
-			}
-			return Ok(Self::#ident { #(#members: #assignments),* });
-		}
-	}
-
-	/// Like [`return_with_hoisted_only`], but for a group that is **not** the last: if hoisted
-	/// shared fields were consumed we must construct here (those tokens are already eaten and
-	/// would otherwise be lost), yet when nothing was consumed we fall through to the next group
-	/// rather than erroring.
-	fn return_if_hoisted(&self, hoisted: &[&Ident]) -> TokenStream {
-		let ident = &self.ident;
-		let members = &self.members;
-		let post_parse_steps = &self.post_parse_steps;
-		let none_checks: Vec<_> =
-			self.fields.iter().filter(|f| hoisted.contains(&&f.var)).map(Field::none_check).collect();
-		if none_checks.is_empty() {
-			return TokenStream::new();
-		}
-		let assignments: Vec<TokenStream> = self
-			.fields
-			.iter()
-			.map(|f| {
-				if hoisted.contains(&&f.var) {
-					let v = &f.var;
-					quote! { #v }
-				} else {
-					quote! { None }
-				}
-			})
-			.collect();
-		quote! {
-			if !(#(#none_checks)&&*) {
-				#post_parse_steps
-				return Ok(Self::#ident { #(#members: #assignments),* });
 			}
 		}
 	}
-}
 
-/// Top-level enum-variant group: dispatches between `AtomDispatchPlan` (variants
-/// with effective atoms on a shared first-field type) and `PeekedFallbackPlan`
-/// (variants with no atom, fall back to peek-based discrimination).
-enum EnumGroupPlan<'a> {
-	AtomDispatch(AtomDispatchPlan<'a>),
-	PeekedFallback(PeekedFallbackPlan<'a>),
-}
-
-impl<'a> EnumGroupPlan<'a> {
-	fn new(no_atom: bool, variants: Vec<&'a VariantPlan>, position: &Position) -> Self {
-		if no_atom {
-			Self::PeekedFallback(PeekedFallbackPlan::new(variants, position))
-		} else {
-			let first_type = variants[0].first_type.clone();
-			Self::AtomDispatch(AtomDispatchPlan::new(first_type, variants, position))
-		}
-	}
-}
-
-impl<'a> Plan for EnumGroupPlan<'a> {
-	fn render(&self, wc: &mut WhereCollector) -> TokenStream {
-		match self {
-			Self::AtomDispatch(p) => p.render(wc),
-			Self::PeekedFallback(p) => p.render(wc),
-		}
-	}
-}
-
-/// Plan for a group of variants dispatched by atom on a shared first-field type.
-///
-/// All variants in the group have an effective atom; the type is peeked first,
-/// then `to_atom` selects the branch.  When `is_last`, unknown atoms and a
-/// missing peek both produce an error; otherwise they fall through silently.
-struct AtomDispatchPlan<'a> {
-	first_type: Type,
-	variants: Vec<&'a VariantPlan>,
-	is_last: bool,
-}
-
-impl<'a> AtomDispatchPlan<'a> {
-	fn new(first_type: Type, variants: Vec<&'a VariantPlan>, position: &Position) -> Self {
-		Self { first_type, variants, is_last: position.is_last() || position.is_exactly_one() }
-	}
-}
-
-impl<'a> Plan for AtomDispatchPlan<'a> {
-	fn render(&self, wc: &mut WhereCollector) -> TokenStream {
-		let ty = &self.first_type;
-		let extract_atom: TokenStream = self
-			.variants
-			.first()
-			.iter()
-			.flat_map(|v| v.effective_atom.as_ref())
-			.map(|atom| atom.to_atom(format_ident!("c")))
-			.collect();
-
-		let mut groups: Vec<(String, ExprPath, Vec<&VariantPlan>)> = Vec::new();
-		for v in &self.variants {
-			let path = v.effective_atom.as_ref().expect("AtomDispatch variant must have atom").path();
-			let key = quote!(#path).to_string();
-			if let Some((_, _, group)) = groups.iter_mut().find(|(k, _, _)| *k == key) {
-				group.push(v);
-			} else {
-				groups.push((key, path, vec![v]));
-			}
-		}
-
-		let atom_arms: TokenStream = groups
-			.iter()
-			.map(|(_, atom_path, group)| {
-				let body = match AtomPrefixPlan::try_new(group) {
-					Some(plan) => plan.render(wc),
-					None => group[0].body(wc),
-				};
-				quote! { #atom_path => { #body }, }
-			})
-			.collect();
-
-		let unknown_atom_arm = if self.is_last {
-			quote! { _ => { return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?; } }
-		} else {
-			quote! { _ => {} }
-		};
-		let else_branch = if self.is_last {
-			let unexpected = unexpected_at_next();
-			quote! { else { #unexpected } }
-		} else {
-			TokenStream::new()
-		};
-		quote! {
-			if p.peek::<#ty>() {
-				let c = p.peek_n(1);
-				match #extract_atom {
-					#atom_arms
-					#unknown_atom_arm
-				}
-			} #else_branch
-		}
-	}
-}
-
-/// Plan for a group of variants dispatched by type-peek (no effective atom on
-/// the group key).  Handles three sub-cases in priority order:
-///
-/// 1. Single variant, last group, no hoisting — emit body directly.
-/// 2. Shared-prefix variants — delegate to `SharedPrefixPlan`.
-/// 3. General case — emit one `if type_check { body }` block per variant,
-///    with optional hoisted bindings and trailing fallback.
-struct PeekedFallbackPlan<'a> {
-	variants: Vec<&'a VariantPlan>,
-	is_last: bool,
-}
-
-impl<'a> PeekedFallbackPlan<'a> {
-	fn new(variants: Vec<&'a VariantPlan>, position: &Position) -> Self {
-		Self { variants, is_last: position.is_last() || position.is_exactly_one() }
-	}
-}
-
-impl<'a> Plan for PeekedFallbackPlan<'a> {
-	fn render(&self, where_collector: &mut WhereCollector) -> TokenStream {
-		let hoist = SharedAtomHoistPlan::new(&self.variants);
-
-		// Single variant, last group, no hoisting — emit body directly.
-		if self.is_last && self.variants.len() == 1 && hoist.shared_atom_paths.is_empty() {
-			return self.variants[0].body(where_collector);
-		}
-
-		// Shared prefix across all variants — consume prefix first, then atom-dispatch.
-		if let Some(p) = SharedPrefixPlan::try_new(&self.variants, self.is_last) {
-			return p.render(where_collector);
-		}
-
-		if let Some(p) = SharedAllMustOccurPlan::try_new(&self.variants, self.is_last) {
-			return p.render(where_collector);
-		}
-
-		// General case: per-variant if-blocks with optional hoisting.
-		MultiVariantBlocksPlan { variants: &self.variants, is_last: self.is_last, hoist: &hoist }
-			.render(where_collector)
-	}
-}
-
-/// General `PeekedFallback` rendering: per-variant `if discriminator { body }`
-/// blocks with optional shared-atom hoisting and a fallback at the end.
-struct MultiVariantBlocksPlan<'a, 'b> {
-	variants: &'b [&'a VariantPlan],
-	is_last: bool,
-	hoist: &'b SharedAtomHoistPlan<'a>,
-}
-
-impl<'a, 'b> Plan for MultiVariantBlocksPlan<'a, 'b> {
-	fn render(&self, where_collector: &mut WhereCollector) -> TokenStream {
-		let hoisted_bindings = self.hoist.hoisted_bindings();
-		let hoisted_preloop = self.hoist.hoisted_preloop(where_collector);
-		let all_hoisted_var_names = self.hoist.all_hoisted_var_names();
-
-		let variant_blocks: TokenStream = self
-			.variants
-			.iter()
-			.map(|variant| {
-				let type_check =
-					variant.discriminator(&self.hoist.shared_atom_paths, &self.hoist.hoisted_type_var_names());
-				let final_step = if all_hoisted_var_names.is_empty() {
-					variant.body(where_collector)
-				} else {
-					variant.body_with_hoisted(&all_hoisted_var_names, where_collector)
-				};
-				quote! { if #type_check { #final_step } }
-			})
-			.collect();
-
-		let fallback = if all_hoisted_var_names.is_empty() {
-			let unexpected = unexpected_at_next();
-			quote! { #unexpected }
-		} else {
-			self.variants[0].return_with_hoisted_only(&all_hoisted_var_names)
-		};
-
-		let trailing = if self.is_last {
-			quote! { #fallback }
-		} else if !all_hoisted_var_names.is_empty() {
-			self.variants[0].return_if_hoisted(&all_hoisted_var_names)
-		} else {
-			TokenStream::new()
-		};
-
-		let needs_c = !self.hoist.shared_fields.is_empty()
-			|| self.variants.iter().any(|v| {
-				let shared = &self.hoist.shared_atom_paths;
-				let hoisted = self.hoist.hoisted_type_var_names();
-				v.fields.iter().any(|f| {
-					f.atom.is_some()
-						&& f.atom_path_string().is_none_or(|ap| !shared.contains(&ap))
-						&& !hoisted.contains(&&f.var)
-				})
+	// Keywords are tried before open types, which may accept them too, as `<custom-ident>` does.
+	nodes.sort_by_key(|node| !matches!(node, Node::Keyed { set: Some(_), .. }));
+	let nodes = nodes.iter().map(|node| match node {
+		Node::Alone(variant) => {
+			let body = variant.ordered(depth, post, wc);
+			let rest = &variant.fields[depth..];
+			let Some(required) = rest.iter().position(|field| !field.optional) else {
+				return body;
+			};
+			let starts = rest[..=required].iter().map(|field| {
+				wc.add(&field.ty);
+				field.peek()
 			});
-		let peek_binding = if needs_c {
-			quote! { let c = p.peek_n(1); }
-		} else {
-			quote! {}
-		};
-
-		quote! {
-			#hoisted_bindings
-			#hoisted_preloop
-			#peek_binding
-			#variant_blocks
-			#trailing
+			quote! { { let c = p.peek_n(1); if #(#starts)||* { #body } } }
 		}
-	}
-}
-
-/// Hoisting plan for sibling variants in a `PeekedFallback` group that share atom fields.
-///
-/// Hoists two kinds of shared fields:
-/// - Atom fields (e.g. `balance` in `[ wrap | wrap-reverse ] || balance`): declared at
-///   group level and consumed in a pre-check before the variant discriminator.
-/// - Non-atom `Option<Type>` fields shared across all variants (e.g. `alignment_baseline`
-///   in `[ first | last ] || <'alignment-baseline'>`): declared at group level and
-///   consumed in a pre-loop before the variant discriminator, enabling parse of input
-///   that starts with those types without a leading keyword.
-///
-/// Per-variant bodies reference the hoisted bindings instead of redeclaring them.
-struct SharedAtomHoistPlan<'a> {
-	shared_atom_paths: Vec<String>,
-	shared_fields: Vec<&'a Field>,
-	shared_type_fields: Vec<&'a Field>,
-}
-
-impl<'a> SharedAtomHoistPlan<'a> {
-	fn new(variants: &[&'a VariantPlan]) -> Self {
-		if variants.len() <= 1 {
-			return Self { shared_atom_paths: Vec::new(), shared_fields: Vec::new(), shared_type_fields: Vec::new() };
-		}
-
-		let first_atoms: Vec<String> = variants[0].fields.iter().filter_map(Field::atom_path_string).collect();
-		let shared_atom_paths: Vec<String> = first_atoms
-			.into_iter()
-			.filter(|ap| {
-				variants[1..].iter().all(|v| v.fields.iter().any(|f| f.atom_path_string().as_deref() == Some(ap)))
-			})
-			.collect();
-
-		let shared_fields: Vec<&Field> = variants[0]
-			.fields
-			.iter()
-			.filter(|f| f.atom_path_string().is_some_and(|ap| shared_atom_paths.contains(&ap)))
-			.collect();
-
-		let shared_type_fields: Vec<&Field> = if variants.iter().all(|v| v.parse_mode == FieldParseMode::OneMustOccur) {
-			variants[0]
-				.fields
-				.iter()
-				.filter(|f| f.atom.is_none() && f.ty.is_option())
-				.filter(|f| {
-					let var_str = f.var.to_string();
-					let ty = &f.ty;
-					let ty_str = quote!(#ty).to_string();
-					variants[1..].iter().all(|v| {
-						v.fields.iter().any(|vf| {
-							let vf_ty = &vf.ty;
-							vf.atom.is_none() && vf.var == var_str && quote!(#vf_ty).to_string() == ty_str
-						})
-					})
-				})
-				.collect()
-		} else {
-			Vec::new()
-		};
-
-		Self { shared_atom_paths, shared_fields, shared_type_fields }
-	}
-
-	fn hoisted_type_var_names(&self) -> Vec<&Ident> {
-		self.shared_type_fields.iter().map(|f| &f.var).collect()
-	}
-
-	fn all_hoisted_var_names(&self) -> Vec<&Ident> {
-		self.shared_fields.iter().chain(self.shared_type_fields.iter()).map(|f| &f.var).collect()
-	}
-
-	fn hoisted_bindings(&self) -> TokenStream {
-		self.shared_fields.iter().chain(self.shared_type_fields.iter()).map(|f| f.binding()).collect()
-	}
-
-	fn hoisted_preloop(&self, wc: &mut WhereCollector) -> TokenStream {
-		let atom_preloop = match self.shared_fields.as_slice() {
-			[] => TokenStream::new(),
-			[field] => {
-				let inner = field.atom_parse_if_peek();
-				quote! { { let c = p.peek_n(1); #inner } }
-			}
-			_ => {
-				let parse_steps: TokenStream = self.shared_fields.iter().map(|f| f.atom_match_arm()).collect();
+		Node::Keyed { ty, set, arms } => {
+			wc.add(ty);
+			let mut consume = |group: &[&Variant]| {
+				let step = group[0].fields[depth].step(true, wc);
+				let rest = dispatch(group, depth + 1, post, wc);
+				quote! { #step #rest }
+			};
+			let plain = arms.iter().find(|(atom, _)| atom.is_none()).map(|(_, group)| consume(group));
+			if set.is_none() {
+				quote! { if p.peek::<#ty>() { #plain } }
+			} else {
+				let keyed = arms.iter().filter_map(|(atom, group)| {
+					let path = atom.as_ref()?.path();
+					let body = consume(group);
+					Some(quote! { #path => { #body } })
+				});
 				quote! {
-					loop {
+					if p.peek::<#ty>() {
 						let c = p.peek_n(1);
-						#parse_steps
-						break;
-					}
-				}
-			}
-		};
-
-		let type_preloop = if self.shared_type_fields.is_empty() {
-			TokenStream::new()
-		} else {
-			let parse_steps: TokenStream = self
-				.shared_type_fields
-				.iter()
-				.map(|f| f.parse_normal_tokens(FieldParseMode::OneMustOccur, wc))
-				.collect();
-			quote! {
-				loop {
-					let c = p.peek_n(1);
-					#parse_steps
-					break;
-				}
-			}
-		};
-
-		quote! { #atom_preloop #type_preloop }
-	}
-}
-
-/// Atom-prefix plan: variants in an `AtomDispatch` group that share the same
-/// effective (first) atom, differing only by a subsequent atom field — or having
-/// no second field at all, the bare fallback.
-///
-/// e.g. `[ text | cap ] [ text | alphabetic ] | text` generates:
-///   `TextText(#[atom(Text)] Ident, #[atom(Text)] Ident)`
-///   `TextAlphabetic(#[atom(Text)] Ident, #[atom(Alphabetic)] Ident)`
-///   `CapText(#[atom(Cap)] Ident, #[atom(Text)] Ident)`
-///   `CapAlphabetic(#[atom(Cap)] Ident, #[atom(Alphabetic)] Ident)`
-///   `#[atom(Text)] Text(Ident)`
-///
-/// The `Text`-keyed group would otherwise dispatch on the first atom alone,
-/// making every variant but the first unreachable.  This consumes the shared
-/// first token, then atom-dispatches on the next one.
-struct AtomPrefixPlan<'a> {
-	prefix_ty: Type,
-	/// Variants that have a second field with a distinguishing atom.
-	atom_variants: Vec<&'a VariantPlan>,
-	/// Variant with only the prefix field (no second field), if any.
-	bare_variant: Option<&'a VariantPlan>,
-}
-
-impl<'a> AtomPrefixPlan<'a> {
-	fn try_new(variants: &[&'a VariantPlan]) -> Option<Self> {
-		if variants.len() < 2 {
-			return None;
-		}
-		let first_field = variants[0].fields.first()?;
-		let first_ty = &first_field.ty;
-		let prefix_ty_str = quote!(#first_ty).to_string();
-		let mut atom_variants = Vec::new();
-		let mut bare_variant = None;
-		for v in variants {
-			if v.parse_mode != FieldParseMode::Sequential {
-				return None;
-			}
-			let ty = &v.fields.first()?.ty;
-			if quote!(#ty).to_string() != prefix_ty_str {
-				return None;
-			}
-			match v.fields.as_slice() {
-				[_prefix] => {
-					if bare_variant.is_some() {
-						return None; // two bare variants — ambiguous
-					}
-					bare_variant = Some(*v);
-				}
-				[_prefix, second] if second.atom.is_some() && !second.ty.is_option() => {
-					atom_variants.push(*v);
-				}
-				_ => return None, // more complex structure — don't handle here
-			}
-		}
-		if atom_variants.is_empty() {
-			return None;
-		}
-		Some(Self { prefix_ty: first_field.ty.clone(), atom_variants, bare_variant })
-	}
-}
-
-impl<'a> Plan for AtomPrefixPlan<'a> {
-	fn render(&self, wc: &mut WhereCollector) -> TokenStream {
-		let prefix_ty = &self.prefix_ty;
-		wc.add(prefix_ty);
-		let atom_set = self.atom_variants[0].fields[1]
-			.atom
-			.as_ref()
-			.expect("atom_variants guaranteed to have atom on field 1")
-			.first_segment();
-
-		let atom_arms: TokenStream = self
-			.atom_variants
-			.iter()
-			.map(|v| {
-				let atom_path = v.fields[1].atom.as_ref().expect("checked above").path();
-				let ident = &v.ident;
-				let second_ty = &v.fields[1].ty;
-				wc.add(second_ty);
-				let (m0, m1) = (&v.members[0], &v.members[1]);
-				let post_parse_steps = &v.post_parse_steps;
-				quote! {
-					#atom_path => {
-						let v1 = p.parse::<#second_ty>()?;
-						#post_parse_steps
-						return Ok(Self::#ident { #m0: v0, #m1: v1 });
-					}
-				}
-			})
-			.collect();
-
-		let default_arm: TokenStream = if let Some(bare) = self.bare_variant {
-			let ident = &bare.ident;
-			let m0 = &bare.members[0];
-			let post_parse_steps = &bare.post_parse_steps;
-			quote! { _ => { #post_parse_steps return Ok(Self::#ident { #m0: v0 }); } }
-		} else {
-			let unexpected = unexpected_at_c();
-			quote! { _ => { #unexpected } }
-		};
-
-		quote! {
-			let v0 = p.parse::<#prefix_ty>()?;
-			let c = p.peek_n(1);
-			match p.to_atom::<#atom_set>(c) {
-				#atom_arms
-				#default_arm
-			}
-		}
-	}
-}
-
-/// Shared-prefix plan: variants in a `PeekedFallback` group all start with the
-/// same non-atom required field type, differing only by a subsequent atom field
-/// (or having no second field at all — the bare fallback).
-///
-/// e.g. `none | <custom-ident> [element | content]?` generates:
-///   `None(Ident)`
-///   `CustomIdentElement(CustomIdent, #[atom(Element)] Ident)`
-///   `CustomIdentContent(CustomIdent, #[atom(Content)] Ident)`
-///   `CustomIdent(CustomIdent)`
-///
-/// This should consume `CustomIdent` first, then atom-dispatch on next token.
-///
-/// A trailing alternative may also be a type rather than a keyword, as in
-/// `auto | <id> [ current | root | <target-name> ]?`, which additionally generates
-/// `IdTargetName(Id, TargetName)`. Keyword arms take priority; the typed tail is
-/// peeked only once no atom matched.
-struct SharedPrefixPlan<'a> {
-	prefix_ty: Type,
-	/// Variants that have a second field with a distinguishing atom.
-	atom_variants: Vec<&'a VariantPlan>,
-	/// Variant whose second field is a type rather than a keyword, if any.
-	typed_variant: Option<&'a VariantPlan>,
-	/// Variant with only the prefix field (no second field), if any.
-	bare_variant: Option<&'a VariantPlan>,
-	is_last: bool,
-}
-
-impl<'a> SharedPrefixPlan<'a> {
-	fn try_new(variants: &[&'a VariantPlan], is_last: bool) -> Option<Self> {
-		if variants.len() < 2 {
-			return None;
-		}
-		// All variants must start with the same non-atom first field type.
-		let first_field = variants[0].fields.first()?;
-		if first_field.atom.is_some() {
-			return None;
-		}
-		let first_ty = &first_field.ty;
-		let prefix_ty_str = quote!(#first_ty).to_string();
-		let all_share_prefix = variants.iter().all(|v| {
-			v.fields.first().is_some_and(|f| {
-				let ty = &f.ty;
-				f.atom.is_none() && quote!(#ty).to_string() == prefix_ty_str
-			})
-		});
-		if !all_share_prefix {
-			return None;
-		}
-		let mut atom_variants = Vec::new();
-		let mut typed_variant = None;
-		let mut bare_variant = None;
-		for v in variants {
-			match v.fields.as_slice() {
-				[_prefix] => {
-					if bare_variant.is_some() {
-						return None; // two bare variants — ambiguous
-					}
-					bare_variant = Some(*v);
-				}
-				[_prefix, second] if second.atom.is_some() => {
-					atom_variants.push(*v);
-				}
-				[_prefix, _second] => {
-					if typed_variant.is_some() {
-						return None; // two typed tails — ambiguous
-					}
-					typed_variant = Some(*v);
-				}
-				_ => return None, // more complex structure — don't handle here
-			}
-		}
-		// Need at least one atom variant for this to be useful.
-		if atom_variants.is_empty() {
-			return None;
-		}
-		if typed_variant.is_some() && bare_variant.is_none() {
-			return None;
-		}
-		Some(Self { prefix_ty: first_field.ty.clone(), atom_variants, typed_variant, bare_variant, is_last })
-	}
-}
-
-impl<'a> Plan for SharedPrefixPlan<'a> {
-	fn render(&self, where_collector: &mut WhereCollector) -> TokenStream {
-		let is_last = self.is_last;
-		let prefix_ty = &self.prefix_ty;
-		where_collector.add(prefix_ty);
-		let atom_set = self.atom_variants[0].fields[1]
-			.atom
-			.as_ref()
-			.expect("atom_variants guaranteed to have atom on field 1")
-			.first_segment();
-
-		let atom_arms: TokenStream = self
-			.atom_variants
-			.iter()
-			.map(|v| {
-				let atom_path = v.fields[1].atom.as_ref().expect("checked above").path();
-				let ident = &v.ident;
-				let second_ty = &v.fields[1].ty;
-				where_collector.add(second_ty);
-				quote! {
-					#atom_path => {
-						let v1 = p.parse::<#second_ty>()?;
-						return Ok(Self::#ident(v0, v1));
-					}
-				}
-			})
-			.collect();
-
-		let typed_probe: TokenStream = if let Some(typed) = self.typed_variant {
-			let ident = &typed.ident;
-			let second_ty = &typed.fields[1].ty;
-			where_collector.add(second_ty);
-			quote! {
-				if p.peek::<#second_ty>() {
-					let v1 = p.parse::<#second_ty>()?;
-					return Ok(Self::#ident(v0, v1));
-				}
-			}
-		} else {
-			TokenStream::new()
-		};
-
-		let default_arm: TokenStream = if let Some(bare) = self.bare_variant {
-			let ident = &bare.ident;
-			quote! { _ => { #typed_probe return Ok(Self::#ident(v0)); } }
-		} else if is_last {
-			let unexpected = unexpected_at_c();
-			quote! { _ => { #typed_probe let c = p.peek_n(1); #unexpected } }
-		} else {
-			quote! { _ => { #typed_probe } }
-		};
-
-		let else_branch = if is_last {
-			quote! { else { return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?; } }
-		} else {
-			TokenStream::new()
-		};
-		quote! {
-			if p.peek::<#prefix_ty>() {
-				let v0 = p.parse::<#prefix_ty>()?;
-				let c = p.peek_n(1);
-				match p.to_atom::<#atom_set>(c) {
-					#atom_arms
-					#default_arm
-				}
-			} #else_branch
-		}
-	}
-}
-
-/// Plan for sibling `AllMustOccur` variants that all have all-optional fields.
-///
-/// A single shared loop consumes every atom (and non-atom type) from every sibling
-/// variant.  After the loop the filled fields determine which variant to construct.
-///
-/// Example: `[ filled | open ] || [ dot | sesame ]` generates four variants
-/// `FilledDot`, `FilledSesame`, `OpenDot`, `OpenSesame` whose atom sets overlap.
-/// Running separate per-variant loops would leave unconsumed tokens; the shared loop
-/// avoids that by accepting all atoms and deciding the constructor at the end.
-struct SharedAllMustOccurPlan<'a> {
-	variants: Vec<&'a VariantPlan>,
-	is_last: bool,
-}
-
-impl<'a> SharedAllMustOccurPlan<'a> {
-	/// Returns `Some` iff all variants are `AllMustOccur` with all-optional fields
-	/// and there is at least one shared atom between any two variants (i.e. the
-	/// per-variant discriminators would overlap and the shared-loop approach is needed).
-	fn try_new(variants: &[&'a VariantPlan], is_last: bool) -> Option<Self> {
-		if variants.len() < 2 {
-			return None;
-		}
-		let all_qualify = variants
-			.iter()
-			.all(|v| v.parse_mode == FieldParseMode::AllMustOccur && v.fields.iter().all(|f| f.ty.is_option()));
-		if !all_qualify {
-			return None;
-		}
-		let has_overlap = variants.iter().enumerate().any(|(i, v)| {
-			let atoms_i: Vec<String> = v.fields.iter().filter_map(Field::atom_path_string).collect();
-			variants.iter().enumerate().any(|(j, w)| {
-				i != j && w.fields.iter().filter_map(Field::atom_path_string).any(|ap| atoms_i.contains(&ap))
-			})
-		});
-		if !has_overlap {
-			return None;
-		}
-		Some(Self { variants: variants.to_vec(), is_last })
-	}
-}
-
-impl<'a> Plan for SharedAllMustOccurPlan<'a> {
-	fn render(&self, wc: &mut WhereCollector) -> TokenStream {
-		let mut seen_vars: Vec<String> = Vec::new();
-		let mut all_fields: Vec<(&Field, usize)> = Vec::new();
-		for (vi, v) in self.variants.iter().enumerate() {
-			for f in &v.fields {
-				let key = f.var.to_string();
-				if !seen_vars.contains(&key) {
-					seen_vars.push(key);
-					all_fields.push((f, vi));
-				}
-			}
-		}
-		let atom_counts: Vec<(String, usize)> = {
-			let mut counts: Vec<(String, usize)> = Vec::new();
-			for v in &self.variants {
-				for f in &v.fields {
-					if let Some(ap) = Field::atom_path_string(f) {
-						if let Some(entry) = counts.iter_mut().find(|(k, _)| k == &ap) {
-							entry.1 += 1;
-						} else {
-							counts.push((ap, 1));
+						match p.to_atom::<#set>(c) {
+							#(#keyed)*
+							_ => { #plain }
 						}
 					}
 				}
 			}
-			counts
-		};
-		let is_shared_atom = |f: &Field| -> bool {
-			match Field::atom_path_string(f) {
-				Some(ap) => atom_counts.iter().find(|(k, _)| k == &ap).is_some_and(|(_, c)| *c > 1),
-				None => false,
-			}
-		};
-		let bindings: TokenStream = all_fields.iter().map(|(f, _)| f.binding()).collect();
-		for (f, _) in all_fields.iter().filter(|(f, _)| f.atom.is_some()) {
-			wc.add(&f.ty.unpack_option());
 		}
-		let parse_steps: TokenStream = all_fields
-			.iter()
-			.map(|(f, vi)| {
-				if let Some(atom) = f.atom.as_ref().filter(|_| !is_shared_atom(f)) {
-					let sentinel = vi + 1;
-					let var = &f.var;
-					let ty = &f.ty.unpack_option();
-					let atom_path = atom.path();
-					let atom_set = atom.first_segment();
-					quote! {
-						if (#var.is_none() && _alternative == 0 && p.peek::<#ty>() && p.to_atom::<#atom_set>(c) == #atom_path) {
-							_alternative = #sentinel;
-							#var = Some(p.parse::<#ty>()?);
-							continue;
-						}
-					}
-				} else if f.atom.is_some() {
-					f.atom_match_arm()
-				} else {
-					f.parse_normal_tokens(FieldParseMode::AllMustOccur, wc)
-				}
-			})
-			.collect();
-
-		let all_none_checks: Vec<TokenStream> = all_fields.iter().map(|(f, _)| f.none_check()).collect();
-		let nothing_parsed_check = quote! { #(#all_none_checks)&&* };
-		let match_arms: TokenStream = self
-			.variants
-			.iter()
-			.enumerate()
-			.map(|(i, v)| {
-				let sentinel = i + 1;
-				let ident = &v.ident;
-				let members = &v.members;
-				let assignments: Vec<TokenStream> = v
-					.fields
-					.iter()
-					.map(|f| {
-						let v2 = &f.var;
-						quote! { #v2 }
-					})
-					.collect();
-				quote! { #sentinel => return Ok(Self::#ident { #(#members: #assignments),* }), }
-			})
-			.collect();
-		let first_ident = &self.variants[0].ident;
-		let first_members = &self.variants[0].members;
-		let first_assignments: Vec<TokenStream> = self.variants[0]
-			.fields
-			.iter()
-			.map(|f| {
-				let v = &f.var;
-				quote! { #v }
-			})
-			.collect();
-
-		let unexpected = unexpected_at_next();
-		let construct = quote! {
-			match _alternative {
-				#match_arms
-				_ => return Ok(Self::#first_ident { #(#first_members: #first_assignments),* }),
-			}
-		};
-
-		let trailing = if self.is_last {
-			quote! {
-				if #nothing_parsed_check {
-					#unexpected
-				}
-				#construct
-			}
-		} else {
-			quote! {
-				if !#nothing_parsed_check {
-					#construct
-				}
-			}
-		};
-
-		quote! {
-			#bindings
-			let mut _alternative: usize = 0;
-			loop {
-				let c = p.peek_n(1);
-				#parse_steps
-				break;
-			}
-			#trailing
-		}
-	}
-}
-
-fn derive_struct_body(
-	data: &DataStruct,
-	parse_mode: FieldParseMode,
-	post_parse_steps: &TokenStream,
-	where_collector: &mut WhereCollector,
-) -> Result<TokenStream> {
-	let fields = Field::from_fields(&data.fields)?;
-	let members = members_tokens(&data.fields);
-	Ok(if parse_mode == FieldParseMode::Sequential {
-		SequentialPlan { fields: &fields, members: &members, post_parse_steps, constructor: quote! { Self } }
-			.render(where_collector)
-	} else {
-		MustOccurPlan {
-			fields: &fields,
-			members: &members,
-			post_parse_steps,
-			parse_mode,
-			constructor: quote! { Self },
-			hoisted: &[],
-		}
-		.render(where_collector)
-	})
+	});
+	let nodes: Vec<TokenStream> = nodes.collect();
+	let miss = match done {
+		Some(variant) => variant.construct(post, |field| field.var.to_token_stream()),
+		None if depth > 0 => unexpected_at_next(),
+		None => quote! {},
+	};
+	quote! { #(#nodes)* #miss }
 }
 
 /// True when `ty` is a substitution value-slot wrapper (`Value<..>` / `CalcableValue<..>`).
-/// These slots peek broadly (they match any substitution/math function), so an enum with
-/// several of them cannot pick the right variant for a leading function by peek alone.
-fn type_is_value_slot(ty: &Type) -> bool {
-	matches!(ty, Type::Path(tp) if tp.path.segments.last().is_some_and(|s| {
-		let n = s.ident.to_string();
-		n == "Value" || n == "CalcableValue"
-	}))
+fn is_value_slot(ty: &Type) -> bool {
+	matches!(ty, Type::Path(path) if path.path.segments.last().is_some_and(|s| s.ident == "Value" || s.ident == "CalcableValue"))
 }
 
-/// Emits a pre-dispatch that resolves a leading substitution/math function to the correct
-/// value-slot variant by *trying* each slot (rewinding on failure) rather than committing to
-/// the first whose peek matches. Only single-field `Value`/`CalcableValue` variants participate.
-///
-/// Typed slots (no keyword atom) are tried before keyword slots (`Value<T![Ident]>`), so e.g.
-/// `var(--a, small)` in `font-size` lands in the typed `<absolute-size>` slot, and only a
-/// keyword-only enum falls back to a (deliberately arbitrary) keyword slot. Restricting the
-/// probe to `Kind::Function` leads keeps ordinary literal/keyword dispatch untouched.
-fn substitution_predispatch(
-	plans: &[VariantPlan],
-	post_parse_steps: &TokenStream,
-	wc: &mut WhereCollector,
-) -> TokenStream {
-	let mut typed: Vec<&VariantPlan> = Vec::new();
-	let mut keyword: Vec<&VariantPlan> = Vec::new();
-	for plan in plans {
-		if plan.fields.len() != 1 || !type_is_value_slot(&plan.first_type) {
-			continue;
+/// Runs `body`, which returns or errors, and rewinds to where it began when it errors.
+fn attempt(body: TokenStream) -> TokenStream {
+	quote! {
+		let checkpoint = p.checkpoint();
+		if let Ok(v) = (|| -> ::css_parse::Result<Self> { #body })() {
+			return Ok(v);
 		}
-		if plan.effective_atom.is_some() { keyword.push(plan) } else { typed.push(plan) }
+		p.rewind(checkpoint);
 	}
-	if typed.is_empty() && keyword.is_empty() {
-		return TokenStream::new();
-	}
-	// Keyword slots are interchangeable `Value<T![Ident]>`; the first is enough.
-	let attempts: TokenStream = typed
+}
+
+/// Value slots peek broadly (any substitution or math function), so an enum with several cannot
+/// pick the right one for a leading function by peek alone: try each variant which starts with
+/// one in turn, rewinding on failure. Typed slots come before the keyword slot, which is one
+/// `Value<T![Ident]>` like any other, so `var(--a, small)` lands in the typed slot when there is
+/// one.
+fn substitution_predispatch(variants: &[Variant], post: &TokenStream, wc: &mut WhereCollector) -> TokenStream {
+	let slots = variants.iter().filter(|v| v.is_ordered() && v.fields.first().is_some_and(|f| is_value_slot(&f.ty)));
+	let (keyword, typed): (Vec<_>, Vec<_>) = slots.partition(|v| v.fields[0].atom.is_some());
+	let attempts: Vec<TokenStream> = typed
 		.into_iter()
 		.chain(keyword.into_iter().take(1))
-		.map(|plan| {
-			let ty = &plan.first_type;
-			wc.add(ty);
-			let ident = &plan.ident;
-			let member = &plan.members[0];
-			quote! {
-				if let Ok(v) = p.try_parse::<#ty>() {
-					#post_parse_steps
-					return Ok(Self::#ident { #member: v });
-				}
-			}
-		})
+		.map(|variant| attempt(variant.ordered(0, post, wc)))
 		.collect();
+	if attempts.is_empty() {
+		quote! {}
+	} else {
+		quote! { if p.peek_n(1) == ::css_parse::Kind::Function { #(#attempts)* } }
+	}
+}
+
+/// Sibling any-order variants whose fields are all optional and whose atoms overlap, such as
+/// `[ filled | open ] || [ dot | sesame ]`, cannot be tried one at a time: the first would stop at
+/// a token a sibling accepts and succeed with it unconsumed. One loop accepts every field of every
+/// sibling, and the first atom which belongs to one sibling alone decides which is built.
+fn shared_loop(variants: &[&Variant], post: &TokenStream, wc: &mut WhereCollector) -> TokenStream {
+	let mut union: Vec<(&Field, usize)> = vec![];
+	let same = |a: &Field, b: &Field| a.atom == b.atom && a.ty == b.ty;
+	for (i, variant) in variants.iter().enumerate() {
+		for field in &variant.fields {
+			if !union.iter().any(|(seen, _)| same(seen, field)) {
+				union.push((field, i));
+			}
+		}
+	}
+	let var = |field: &Field| {
+		let i = union.iter().position(|(seen, _)| same(seen, field)).expect("field is in union");
+		format_ident!("u{i}")
+	};
+	let owners = |field: &Field| variants.iter().filter(|v| v.fields.iter().any(|f| same(f, field))).count();
+
+	let bindings = union.iter().map(|(field, _)| {
+		let var = var(field);
+		let ty = &field.ty;
+		quote! { let mut #var: Option<#ty> = None; }
+	});
+	let steps = union.iter().map(|(field, i)| {
+		wc.add(&field.ty);
+		let var = var(field);
+		let ty = &field.ty;
+		let peek = field.peek();
+		let decides = field.atom.is_some() && owners(field) == 1;
+		let guard = decides.then(|| quote! { && _alternative == 0 });
+		let decide = decides.then(|| {
+			let alternative = i + 1;
+			quote! { _alternative = #alternative; }
+		});
+		quote! {
+			if #var.is_none() #guard && #peek {
+				#decide
+				#var = Some(p.parse::<#ty>()?);
+				continue;
+			}
+		}
+	});
+	let none = union.iter().map(|(field, _)| {
+		let var = var(field);
+		quote! { #var.is_none() }
+	});
+	let arms = variants.iter().enumerate().map(|(i, variant)| {
+		let alternative = i + 1;
+		let construct = variant.construct(post, |field| var(field).to_token_stream());
+		quote! { #alternative => { #construct } }
+	});
+	let first = variants[0].construct(post, |field| var(field).to_token_stream());
+	let unexpected = unexpected_at_next();
 	quote! {
-		if p.peek_n(1) == ::css_parse::Kind::Function {
-			#attempts
+		#(#bindings)*
+		let mut _alternative: usize = 0;
+		loop {
+			let c = p.peek_n(1);
+			#(#steps)*
+			break;
+		}
+		if #(#none)&&* { #unexpected }
+		match _alternative {
+			#(#arms)*
+			_ => { #first }
 		}
 	}
 }
 
-fn derive_enum_body(
-	data: &DataEnum,
-	post_parse_steps: &TokenStream,
-	where_collector: &mut WhereCollector,
-) -> Result<TokenStream> {
-	let plans: Vec<VariantPlan> =
-		data.variants.iter().map(|v| VariantPlan::new(v, post_parse_steps)).collect::<Result<_>>()?;
+fn enum_body(variants: &[Variant], post: &TokenStream, wc: &mut WhereCollector) -> TokenStream {
+	let predispatch = substitution_predispatch(variants, post, wc);
+	let ordered: Vec<&Variant> = variants.iter().filter(|v| v.is_ordered()).collect();
+	let any_order: Vec<&Variant> = variants.iter().filter(|v| !v.is_ordered()).collect();
+	let dispatch = dispatch(&ordered, 0, post, wc);
 
-	// Group by (first-field type, has-effective-atom). No-atom variants get their
-	// own peeked-fallback group, after any atom-dispatch group for the same type.
-	let grouped = plans
-		.iter()
-		.sorted_by_key(|p| {
-			let ty = &p.first_type;
-			(quote!(#ty).to_string(), p.effective_atom.is_none())
-		})
-		.chunk_by(|p| {
-			let ty = &p.first_type;
-			(quote!(#ty).to_string(), p.effective_atom.is_none())
+	let overlapping = any_order.len() > 1
+		&& any_order.iter().all(|v| v.all_optional())
+		&& any_order.iter().enumerate().any(|(i, v)| {
+			any_order.iter().enumerate().any(|(j, w)| {
+				i != j && v.fields.iter().any(|f| f.atom.is_some() && w.fields.iter().any(|g| g.atom == f.atom))
+			})
 		});
-
-	let ts = grouped
-		.into_iter()
-		.with_position()
-		.map(|(position, ((_type_str, no_atom), group))| {
-			let variants: Vec<&VariantPlan> = group.collect();
-			Ok(EnumGroupPlan::new(no_atom, variants, &position).render(where_collector))
-		})
-		.collect::<Result<TokenStream>>()?;
-	let predispatch = substitution_predispatch(&plans, post_parse_steps, where_collector);
-	Ok(quote! { #predispatch #ts })
+	let tail = if overlapping {
+		shared_loop(&any_order, post, wc)
+	} else if let Some((last, rest)) = any_order.split_last() {
+		let attempts: Vec<TokenStream> = rest.iter().map(|variant| attempt(variant.any_order(post, wc))).collect();
+		let last = last.any_order(post, wc);
+		quote! { #(#attempts)* #last }
+	} else {
+		unexpected_at_next()
+	};
+	quote! { #predispatch #dispatch #tail }
 }
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream> {
-	let mut where_collector = WhereCollector::new();
-	let ident = input.ident;
+	let mut wc = WhereCollector::new();
+	let ident = &input.ident;
 	let generics = &input.generics;
 	let generic_with_a = ensure_lifetime_a(generics);
 	let (impl_generics, _, _) = generic_with_a.split_for_impl();
 	let (_, type_generics, _) = generics.split_for_impl();
 
-	let mut pre_parse_steps = quote! {};
-	let mut post_parse_steps = quote! {};
-	let parse_arg = ParseArg::from_attributes(&input.attrs)?;
-	let parse_mode = parse_arg.parse_mode();
-	if let Some(crate::darling_ext::StateArg(state_ident)) = parse_arg.state {
-		pre_parse_steps = quote! {
-			let state = p.set_state(State::#state_ident);
-			#pre_parse_steps
-		};
-		post_parse_steps = quote! {
-			#post_parse_steps
-			p.set_state(state);
-		};
+	let mut pre = quote! {};
+	let mut post = quote! {};
+	let arg = ParseArg::from_attributes(&input.attrs)?;
+	if let Some(StateArg(state)) = &arg.state {
+		pre = quote! { let state = p.set_state(State::#state); #pre };
+		post = quote! { #post p.set_state(state); };
 	}
-	if let Some(stop) = parse_arg.stop {
-		let kind_ident = &stop.variant;
-		pre_parse_steps = if stop.prefix == "Kind" {
-			quote! {
-				let stop = p.set_stop(KindSet::new(&[Kind::#kind_ident]));
-				#pre_parse_steps
-			}
+	if let Some(stop) = &arg.stop {
+		let variant = &stop.variant;
+		let set = if stop.prefix == "Kind" {
+			quote! { KindSet::new(&[Kind::#variant]) }
 		} else {
-			quote! {
-				let stop = p.set_stop(KindSet::#kind_ident);
-				#pre_parse_steps
-			}
+			quote! { KindSet::#variant }
 		};
-		post_parse_steps = quote! {
-			#post_parse_steps
-			p.set_stop(stop);
-		};
+		pre = quote! { let stop = p.set_stop(#set); #pre };
+		post = quote! { #post p.set_stop(stop); };
 	}
 
 	let body = match &input.data {
 		Data::Union(_) => return Err(Error::new(ident.span(), "Cannot derive Parse on a Union")),
-		Data::Struct(data) => derive_struct_body(data, parse_mode, &post_parse_steps, &mut where_collector)?,
-		Data::Enum(data) => derive_enum_body(data, &post_parse_steps, &mut where_collector)?,
+		Data::Struct(data) => {
+			let variant =
+				Variant { path: quote! { Self }, mode: arg.parse_mode(), fields: Field::all(&data.fields, None)? };
+			variant.body(&post, &mut wc)
+		}
+		Data::Enum(data) => {
+			let variants = data
+				.variants
+				.iter()
+				.map(|variant| {
+					if variant.fields.is_empty() {
+						return Err(Error::new(variant.ident.span(), "enum variant must have at least one field"));
+					}
+					let ident = &variant.ident;
+					Ok(Variant {
+						path: quote! { Self::#ident },
+						mode: ParseArg::from_attributes(&variant.attrs)?.parse_mode(),
+						fields: Field::all(&variant.fields, extract_atom(&variant.attrs)?)?,
+					})
+				})
+				.collect::<Result<Vec<_>>>()?;
+			enum_body(&variants, &post, &mut wc)
+		}
 	};
 
-	let generics = input.generics.clone();
-	let mut where_clause = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::Parse<'a> });
-	// Add Peek<'a> predicate for each collected type param too.
-	if let Some(ref mut wc) = where_clause {
-		let additional = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::Peek<'a> });
-		if let Some(additional) = additional {
-			for pred in additional.predicates {
-				if !wc.predicates.iter().any(|p| p == &pred) {
-					wc.predicates.push(pred);
-				}
-			}
-		}
-	}
+	let where_clause =
+		wc.extend_where_clause(generics, parse_quote! { ::css_parse::Parse<'a> + ::css_parse::Peek<'a> });
 
 	Ok(quote! {
 		#[automatically_derived]
@@ -1466,7 +525,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 				I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
 			{
 				use css_parse::{Parse, Peek};
-				#pre_parse_steps
+				#pre
 				#body
 			}
 		}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_non_atom_only_input.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_non_atom_only_input.snap
@@ -19,29 +19,29 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 _ => {}
             }
         }
-        let mut auto: Option<Ident> = None;
-        let mut length: Option<Length> = None;
+        let mut v0: Option<Ident> = None;
+        let mut v1: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            if auto.is_none() && p.peek::<Ident>()
+            if v0.is_none() && p.peek::<Ident>()
                 && p.to_atom::<FooAtoms>(c) == FooAtoms::Auto
             {
-                auto = Some(p.parse::<Ident>()?);
+                v0 = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if length.is_none() && <Length>::peek(p, c) {
-                length = Some(p.parse::<Length>()?);
+            if v1.is_none() && p.peek::<Length>() {
+                v1 = Some(p.parse::<Length>()?);
                 continue;
             }
             break;
         }
-        if auto.is_none() && length.is_none() {
+        if v0.is_none() && v1.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
         return Ok(Self::Valued {
-            auto: auto,
-            length: length,
+            auto: v0,
+            length: v1,
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_overlapping_lead_atoms.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_all_must_occur_overlapping_lead_atoms.snap
@@ -9,43 +9,52 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut wrap: Option<Ident> = None;
-        let mut a: Option<Ident> = None;
-        let mut b: Option<Ident> = None;
+        let mut u0: Option<Ident> = None;
+        let mut u1: Option<Ident> = None;
+        let mut u2: Option<Ident> = None;
         let mut _alternative: usize = 0;
         loop {
             let c = p.peek_n(1);
-            if wrap.is_none() && p.peek::<Ident>()
+            if u0.is_none() && p.peek::<Ident>()
                 && p.to_atom::<FooAtoms>(c) == FooAtoms::Wrap
             {
-                wrap = Some(p.parse::<Ident>()?);
+                u0 = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if (a.is_none() && _alternative == 0 && p.peek::<Ident>()
-                && p.to_atom::<FooAtoms>(c) == FooAtoms::A)
+            if u1.is_none() && _alternative == 0 && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::A
             {
                 _alternative = 1usize;
-                a = Some(p.parse::<Ident>()?);
+                u1 = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if (b.is_none() && _alternative == 0 && p.peek::<Ident>()
-                && p.to_atom::<FooAtoms>(c) == FooAtoms::B)
+            if u2.is_none() && _alternative == 0 && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::B
             {
                 _alternative = 2usize;
-                b = Some(p.parse::<Ident>()?);
+                u2 = Some(p.parse::<Ident>()?);
                 continue;
             }
             break;
         }
-        if wrap.is_none() && a.is_none() && b.is_none() {
+        if u0.is_none() && u1.is_none() && u2.is_none() {
             return Err(
-                crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected),
+                ::css_parse::Diagnostic::new(
+                    p.peek_n(1),
+                    ::css_parse::Diagnostic::unexpected,
+                ),
             )?;
         }
         match _alternative {
-            1usize => return Ok(Self::WrapA { wrap: wrap, a: a }),
-            2usize => return Ok(Self::WrapB { wrap: wrap, b: b }),
-            _ => return Ok(Self::WrapA { wrap: wrap, a: a }),
+            1usize => {
+                return Ok(Self::WrapA { wrap: u0, a: u1 });
+            }
+            2usize => {
+                return Ok(Self::WrapB { wrap: u0, b: u2 });
+            }
+            _ => {
+                return Ok(Self::WrapA { wrap: u0, a: u1 });
+            }
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
@@ -5,8 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a, T> ::css_parse::Parse<'a> for Container<T>
 where
-    T: ::css_parse::Parse<'a>,
-    T: ::css_parse::Peek<'a>,
+    T: ::css_parse::Parse<'a> + ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where
@@ -14,14 +13,20 @@ where
     {
         use css_parse::{Parse, Peek};
         if p.peek::<T>() {
-            let v0 = p.parse::<Option<T>>()?;
-            return Ok(Self::Optional { 0: v0 });
-        }
-        if p.peek::<T>() {
             let v0 = p.parse::<T>()?;
             return Ok(Self::Single { 0: v0 });
         }
-        let v0 = p.parse::<Vec<T>>()?;
-        return Ok(Self::Multiple { 0: v0 });
+        if p.peek::<Vec<T>>() {
+            let v0 = p.parse::<Vec<T>>()?;
+            return Ok(Self::Multiple { 0: v0 });
+        }
+        let v0 = p.parse::<Option<T>>()?;
+        return Ok(Self::Optional { 0: v0 });
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_non_ident_atom_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_non_ident_atom_field.snap
@@ -9,31 +9,31 @@ impl<'a> ::css_parse::Parse<'a> for VoiceVolume {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut soft: Option<Ident> = None;
-        let mut decibel: Option<Decibel> = None;
+        let mut v0: Option<Ident> = None;
+        let mut v1: Option<Decibel> = None;
         loop {
             let c = p.peek_n(1);
-            if soft.is_none() && p.peek::<Ident>()
+            if v0.is_none() && p.peek::<Ident>()
                 && p.to_atom::<FooAtoms>(c) == FooAtoms::Soft
             {
-                soft = Some(p.parse::<Ident>()?);
+                v0 = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if decibel.is_none() && p.peek::<Decibel>()
+            if v1.is_none() && p.peek::<Decibel>()
                 && p.to_atom::<FooAtoms>(c) == FooAtoms::Db
             {
-                decibel = Some(p.parse::<Decibel>()?);
+                v1 = Some(p.parse::<Decibel>()?);
                 continue;
             }
             break;
         }
-        if soft.is_none() && decibel.is_none() {
+        if v0.is_none() && v1.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
         return Ok(Self::Soft {
-            soft: soft,
-            decibel: decibel,
+            soft: v0,
+            decibel: v1,
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_siblings_no_shared_atoms.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_siblings_no_shared_atoms.snap
@@ -19,67 +19,65 @@ impl<'a> ::css_parse::Parse<'a> for MarginTrim {
                 _ => {}
             }
         }
-        let c = p.peek_n(1);
-        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::Block
-            || p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::Inline
-        {
-            let mut block: Option<Ident> = None;
-            let mut inline: Option<Ident> = None;
+        let checkpoint = p.checkpoint();
+        if let Ok(v) = (|| -> ::css_parse::Result<Self> {
+            let mut v0: Option<Ident> = None;
+            let mut v1: Option<Ident> = None;
             loop {
                 let c = p.peek_n(1);
-                if block.is_none() && p.peek::<Ident>()
+                if v0.is_none() && p.peek::<Ident>()
                     && p.to_atom::<FooAtoms>(c) == FooAtoms::Block
                 {
-                    block = Some(p.parse::<Ident>()?);
+                    v0 = Some(p.parse::<Ident>()?);
                     continue;
                 }
-                if inline.is_none() && p.peek::<Ident>()
+                if v1.is_none() && p.peek::<Ident>()
                     && p.to_atom::<FooAtoms>(c) == FooAtoms::Inline
                 {
-                    inline = Some(p.parse::<Ident>()?);
+                    v1 = Some(p.parse::<Ident>()?);
                     continue;
                 }
                 break;
             }
-            if block.is_none() && inline.is_none() {
+            if v0.is_none() && v1.is_none() {
                 let c = p.peek_n(1);
-                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+                Err(
+                    ::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected),
+                )?
             }
             return Ok(Self::BlockInline {
-                block: block,
-                inline: inline,
+                block: v0,
+                inline: v1,
             });
+        })() {
+            return Ok(v);
         }
-        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockStart
-            || p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockEnd
-        {
-            let mut block_start: Option<Ident> = None;
-            let mut block_end: Option<Ident> = None;
-            loop {
-                let c = p.peek_n(1);
-                if block_start.is_none() && p.peek::<Ident>()
-                    && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockStart
-                {
-                    block_start = Some(p.parse::<Ident>()?);
-                    continue;
-                }
-                if block_end.is_none() && p.peek::<Ident>()
-                    && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockEnd
-                {
-                    block_end = Some(p.parse::<Ident>()?);
-                    continue;
-                }
-                break;
+        p.rewind(checkpoint);
+        let mut v0: Option<Ident> = None;
+        let mut v1: Option<Ident> = None;
+        loop {
+            let c = p.peek_n(1);
+            if v0.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockStart
+            {
+                v0 = Some(p.parse::<Ident>()?);
+                continue;
             }
-            if block_start.is_none() && block_end.is_none() {
-                let c = p.peek_n(1);
-                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            if v1.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::BlockEnd
+            {
+                v1 = Some(p.parse::<Ident>()?);
+                continue;
             }
-            return Ok(Self::BlockStartBlockEnd {
-                block_start: block_start,
-                block_end: block_end,
-            });
+            break;
         }
-        return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?;
+        if v0.is_none() && v1.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
+        }
+        return Ok(Self::BlockStartBlockEnd {
+            block_start: v0,
+            block_end: v1,
+        });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_variant_mixed_atom_and_type_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_one_must_occur_variant_mixed_atom_and_type_fields.snap
@@ -9,92 +9,73 @@ impl<'a> ::css_parse::Parse<'a> for VerticalAlign {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut alignment_baseline: Option<AlignmentBaseline> = None;
-        let mut baseline_shift: Option<BaselineShift> = None;
+        let checkpoint = p.checkpoint();
+        if let Ok(v) = (|| -> ::css_parse::Result<Self> {
+            let mut v0: Option<Ident> = None;
+            let mut v1: Option<AlignmentBaseline> = None;
+            let mut v2: Option<BaselineShift> = None;
+            loop {
+                let c = p.peek_n(1);
+                if v0.is_none() && p.peek::<Ident>()
+                    && p.to_atom::<CssAtomSet>(c) == CssAtomSet::First
+                {
+                    v0 = Some(p.parse::<Ident>()?);
+                    continue;
+                }
+                if v1.is_none() && p.peek::<AlignmentBaseline>() {
+                    v1 = Some(p.parse::<AlignmentBaseline>()?);
+                    continue;
+                }
+                if v2.is_none() && p.peek::<BaselineShift>() {
+                    v2 = Some(p.parse::<BaselineShift>()?);
+                    continue;
+                }
+                break;
+            }
+            if v0.is_none() && v1.is_none() && v2.is_none() {
+                let c = p.peek_n(1);
+                Err(
+                    ::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected),
+                )?
+            }
+            return Ok(Self::First {
+                first: v0,
+                alignment_baseline: v1,
+                baseline_shift: v2,
+            });
+        })() {
+            return Ok(v);
+        }
+        p.rewind(checkpoint);
+        let mut v0: Option<Ident> = None;
+        let mut v1: Option<AlignmentBaseline> = None;
+        let mut v2: Option<BaselineShift> = None;
         loop {
             let c = p.peek_n(1);
-            if alignment_baseline.is_none() && <AlignmentBaseline>::peek(p, c) {
-                alignment_baseline = Some(p.parse::<AlignmentBaseline>()?);
+            if v0.is_none() && p.peek::<Ident>()
+                && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Last
+            {
+                v0 = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if baseline_shift.is_none() && <BaselineShift>::peek(p, c) {
-                baseline_shift = Some(p.parse::<BaselineShift>()?);
+            if v1.is_none() && p.peek::<AlignmentBaseline>() {
+                v1 = Some(p.parse::<AlignmentBaseline>()?);
+                continue;
+            }
+            if v2.is_none() && p.peek::<BaselineShift>() {
+                v2 = Some(p.parse::<BaselineShift>()?);
                 continue;
             }
             break;
         }
-        let c = p.peek_n(1);
-        if p.peek::<Ident>() && p.to_atom::<CssAtomSet>(c) == CssAtomSet::First {
-            let mut first: Option<Ident> = None;
-            loop {
-                let c = p.peek_n(1);
-                if first.is_none() && p.peek::<Ident>()
-                    && p.to_atom::<CssAtomSet>(c) == CssAtomSet::First
-                {
-                    first = Some(p.parse::<Ident>()?);
-                    continue;
-                }
-                if alignment_baseline.is_none() && <AlignmentBaseline>::peek(p, c) {
-                    alignment_baseline = Some(p.parse::<AlignmentBaseline>()?);
-                    continue;
-                }
-                if baseline_shift.is_none() && <BaselineShift>::peek(p, c) {
-                    baseline_shift = Some(p.parse::<BaselineShift>()?);
-                    continue;
-                }
-                break;
-            }
-            if first.is_none() && alignment_baseline.is_none()
-                && baseline_shift.is_none()
-            {
-                let c = p.peek_n(1);
-                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-            }
-            return Ok(Self::First {
-                first: first,
-                alignment_baseline: alignment_baseline,
-                baseline_shift: baseline_shift,
-            });
-        }
-        if p.peek::<Ident>() && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Last {
-            let mut last: Option<Ident> = None;
-            loop {
-                let c = p.peek_n(1);
-                if last.is_none() && p.peek::<Ident>()
-                    && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Last
-                {
-                    last = Some(p.parse::<Ident>()?);
-                    continue;
-                }
-                if alignment_baseline.is_none() && <AlignmentBaseline>::peek(p, c) {
-                    alignment_baseline = Some(p.parse::<AlignmentBaseline>()?);
-                    continue;
-                }
-                if baseline_shift.is_none() && <BaselineShift>::peek(p, c) {
-                    baseline_shift = Some(p.parse::<BaselineShift>()?);
-                    continue;
-                }
-                break;
-            }
-            if last.is_none() && alignment_baseline.is_none() && baseline_shift.is_none()
-            {
-                let c = p.peek_n(1);
-                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-            }
-            return Ok(Self::Last {
-                last: last,
-                alignment_baseline: alignment_baseline,
-                baseline_shift: baseline_shift,
-            });
-        }
-        if alignment_baseline.is_none() && baseline_shift.is_none() {
+        if v0.is_none() && v1.is_none() && v2.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
-        return Ok(Self::First {
-            first: None,
-            alignment_baseline: alignment_baseline,
-            baseline_shift: baseline_shift,
+        return Ok(Self::Last {
+            last: v0,
+            alignment_baseline: v1,
+            baseline_shift: v2,
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_and_tuple_mixed.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_and_tuple_mixed.snap
@@ -15,22 +15,26 @@ impl<'a> ::css_parse::Parse<'a> for FlexValue {
         }
         if p.peek::<Length>() {
             let v0 = p.parse::<Length>()?;
+            if p.peek::<Length>() {
+                let v1 = p.parse::<Length>()?;
+                return Ok(Self::MinMax { min: v0, max: v1 });
+            }
             return Ok(Self::Length { 0: v0 });
-        }
-        if p.peek::<Length>() {
-            let min = p.parse::<Length>()?;
-            let max = p.parse::<Length>()?;
-            return Ok(Self::MinMax { min: min, max: max });
         }
         if p.peek::<Percentage>() {
             let v0 = p.parse::<Percentage>()?;
             return Ok(Self::Percentage { 0: v0 });
         }
-        let expr = p.parse::<String>()?;
-        let unit = p.parse::<Unit>()?;
-        return Ok(Self::Calc {
-            expr: expr,
-            unit: unit,
-        });
+        if p.peek::<String>() {
+            let v0 = p.parse::<String>()?;
+            let v1 = p.parse::<Unit>()?;
+            return Ok(Self::Calc { expr: v0, unit: v1 });
+        }
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variant_one_must_occur.snap
@@ -19,31 +19,31 @@ impl<'a> ::css_parse::Parse<'a> for FlexWrap {
                 _ => {}
             }
         }
-        let mut wrap: Option<Ident> = None;
-        let mut balance: Option<Ident> = None;
+        let mut v0: Option<Ident> = None;
+        let mut v1: Option<Ident> = None;
         loop {
             let c = p.peek_n(1);
-            if wrap.is_none() && p.peek::<Ident>()
+            if v0.is_none() && p.peek::<Ident>()
                 && p.to_atom::<FooAtoms>(c) == FooAtoms::Wrap
             {
-                wrap = Some(p.parse::<Ident>()?);
+                v0 = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if balance.is_none() && p.peek::<Ident>()
+            if v1.is_none() && p.peek::<Ident>()
                 && p.to_atom::<FooAtoms>(c) == FooAtoms::Balance
             {
-                balance = Some(p.parse::<Ident>()?);
+                v1 = Some(p.parse::<Ident>()?);
                 continue;
             }
             break;
         }
-        if wrap.is_none() && balance.is_none() {
+        if v0.is_none() && v1.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
         return Ok(Self::Wrap {
-            wrap: wrap,
-            balance: balance,
+            wrap: v0,
+            balance: v1,
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_one_must_occur_siblings.snap
@@ -19,75 +19,61 @@ impl<'a> ::css_parse::Parse<'a> for FlexWrap {
                 _ => {}
             }
         }
-        let mut balance: Option<Ident> = None;
-        {
+        let mut u0: Option<Ident> = None;
+        let mut u1: Option<Ident> = None;
+        let mut u2: Option<Ident> = None;
+        let mut _alternative: usize = 0;
+        loop {
             let c = p.peek_n(1);
-            if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::Balance {
-                balance = Some(p.parse::<Ident>()?);
+            if u0.is_none() && _alternative == 0 && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::Wrap
+            {
+                _alternative = 1usize;
+                u0 = Some(p.parse::<Ident>()?);
+                continue;
+            }
+            if u1.is_none() && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::Balance
+            {
+                u1 = Some(p.parse::<Ident>()?);
+                continue;
+            }
+            if u2.is_none() && _alternative == 0 && p.peek::<Ident>()
+                && p.to_atom::<FooAtoms>(c) == FooAtoms::WrapReverse
+            {
+                _alternative = 2usize;
+                u2 = Some(p.parse::<Ident>()?);
+                continue;
+            }
+            break;
+        }
+        if u0.is_none() && u1.is_none() && u2.is_none() {
+            return Err(
+                ::css_parse::Diagnostic::new(
+                    p.peek_n(1),
+                    ::css_parse::Diagnostic::unexpected,
+                ),
+            )?;
+        }
+        match _alternative {
+            1usize => {
+                return Ok(Self::Wrap {
+                    wrap: u0,
+                    balance: u1,
+                });
+            }
+            2usize => {
+                return Ok(Self::WrapReverse {
+                    wrap_reverse: u2,
+                    balance: u1,
+                });
+            }
+            _ => {
+                return Ok(Self::Wrap {
+                    wrap: u0,
+                    balance: u1,
+                });
             }
         }
-        let c = p.peek_n(1);
-        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::Wrap {
-            let mut wrap: Option<Ident> = None;
-            loop {
-                let c = p.peek_n(1);
-                if wrap.is_none() && p.peek::<Ident>()
-                    && p.to_atom::<FooAtoms>(c) == FooAtoms::Wrap
-                {
-                    wrap = Some(p.parse::<Ident>()?);
-                    continue;
-                }
-                if balance.is_none() && p.peek::<Ident>()
-                    && p.to_atom::<FooAtoms>(c) == FooAtoms::Balance
-                {
-                    balance = Some(p.parse::<Ident>()?);
-                    continue;
-                }
-                break;
-            }
-            if wrap.is_none() && balance.is_none() {
-                let c = p.peek_n(1);
-                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-            }
-            return Ok(Self::Wrap {
-                wrap: wrap,
-                balance: balance,
-            });
-        }
-        if p.peek::<Ident>() && p.to_atom::<FooAtoms>(c) == FooAtoms::WrapReverse {
-            let mut wrap_reverse: Option<Ident> = None;
-            loop {
-                let c = p.peek_n(1);
-                if wrap_reverse.is_none() && p.peek::<Ident>()
-                    && p.to_atom::<FooAtoms>(c) == FooAtoms::WrapReverse
-                {
-                    wrap_reverse = Some(p.parse::<Ident>()?);
-                    continue;
-                }
-                if balance.is_none() && p.peek::<Ident>()
-                    && p.to_atom::<FooAtoms>(c) == FooAtoms::Balance
-                {
-                    balance = Some(p.parse::<Ident>()?);
-                    continue;
-                }
-                break;
-            }
-            if wrap_reverse.is_none() && balance.is_none() {
-                let c = p.peek_n(1);
-                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-            }
-            return Ok(Self::WrapReverse {
-                wrap_reverse: wrap_reverse,
-                balance: balance,
-            });
-        }
-        if balance.is_none() {
-            let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-        }
-        return Ok(Self::Wrap {
-            wrap: None,
-            balance: balance,
-        });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
@@ -9,47 +9,41 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurEnum {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        if p.peek::<AutoValue>() {
-            let c = p.peek_n(1);
-            match p.to_atom::<FooKeywords>(c) {
-                FooKeywords::Auto => {
-                    let mut auto_field: Option<AutoValue> = None;
-                    let mut none_field: Option<NoneValue> = None;
-                    let mut length: Option<Length> = None;
-                    loop {
-                        let c = p.peek_n(1);
-                        if auto_field.is_none() && p.peek::<AutoValue>()
-                            && p.to_atom::<FooKeywords>(c) == FooKeywords::Auto
-                        {
-                            auto_field = Some(p.parse::<AutoValue>()?);
-                            continue;
-                        }
-                        if none_field.is_none() && p.peek::<NoneValue>()
-                            && p.to_atom::<FooKeywords>(c) == FooKeywords::None
-                        {
-                            none_field = Some(p.parse::<NoneValue>()?);
-                            continue;
-                        }
-                        if length.is_none() && <Length>::peek(p, c) {
-                            length = Some(p.parse::<Length>()?);
-                            continue;
-                        }
-                        break;
-                    }
-                    if auto_field.is_none() || none_field.is_none() || length.is_none() {
-                        let c = p.peek_n(1);
-                        Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-                    }
-                    return Ok(Self::Complex {
-                        auto_field: auto_field.unwrap(),
-                        none_field: none_field.unwrap(),
-                        length: length.unwrap(),
-                    });
-                }
-                _ => {}
-            }
+        if p.peek::<String>() {
+            let v0 = p.parse::<String>()?;
+            return Ok(Self::Simple { 0: v0 });
         }
-        let v0 = p.parse::<String>()?;
-        return Ok(Self::Simple { 0: v0 });
+        let mut v0: Option<AutoValue> = None;
+        let mut v1: Option<NoneValue> = None;
+        let mut v2: Option<Length> = None;
+        loop {
+            let c = p.peek_n(1);
+            if v0.is_none() && p.peek::<AutoValue>()
+                && p.to_atom::<FooKeywords>(c) == FooKeywords::Auto
+            {
+                v0 = Some(p.parse::<AutoValue>()?);
+                continue;
+            }
+            if v1.is_none() && p.peek::<NoneValue>()
+                && p.to_atom::<FooKeywords>(c) == FooKeywords::None
+            {
+                v1 = Some(p.parse::<NoneValue>()?);
+                continue;
+            }
+            if v2.is_none() && p.peek::<Length>() {
+                v2 = Some(p.parse::<Length>()?);
+                continue;
+            }
+            break;
+        }
+        if v0.is_none() || v1.is_none() || v2.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
+        }
+        return Ok(Self::Complex {
+            auto_field: v0.unwrap(),
+            none_field: v1.unwrap(),
+            length: v2.unwrap(),
+        });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_optional_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_optional_fields.snap
@@ -16,44 +16,34 @@ impl<'a> ::css_parse::Parse<'a> for ScrollbarGutter {
                     let v0 = p.parse::<Ident>()?;
                     return Ok(Self::Auto { 0: v0 });
                 }
-                CssAtomSet::Stable => {
-                    let mut stable: Option<Ident> = None;
-                    let mut both_edges: Option<Ident> = None;
-                    loop {
-                        let c = p.peek_n(1);
-                        if stable.is_none() && p.peek::<Ident>()
-                            && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Stable
-                        {
-                            stable = Some(p.parse::<Ident>()?);
-                            continue;
-                        }
-                        if both_edges.is_none() && p.peek::<Ident>()
-                            && p.to_atom::<CssAtomSet>(c) == CssAtomSet::BothEdges
-                        {
-                            both_edges = Some(p.parse::<Ident>()?);
-                            continue;
-                        }
-                        break;
-                    }
-                    if stable.is_none() {
-                        let c = p.peek_n(1);
-                        Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-                    }
-                    return Ok(Self::Stable {
-                        stable: stable.unwrap(),
-                        both_edges: both_edges,
-                    });
-                }
-                _ => {
-                    return Err(
-                        crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
-                    )?;
-                }
+                _ => {}
             }
-        } else {
-            return Err(
-                crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected),
-            )?;
         }
+        let mut v0: Option<Ident> = None;
+        let mut v1: Option<Ident> = None;
+        loop {
+            let c = p.peek_n(1);
+            if v0.is_none() && p.peek::<Ident>()
+                && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Stable
+            {
+                v0 = Some(p.parse::<Ident>()?);
+                continue;
+            }
+            if v1.is_none() && p.peek::<Ident>()
+                && p.to_atom::<CssAtomSet>(c) == CssAtomSet::BothEdges
+            {
+                v1 = Some(p.parse::<Ident>()?);
+                continue;
+            }
+            break;
+        }
+        if v0.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
+        }
+        return Ok(Self::Stable {
+            stable: v0.unwrap(),
+            both_edges: v1,
+        });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_discriminated_by_second_field_atom.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_discriminated_by_second_field_atom.snap
@@ -9,23 +9,6 @@ impl<'a> ::css_parse::Parse<'a> for FlowInto {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        if p.peek::<CustomIdent>() {
-            let v0 = p.parse::<CustomIdent>()?;
-            let c = p.peek_n(1);
-            match p.to_atom::<Atoms>(c) {
-                Atoms::Element => {
-                    let v1 = p.parse::<Ident>()?;
-                    return Ok(Self::WithElement(v0, v1));
-                }
-                Atoms::Content => {
-                    let v1 = p.parse::<Ident>()?;
-                    return Ok(Self::WithContent(v0, v1));
-                }
-                _ => {
-                    return Ok(Self::Bare(v0));
-                }
-            }
-        }
         if p.peek::<Ident>() {
             let c = p.peek_n(1);
             match p.to_atom::<Atoms>(c) {
@@ -33,16 +16,32 @@ impl<'a> ::css_parse::Parse<'a> for FlowInto {
                     let v0 = p.parse::<Ident>()?;
                     return Ok(Self::None { 0: v0 });
                 }
-                _ => {
-                    return Err(
-                        crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
-                    )?;
+                _ => {}
+            }
+        }
+        if p.peek::<CustomIdent>() {
+            let v0 = p.parse::<CustomIdent>()?;
+            if p.peek::<Ident>() {
+                let c = p.peek_n(1);
+                match p.to_atom::<Atoms>(c) {
+                    Atoms::Element => {
+                        let v1 = p.parse::<Ident>()?;
+                        return Ok(Self::WithElement { 0: v0, 1: v1 });
+                    }
+                    Atoms::Content => {
+                        let v1 = p.parse::<Ident>()?;
+                        return Ok(Self::WithContent { 0: v0, 1: v1 });
+                    }
+                    _ => {}
                 }
             }
-        } else {
-            return Err(
-                crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected),
-            )?;
+            return Ok(Self::Bare { 0: v0 });
         }
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
@@ -9,31 +9,31 @@ impl<'a> ::css_parse::Parse<'a> for Value {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        if p.peek::<AutoKeyword>() {
-            let mut auto: Option<AutoKeyword> = None;
-            let mut length: Option<Length> = None;
-            loop {
-                let c = p.peek_n(1);
-                if auto.is_none() && <AutoKeyword>::peek(p, c) {
-                    auto = Some(p.parse::<AutoKeyword>()?);
-                    continue;
-                }
-                if length.is_none() && <Length>::peek(p, c) {
-                    length = Some(p.parse::<Length>()?);
-                    continue;
-                }
-                break;
-            }
-            if auto.is_none() || length.is_none() {
-                let c = p.peek_n(1);
-                Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
-            }
-            return Ok(Self::Complex {
-                auto: auto.unwrap(),
-                length: length.unwrap(),
-            });
+        if p.peek::<String>() {
+            let v0 = p.parse::<String>()?;
+            return Ok(Self::Normal { 0: v0 });
         }
-        let v0 = p.parse::<String>()?;
-        return Ok(Self::Normal { 0: v0 });
+        let mut v0: Option<AutoKeyword> = None;
+        let mut v1: Option<Length> = None;
+        loop {
+            let c = p.peek_n(1);
+            if v0.is_none() && p.peek::<AutoKeyword>() {
+                v0 = Some(p.parse::<AutoKeyword>()?);
+                continue;
+            }
+            if v1.is_none() && p.peek::<Length>() {
+                v1 = Some(p.parse::<Length>()?);
+                continue;
+            }
+            break;
+        }
+        if v0.is_none() || v1.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
+        }
+        return Ok(Self::Complex {
+            auto: v0.unwrap(),
+            length: v1.unwrap(),
+        });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
@@ -13,26 +13,25 @@ impl<'a> ::css_parse::Parse<'a> for TestEnum {
             let c = p.peek_n(1);
             match p.to_atom::<FooKeywords>(c) {
                 FooKeywords::None => {
-                    let none_value = {
-                        let c = p.peek_n(1);
-                        if p.equals_atom(c.into(), &FooKeywords::None) {
-                            p.parse::<NoneValue>()?
-                        } else {
-                            return Err(
-                                crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
-                            )?;
-                        }
-                    };
-                    let other_field = p.parse::<Length>()?;
+                    let v0 = p.parse::<NoneValue>()?;
+                    let v1 = p.parse::<Length>()?;
                     return Ok(Self::WithKeyword {
-                        none_value: none_value,
-                        other_field: other_field,
+                        none_value: v0,
+                        other_field: v1,
                     });
                 }
                 _ => {}
             }
         }
-        let v0 = p.parse::<String>()?;
-        return Ok(Self::Normal { 0: v0 });
+        if p.peek::<String>() {
+            let v0 = p.parse::<String>()?;
+            return Ok(Self::Normal { 0: v0 });
+        }
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
@@ -20,16 +20,14 @@ impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
                     let v0 = p.parse::<Ident>()?;
                     return Ok(Self::Bar { 0: v0 });
                 }
-                _ => {
-                    return Err(
-                        crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
-                    )?;
-                }
+                _ => {}
             }
-        } else {
-            return Err(
-                crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected),
-            )?;
         }
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
@@ -23,7 +23,15 @@ impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
                 _ => {}
             }
         }
-        let v0 = p.parse::<Length>()?;
-        return Ok(Self::Length { 0: v0 });
+        if p.peek::<Length>() {
+            let v0 = p.parse::<Length>()?;
+            return Ok(Self::Length { 0: v0 });
+        }
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_fields.snap
@@ -9,6 +9,10 @@ impl<'a> ::css_parse::Parse<'a> for Value {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
+        if p.peek::<String>() {
+            let v0 = p.parse::<String>()?;
+            return Ok(Self::Keyword { 0: v0 });
+        }
         if p.peek::<Length>() {
             let v0 = p.parse::<Length>()?;
             return Ok(Self::Length { 0: v0 });
@@ -17,7 +21,11 @@ impl<'a> ::css_parse::Parse<'a> for Value {
             let v0 = p.parse::<Percentage>()?;
             return Ok(Self::Percentage { 0: v0 });
         }
-        let v0 = p.parse::<String>()?;
-        return Ok(Self::Keyword { 0: v0 });
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_lifetime.snap
@@ -9,22 +9,26 @@ impl<'a> ::css_parse::Parse<'a> for CssValue<'a> {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
+        if p.peek::<String>() {
+            let v0 = p.parse::<String>()?;
+            if p.peek::<Vec<String>>() {
+                let v1 = p.parse::<Vec<String>>()?;
+                return Ok(Self::Function {
+                    name: v0,
+                    args: v1,
+                });
+            }
+            return Ok(Self::Keyword { 0: v0 });
+        }
         if p.peek::<Length>() {
             let v0 = p.parse::<Length>()?;
             return Ok(Self::Length { 0: v0 });
         }
-        if p.peek::<String>() {
-            let v0 = p.parse::<String>()?;
-            return Ok(Self::Keyword { 0: v0 });
-        }
-        if p.peek::<String>() {
-            let name = p.parse::<String>()?;
-            let args = p.parse::<Vec<String>>()?;
-            return Ok(Self::Function {
-                name: name,
-                args: args,
-            });
-        }
-        return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?;
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_struct_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_struct_variants.snap
@@ -14,13 +14,14 @@ impl<'a> ::css_parse::Parse<'a> for BorderStyle {
             return Ok(Self::Solid { 0: v0 });
         }
         if p.peek::<Length>() {
-            let width = p.parse::<Length>()?;
-            return Ok(Self::Dashed { width: width });
+            let v0 = p.parse::<Length>()?;
+            return Ok(Self::Dashed { width: v0 });
         }
-        if p.peek::<Length>() {
-            let radius = p.parse::<Length>()?;
-            return Ok(Self::Dotted { radius: radius });
-        }
-        return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?;
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_keyword_pair_alternation.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_keyword_pair_alternation.snap
@@ -14,56 +14,59 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
             match p.to_atom::<FooAtoms>(c) {
                 FooAtoms::Text => {
                     let v0 = p.parse::<Ident>()?;
-                    let c = p.peek_n(1);
-                    match p.to_atom::<FooAtoms>(c) {
-                        FooAtoms::Text => {
-                            let v1 = p.parse::<Ident>()?;
-                            return Ok(Self::TextText { 0: v0, 1: v1 });
-                        }
-                        FooAtoms::Alphabetic => {
-                            let v1 = p.parse::<Ident>()?;
-                            return Ok(Self::TextAlphabetic {
-                                0: v0,
-                                1: v1,
-                            });
-                        }
-                        _ => {
-                            return Ok(Self::Text { 0: v0 });
+                    if p.peek::<Ident>() {
+                        let c = p.peek_n(1);
+                        match p.to_atom::<FooAtoms>(c) {
+                            FooAtoms::Text => {
+                                let v1 = p.parse::<Ident>()?;
+                                return Ok(Self::TextText { 0: v0, 1: v1 });
+                            }
+                            FooAtoms::Alphabetic => {
+                                let v1 = p.parse::<Ident>()?;
+                                return Ok(Self::TextAlphabetic {
+                                    0: v0,
+                                    1: v1,
+                                });
+                            }
+                            _ => {}
                         }
                     }
+                    return Ok(Self::Text { 0: v0 });
                 }
                 FooAtoms::Cap => {
                     let v0 = p.parse::<Ident>()?;
-                    let c = p.peek_n(1);
-                    match p.to_atom::<FooAtoms>(c) {
-                        FooAtoms::Text => {
-                            let v1 = p.parse::<Ident>()?;
-                            return Ok(Self::CapText { 0: v0, 1: v1 });
-                        }
-                        FooAtoms::Alphabetic => {
-                            let v1 = p.parse::<Ident>()?;
-                            return Ok(Self::CapAlphabetic {
-                                0: v0,
-                                1: v1,
-                            });
-                        }
-                        _ => {
-                            Err(
-                                crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
-                            )?
+                    if p.peek::<Ident>() {
+                        let c = p.peek_n(1);
+                        match p.to_atom::<FooAtoms>(c) {
+                            FooAtoms::Text => {
+                                let v1 = p.parse::<Ident>()?;
+                                return Ok(Self::CapText { 0: v0, 1: v1 });
+                            }
+                            FooAtoms::Alphabetic => {
+                                let v1 = p.parse::<Ident>()?;
+                                return Ok(Self::CapAlphabetic {
+                                    0: v0,
+                                    1: v1,
+                                });
+                            }
+                            _ => {}
                         }
                     }
-                }
-                _ => {
                     return Err(
-                        crate::Diagnostic::new(c, crate::Diagnostic::unexpected),
+                        ::css_parse::Diagnostic::new(
+                            p.peek_n(1),
+                            ::css_parse::Diagnostic::unexpected,
+                        ),
                     )?;
                 }
+                _ => {}
             }
-        } else {
-            return Err(
-                crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected),
-            )?;
         }
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_sequential_optional_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_sequential_optional_keyword.snap
@@ -14,7 +14,9 @@ impl<'a> ::css_parse::Parse<'a> for AxisWithOptionalSnap {
             if p.equals_atom(c.into(), &CssAtomSet::X) {
                 p.parse::<Ident>()?
             } else {
-                return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
+                return Err(
+                    ::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected),
+                )?;
             }
         };
         let v1 = {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_enum.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_enum.snap
@@ -13,14 +13,11 @@ impl<'a> ::css_parse::Parse<'a> for Display {
             let v0 = p.parse::<Ident>()?;
             return Ok(Self::Block { 0: v0 });
         }
-        if p.peek::<Ident>() {
-            let v0 = p.parse::<Ident>()?;
-            return Ok(Self::Inline { 0: v0 });
-        }
-        if p.peek::<Ident>() {
-            let v0 = p.parse::<Ident>()?;
-            return Ok(Self::None { 0: v0 });
-        }
-        return Err(crate::Diagnostic::new(p.peek_n(1), crate::Diagnostic::unexpected))?;
+        return Err(
+            ::css_parse::Diagnostic::new(
+                p.peek_n(1),
+                ::css_parse::Diagnostic::unexpected,
+            ),
+        )?;
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
@@ -9,33 +9,33 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurNewtypeTest {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut auto_value: Option<Auto> = None;
-        let mut none_value: Option<None> = None;
-        let mut length: Option<Length> = None;
+        let mut v0: Option<Auto> = None;
+        let mut v1: Option<None> = None;
+        let mut v2: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            if auto_value.is_none() && p.peek::<Auto>() && p.to_atom::<Auto>(c) == Auto {
-                auto_value = Some(p.parse::<Auto>()?);
+            if v0.is_none() && p.peek::<Auto>() && p.to_atom::<Auto>(c) == Auto {
+                v0 = Some(p.parse::<Auto>()?);
                 continue;
             }
-            if none_value.is_none() && p.peek::<None>() && p.to_atom::<None>(c) == None {
-                none_value = Some(p.parse::<None>()?);
+            if v1.is_none() && p.peek::<None>() && p.to_atom::<None>(c) == None {
+                v1 = Some(p.parse::<None>()?);
                 continue;
             }
-            if length.is_none() && <Length>::peek(p, c) {
-                length = Some(p.parse::<Length>()?);
+            if v2.is_none() && p.peek::<Length>() {
+                v2 = Some(p.parse::<Length>()?);
                 continue;
             }
             break;
         }
-        if auto_value.is_none() || none_value.is_none() || length.is_none() {
+        if v0.is_none() || v1.is_none() || v2.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
         return Ok(Self {
-            auto_value: auto_value.unwrap(),
-            none_value: none_value.unwrap(),
-            length: length.unwrap(),
+            auto_value: v0.unwrap(),
+            none_value: v1.unwrap(),
+            length: v2.unwrap(),
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_optional_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_optional_fields.snap
@@ -9,31 +9,31 @@ impl<'a> ::css_parse::Parse<'a> for StableWithOptionalEdges {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut stable: Option<Ident> = None;
-        let mut both_edges: Option<Ident> = None;
+        let mut v0: Option<Ident> = None;
+        let mut v1: Option<Ident> = None;
         loop {
             let c = p.peek_n(1);
-            if stable.is_none() && p.peek::<Ident>()
+            if v0.is_none() && p.peek::<Ident>()
                 && p.to_atom::<CssAtomSet>(c) == CssAtomSet::Stable
             {
-                stable = Some(p.parse::<Ident>()?);
+                v0 = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if both_edges.is_none() && p.peek::<Ident>()
+            if v1.is_none() && p.peek::<Ident>()
                 && p.to_atom::<CssAtomSet>(c) == CssAtomSet::BothEdges
             {
-                both_edges = Some(p.parse::<Ident>()?);
+                v1 = Some(p.parse::<Ident>()?);
                 continue;
             }
             break;
         }
-        if stable.is_none() {
+        if v0.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
         return Ok(Self {
-            stable: stable.unwrap(),
-            both_edges: both_edges,
+            stable: v0.unwrap(),
+            both_edges: v1,
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_existing_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_existing_lifetime.snap
@@ -9,7 +9,7 @@ impl<'a> ::css_parse::Parse<'a> for Token<'a> {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let span = p.parse::<str>()?;
-        return Ok(Self { span: span });
+        let v0 = p.parse::<str>()?;
+        return Ok(Self { span: v0 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_one_must_occur_with_optionals.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_one_must_occur_with_optionals.snap
@@ -9,24 +9,24 @@ impl<'a> ::css_parse::Parse<'a> for OneMustOccurTest {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut foo: Option<Foo> = None;
-        let mut bar: Option<Bar> = None;
+        let mut v0: Option<Foo> = None;
+        let mut v1: Option<Bar> = None;
         loop {
             let c = p.peek_n(1);
-            if foo.is_none() && <Foo>::peek(p, c) {
-                foo = Some(p.parse::<Foo>()?);
+            if v0.is_none() && p.peek::<Foo>() {
+                v0 = Some(p.parse::<Foo>()?);
                 continue;
             }
-            if bar.is_none() && <Bar>::peek(p, c) {
-                bar = Some(p.parse::<Bar>()?);
+            if v1.is_none() && p.peek::<Bar>() {
+                v1 = Some(p.parse::<Bar>()?);
                 continue;
             }
             break;
         }
-        if foo.is_none() && bar.is_none() {
+        if v0.is_none() && v1.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
-        return Ok(Self { foo: foo, bar: bar });
+        return Ok(Self { foo: v0, bar: v1 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
@@ -9,18 +9,17 @@ impl<'a> ::css_parse::Parse<'a> for RegularKeywordTest {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let auto_value = {
+        let v0 = {
             let c = p.peek_n(1);
             if p.equals_atom(c.into(), &FooKeywords::Auto) {
                 p.parse::<AutoValue>()?
             } else {
-                return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
+                return Err(
+                    ::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected),
+                )?;
             }
         };
-        let length = p.parse::<Length>()?;
-        return Ok(Self {
-            auto_value: auto_value,
-            length: length,
-        });
+        let v1 = p.parse::<Length>()?;
+        return Ok(Self { auto_value: v0, length: v1 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
@@ -9,27 +9,27 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLength {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut auto: Option<AutoKeyword> = None;
-        let mut length: Option<Length> = None;
+        let mut v0: Option<AutoKeyword> = None;
+        let mut v1: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            if auto.is_none() && <AutoKeyword>::peek(p, c) {
-                auto = Some(p.parse::<AutoKeyword>()?);
+            if v0.is_none() && p.peek::<AutoKeyword>() {
+                v0 = Some(p.parse::<AutoKeyword>()?);
                 continue;
             }
-            if length.is_none() && <Length>::peek(p, c) {
-                length = Some(p.parse::<Length>()?);
+            if v1.is_none() && p.peek::<Length>() {
+                v1 = Some(p.parse::<Length>()?);
                 continue;
             }
             break;
         }
-        if auto.is_none() || length.is_none() {
+        if v0.is_none() || v1.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
         return Ok(Self {
-            auto: auto.unwrap(),
-            length: length.unwrap(),
+            auto: v0.unwrap(),
+            length: v1.unwrap(),
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
@@ -10,28 +10,28 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLengthInState {
     {
         use css_parse::{Parse, Peek};
         let state = p.set_state(State::InValue);
-        let mut auto: Option<AutoKeyword> = None;
-        let mut length: Option<Length> = None;
+        let mut v0: Option<AutoKeyword> = None;
+        let mut v1: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            if auto.is_none() && <AutoKeyword>::peek(p, c) {
-                auto = Some(p.parse::<AutoKeyword>()?);
+            if v0.is_none() && p.peek::<AutoKeyword>() {
+                v0 = Some(p.parse::<AutoKeyword>()?);
                 continue;
             }
-            if length.is_none() && <Length>::peek(p, c) {
-                length = Some(p.parse::<Length>()?);
+            if v1.is_none() && p.peek::<Length>() {
+                v1 = Some(p.parse::<Length>()?);
                 continue;
             }
             break;
         }
-        p.set_state(state);
-        if auto.is_none() || length.is_none() {
+        if v0.is_none() || v1.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
+        p.set_state(state);
         return Ok(Self {
-            auto: auto.unwrap(),
-            length: length.unwrap(),
+            auto: v0.unwrap(),
+            length: v1.unwrap(),
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
@@ -9,37 +9,37 @@ impl<'a> ::css_parse::Parse<'a> for SpecificKeywordTest {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut auto_field: Option<AutoValue> = None;
-        let mut none_field: Option<NoneValue> = None;
-        let mut length: Option<Length> = None;
+        let mut v0: Option<AutoValue> = None;
+        let mut v1: Option<NoneValue> = None;
+        let mut v2: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            if auto_field.is_none() && p.peek::<AutoValue>()
+            if v0.is_none() && p.peek::<AutoValue>()
                 && p.to_atom::<FooKeywords>(c) == FooKeywords::Auto
             {
-                auto_field = Some(p.parse::<AutoValue>()?);
+                v0 = Some(p.parse::<AutoValue>()?);
                 continue;
             }
-            if none_field.is_none() && p.peek::<NoneValue>()
+            if v1.is_none() && p.peek::<NoneValue>()
                 && p.to_atom::<FooKeywords>(c) == FooKeywords::None
             {
-                none_field = Some(p.parse::<NoneValue>()?);
+                v1 = Some(p.parse::<NoneValue>()?);
                 continue;
             }
-            if length.is_none() && <Length>::peek(p, c) {
-                length = Some(p.parse::<Length>()?);
+            if v2.is_none() && p.peek::<Length>() {
+                v2 = Some(p.parse::<Length>()?);
                 continue;
             }
             break;
         }
-        if auto_field.is_none() || none_field.is_none() || length.is_none() {
+        if v0.is_none() || v1.is_none() || v2.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
         return Ok(Self {
-            auto_field: auto_field.unwrap(),
-            none_field: none_field.unwrap(),
-            length: length.unwrap(),
+            auto_field: v0.unwrap(),
+            none_field: v1.unwrap(),
+            length: v2.unwrap(),
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_fields.snap
@@ -9,13 +9,13 @@ impl<'a> ::css_parse::Parse<'a> for Color {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let red = p.parse::<CSSInt>()?;
-        let green = p.parse::<CSSInt>()?;
-        let blue = p.parse::<CSSInt>()?;
+        let v0 = p.parse::<CSSInt>()?;
+        let v1 = p.parse::<CSSInt>()?;
+        let v2 = p.parse::<CSSInt>()?;
         return Ok(Self {
-            red: red,
-            green: green,
-            blue: blue,
+            red: v0,
+            green: v1,
+            blue: v2,
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_lifetime.snap
@@ -9,7 +9,7 @@ impl<'a> ::css_parse::Parse<'a> for Value<'a> {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let content = p.parse::<Ident>()?;
-        return Ok(Self { content: content });
+        let v0 = p.parse::<Ident>()?;
+        return Ok(Self { content: v0 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_many_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_many_fields.snap
@@ -9,25 +9,25 @@ impl<'a> ::css_parse::Parse<'a> for Transform {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let rotate_x = p.parse::<Angle>()?;
-        let rotate_y = p.parse::<Angle>()?;
-        let rotate_z = p.parse::<Angle>()?;
-        let translate_x = p.parse::<Length>()?;
-        let translate_y = p.parse::<Length>()?;
-        let translate_z = p.parse::<Length>()?;
-        let scale_x = p.parse::<Number>()?;
-        let scale_y = p.parse::<Number>()?;
-        let scale_z = p.parse::<Number>()?;
+        let v0 = p.parse::<Angle>()?;
+        let v1 = p.parse::<Angle>()?;
+        let v2 = p.parse::<Angle>()?;
+        let v3 = p.parse::<Length>()?;
+        let v4 = p.parse::<Length>()?;
+        let v5 = p.parse::<Length>()?;
+        let v6 = p.parse::<Number>()?;
+        let v7 = p.parse::<Number>()?;
+        let v8 = p.parse::<Number>()?;
         return Ok(Self {
-            rotate_x: rotate_x,
-            rotate_y: rotate_y,
-            rotate_z: rotate_z,
-            translate_x: translate_x,
-            translate_y: translate_y,
-            translate_z: translate_z,
-            scale_x: scale_x,
-            scale_y: scale_y,
-            scale_z: scale_z,
+            rotate_x: v0,
+            rotate_y: v1,
+            rotate_z: v2,
+            translate_x: v3,
+            translate_y: v4,
+            translate_z: v5,
+            scale_x: v6,
+            scale_y: v7,
+            scale_z: v8,
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_generics.snap
@@ -5,21 +5,16 @@ expression: pretty
 #[automatically_derived]
 impl<'a, T, U> ::css_parse::Parse<'a> for Container<T, U>
 where
-    T: ::css_parse::Parse<'a>,
-    U: ::css_parse::Parse<'a>,
-    T: ::css_parse::Peek<'a>,
-    U: ::css_parse::Peek<'a>,
+    T: ::css_parse::Parse<'a> + ::css_parse::Peek<'a>,
+    U: ::css_parse::Parse<'a> + ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let first = p.parse::<T>()?;
-        let second = p.parse::<U>()?;
-        return Ok(Self {
-            first: first,
-            second: second,
-        });
+        let v0 = p.parse::<T>()?;
+        let v1 = p.parse::<U>()?;
+        return Ok(Self { first: v0, second: v1 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_newtype_keyword.snap
@@ -9,18 +9,17 @@ impl<'a> ::css_parse::Parse<'a> for NewtypeKeywordTest {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let auto_value = {
+        let v0 = {
             let c = p.peek_n(1);
             if p.equals_atom(c.into(), &Auto) {
                 p.parse::<Auto>()?
             } else {
-                return Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?;
+                return Err(
+                    ::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected),
+                )?;
             }
         };
-        let length = p.parse::<Length>()?;
-        return Ok(Self {
-            auto_value: auto_value,
-            length: length,
-        });
+        let v1 = p.parse::<Length>()?;
+        return Ok(Self { auto_value: v0, length: v1 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
@@ -9,31 +9,31 @@ impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let mut auto_value: Option<Ident> = None;
-        let mut none_value: Option<Ident> = None;
+        let mut v0: Option<Ident> = None;
+        let mut v1: Option<Ident> = None;
         loop {
             let c = p.peek_n(1);
-            if auto_value.is_none() && p.peek::<Ident>()
+            if v0.is_none() && p.peek::<Ident>()
                 && p.to_atom::<FooKeywords>(c) == FooKeywords::Auto
             {
-                auto_value = Some(p.parse::<Ident>()?);
+                v0 = Some(p.parse::<Ident>()?);
                 continue;
             }
-            if none_value.is_none() && p.peek::<Ident>()
+            if v1.is_none() && p.peek::<Ident>()
                 && p.to_atom::<FooKeywords>(c) == FooKeywords::None
             {
-                none_value = Some(p.parse::<Ident>()?);
+                v1 = Some(p.parse::<Ident>()?);
                 continue;
             }
             break;
         }
-        if auto_value.is_none() && none_value.is_none() {
+        if v0.is_none() && v1.is_none() {
             let c = p.peek_n(1);
-            Err(crate::Diagnostic::new(c, crate::Diagnostic::unexpected))?
+            Err(::css_parse::Diagnostic::new(c, ::css_parse::Diagnostic::unexpected))?
         }
         return Ok(Self {
-            auto_value: auto_value,
-            none_value: none_value,
+            auto_value: v0,
+            none_value: v1,
         });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_single_generic.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_single_generic.snap
@@ -5,15 +5,14 @@ expression: pretty
 #[automatically_derived]
 impl<'a, T> ::css_parse::Parse<'a> for Wrapper<T>
 where
-    T: ::css_parse::Parse<'a>,
-    T: ::css_parse::Peek<'a>,
+    T: ::css_parse::Parse<'a> + ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let value = p.parse::<T>()?;
-        return Ok(Self { value: value });
+        let v0 = p.parse::<T>()?;
+        return Ok(Self { value: v0 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_unused_generic.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_unused_generic.snap
@@ -5,15 +5,14 @@ expression: pretty
 #[automatically_derived]
 impl<'a, T, U> ::css_parse::Parse<'a> for PartialWrapper<T, U>
 where
-    T: ::css_parse::Parse<'a>,
-    T: ::css_parse::Peek<'a>,
+    T: ::css_parse::Parse<'a> + ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where
         I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
     {
         use css_parse::{Parse, Peek};
-        let used = p.parse::<T>()?;
-        return Ok(Self { used: used });
+        let v0 = p.parse::<T>()?;
+        return Ok(Self { used: v0 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_generics.snap
@@ -5,10 +5,8 @@ expression: pretty
 #[automatically_derived]
 impl<'a, T, U> ::css_parse::Parse<'a> for Pair<T, U>
 where
-    T: ::css_parse::Parse<'a>,
-    U: ::css_parse::Parse<'a>,
-    T: ::css_parse::Peek<'a>,
-    U: ::css_parse::Peek<'a>,
+    T: ::css_parse::Parse<'a> + ::css_parse::Peek<'a>,
+    U: ::css_parse::Parse<'a> + ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_both_state_and_stop.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_both_state_and_stop.snap
@@ -11,9 +11,9 @@ impl<'a> ::css_parse::Parse<'a> for RuleContent {
         use css_parse::{Parse, Peek};
         let stop = p.set_stop(KindSet::new(&[Kind::RightBrace]));
         let state = p.set_state(State::InRule);
-        let declarations = p.parse::<Vec<String>>()?;
+        let v0 = p.parse::<Vec<String>>()?;
         p.set_state(state);
         p.set_stop(stop);
-        return Ok(Self { declarations: declarations });
+        return Ok(Self { declarations: v0 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_multiple_state_stop_combinations.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_multiple_state_stop_combinations.snap
@@ -11,13 +11,10 @@ impl<'a> ::css_parse::Parse<'a> for Declaration {
         use css_parse::{Parse, Peek};
         let stop = p.set_stop(KindSet::DeclarationEnd);
         let state = p.set_state(State::InDeclaration);
-        let property = p.parse::<Ident>()?;
-        let value = p.parse::<CSSValue>()?;
+        let v0 = p.parse::<Ident>()?;
+        let v1 = p.parse::<CSSValue>()?;
         p.set_state(state);
         p.set_stop(stop);
-        return Ok(Self {
-            property: property,
-            value: value,
-        });
+        return Ok(Self { property: v0, value: v1 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_state_attribute.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_state_attribute.snap
@@ -10,8 +10,8 @@ impl<'a> ::css_parse::Parse<'a> for ValueInState {
     {
         use css_parse::{Parse, Peek};
         let state = p.set_state(State::InValue);
-        let content = p.parse::<String>()?;
+        let v0 = p.parse::<String>()?;
         p.set_state(state);
-        return Ok(Self { content: content });
+        return Ok(Self { content: v0 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kind_attribute.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kind_attribute.snap
@@ -10,8 +10,8 @@ impl<'a> ::css_parse::Parse<'a> for StopOnSemicolon {
     {
         use css_parse::{Parse, Peek};
         let stop = p.set_stop(KindSet::new(&[Kind::Semicolon]));
-        let items = p.parse::<Vec<String>>()?;
+        let v0 = p.parse::<Vec<String>>()?;
         p.set_stop(stop);
-        return Ok(Self { items: items });
+        return Ok(Self { items: v0 });
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kindset_attribute.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kindset_attribute.snap
@@ -10,8 +10,8 @@ impl<'a> ::css_parse::Parse<'a> for StopOnBlockEnd {
     {
         use css_parse::{Parse, Peek};
         let stop = p.set_stop(KindSet::BlockEnd);
-        let declarations = p.parse::<Vec<String>>()?;
+        let v0 = p.parse::<Vec<String>>()?;
         p.set_stop(stop);
-        return Ok(Self { declarations: declarations });
+        return Ok(Self { declarations: v0 });
     }
 }


### PR DESCRIPTION
Rewrite/cleanup derive(Parse). Some slight alterations to ambiguous ASTs due to
better order preservation on enum variants.
