### PR TITLE
css_parse: move AttributeOperator down from css_ast

### DIFF
--- a/crates/css_ast/build.rs
+++ b/crates/css_ast/build.rs
@@ -35,6 +35,10 @@ fn main() {
 		input: parse_str("pub enum ComponentValue<'a> {}").unwrap(),
 		visit_mode: VisitMode::Self_,
 	});
+	all_visitable.push(VisitableNode {
+		input: parse_str("pub enum AttributeOperator {}").unwrap(),
+		visit_mode: VisitMode::Self_,
+	});
 	all_visitable.sort_unstable_by_key(|node| node.ident().to_string());
 
 	let queryable = all_visitable.iter().filter(|node| node.visit_mode.is_queryable()).cloned().collect::<Vec<_>>();

--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -25,7 +25,7 @@ pub mod visit;
 
 pub use constraints::*;
 pub use css_atom_set::*;
-pub use css_parse::{ComponentValue, ComponentValues, Declaration, DeclarationValue, Diagnostic};
+pub use css_parse::{AttributeOperator, ComponentValue, ComponentValues, Declaration, DeclarationValue, Diagnostic};
 pub use encoding_label::*;
 pub use functions::*;
 pub use metadata::*;

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -1,6 +1,7 @@
 use super::prelude::*;
 
 use super::NamespacePrefix;
+use css_parse::AttributeOperator;
 
 #[node]
 #[derive(Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -48,20 +49,6 @@ impl<'a> Parse<'a> for Attribute {
 		let close = p.parse_if_peek::<T![']']>()?;
 		Ok(Self { open, namespace_prefix, attribute, operator, value, modifier, close })
 	}
-}
-
-#[node]
-#[derive(Parse, ToSpan, Peek, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
-#[derive(csskit_derives::NodeWithMetadata)]
-pub enum AttributeOperator {
-	Exact(#[semantic_eq(skip)] T![=]),
-	SpaceList(#[semantic_eq(skip)] T![~=]),
-	LangPrefix(#[semantic_eq(skip)] T![|=]),
-	Prefix(#[semantic_eq(skip)] T![^=]),
-	Suffix(#[semantic_eq(skip)] T!["$="]),
-	Contains(#[semantic_eq(skip)] T![*=]),
 }
 
 #[node]

--- a/crates/css_ast/src/snapshots/css_ast__layout_test__assert_layouts.snap
+++ b/crates/css_ast/src/snapshots/css_ast__layout_test__assert_layouts.snap
@@ -277,13 +277,6 @@ Attribute: size=128 align=4 {
 AttributeModifier: size=16 align=4
     0: Sensitive
     1: Insensitive
-AttributeOperator: size=28 align=4
-    0: Exact
-    1: SpaceList
-    2: LangPrefix
-    3: Prefix
-    4: Suffix
-    5: Contains
 AttributeValue: size=16 align=4
     0: String
     1: Ident

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -3,10 +3,10 @@ include!(concat!(env!("OUT_DIR"), "/css_apply_visit_methods.rs"));
 
 use css_parse::Vec;
 use css_parse::{
-	Block, Box, CommaSeparated, Comparison, ComponentValue, ComponentValues, Cursor, Declaration, DeclarationGroup,
-	DeclarationList, DeclarationOrBad, DeclarationValue, Either, NoBlockAllowed, NodeMetadata, NodeWithMetadata,
-	Optionals2, Optionals3, Optionals4, Optionals5, Parse, Peek, QualifiedRule, RuleList, ToCursors, ToSpan,
-	syntax::BadDeclaration, token_macros,
+	AttributeOperator, Block, Box, CommaSeparated, Comparison, ComponentValue, ComponentValues, Cursor, Declaration,
+	DeclarationGroup, DeclarationList, DeclarationOrBad, DeclarationValue, Either, NoBlockAllowed, NodeMetadata,
+	NodeWithMetadata, Optionals2, Optionals3, Optionals4, Optionals5, Parse, Peek, QualifiedRule, RuleList, ToCursors,
+	ToSpan, syntax::BadDeclaration, token_macros,
 };
 use visit_flow::{VisitFlow, try_visit};
 
@@ -695,6 +695,32 @@ impl<'a> Visitable for ComponentValue<'a> {
 				}
 			}
 			try_visit!(v.exit_component_value(self));
+		}
+		try_visit!(v.exit_node(node));
+		VisitFlow::DESCEND
+	}
+}
+
+impl VisitableMut for AttributeOperator {
+	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
+		v.visit_attribute_operator(self);
+		v.exit_attribute_operator(self);
+	}
+}
+
+impl QueryableNode for AttributeOperator {
+	const NODE_ID: NodeId = NodeId::AttributeOperator;
+}
+
+impl Visitable for AttributeOperator {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
+		let node = QueryableNode::visit_node(self);
+		if let VisitAction::SkipChildren = try_visit!(v.consider_node(node)) {
+			return VisitFlow::DESCEND;
+		}
+		if let VisitAction::Descend = try_visit!(v.enter_node(node)) {
+			try_visit!(v.visit_attribute_operator(self));
+			try_visit!(v.exit_attribute_operator(self));
 		}
 		try_visit!(v.exit_node(node));
 		VisitFlow::DESCEND

--- a/crates/css_parse/src/snapshots/css_parse__layout_test__assert_layouts.snap
+++ b/crates/css_parse/src/snapshots/css_parse__layout_test__assert_layouts.snap
@@ -2,6 +2,13 @@
 source: crates/css_parse/src/layout_test.rs
 expression: render()
 ---
+AttributeOperator: size=28 align=4
+    0: Exact
+    1: SpaceList
+    2: LangPrefix
+    3: Prefix
+    4: Suffix
+    5: Contains
 BadDeclaration: size=24 align=8 {
     0: 0
 }

--- a/crates/css_parse/src/syntax/attribute_operator.rs
+++ b/crates/css_parse/src/syntax/attribute_operator.rs
@@ -1,0 +1,95 @@
+use super::prelude::*;
+
+/// The operator of an attribute selector, e.g. the `^=` of `[href^="https"]`.
+///
+/// <https://drafts.csswg.org/selectors/#attribute-selectors>
+#[node]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+pub enum AttributeOperator {
+	Exact(T![=]),
+	SpaceList(T![~=]),
+	LangPrefix(T![|=]),
+	Prefix(T![^=]),
+	Suffix(T!["$="]),
+	Contains(T![*=]),
+}
+
+impl<M: NodeMetadata> NodeWithMetadata<M> for AttributeOperator {
+	fn metadata(&self) -> M {
+		M::default()
+	}
+}
+
+impl<'a> Peek<'a> for AttributeOperator {
+	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Delim]);
+}
+
+impl<'a> Parse<'a> for AttributeOperator {
+	fn parse<I>(p: &mut Parser<'a, I>) -> Result<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		if p.peek::<T![~=]>() {
+			p.parse::<T![~=]>().map(Self::SpaceList)
+		} else if p.peek::<T![|=]>() {
+			p.parse::<T![|=]>().map(Self::LangPrefix)
+		} else if p.peek::<T![^=]>() {
+			p.parse::<T![^=]>().map(Self::Prefix)
+		} else if p.peek::<T!["$="]>() {
+			p.parse::<T!["$="]>().map(Self::Suffix)
+		} else if p.peek::<T![*=]>() {
+			p.parse::<T![*=]>().map(Self::Contains)
+		} else {
+			p.parse::<T![=]>().map(Self::Exact)
+		}
+	}
+}
+
+impl ToCursors for AttributeOperator {
+	fn to_cursors(&self, s: &mut impl CursorSink) {
+		match self {
+			Self::Exact(t) => t.to_cursors(s),
+			Self::SpaceList(t) => t.to_cursors(s),
+			Self::LangPrefix(t) => t.to_cursors(s),
+			Self::Prefix(t) => t.to_cursors(s),
+			Self::Suffix(t) => t.to_cursors(s),
+			Self::Contains(t) => t.to_cursors(s),
+		}
+	}
+}
+
+impl ToSpan for AttributeOperator {
+	fn to_span(&self) -> Span {
+		match self {
+			Self::Exact(t) => t.to_span(),
+			Self::SpaceList(t) => t.to_span(),
+			Self::LangPrefix(t) => t.to_span(),
+			Self::Prefix(t) => t.to_span(),
+			Self::Suffix(t) => t.to_span(),
+			Self::Contains(t) => t.to_span(),
+		}
+	}
+}
+
+impl SemanticEq for AttributeOperator {
+	fn semantic_eq(&self, other: &Self, _source_text: &str) -> bool {
+		std::mem::discriminant(self) == std::mem::discriminant(other)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::{EmptyAtomSet, assert_parse};
+
+	#[test]
+	fn test_writes() {
+		assert_parse!(EmptyAtomSet::ATOMS, AttributeOperator, "=");
+		assert_parse!(EmptyAtomSet::ATOMS, AttributeOperator, "~=");
+		assert_parse!(EmptyAtomSet::ATOMS, AttributeOperator, "|=");
+		assert_parse!(EmptyAtomSet::ATOMS, AttributeOperator, "^=");
+		assert_parse!(EmptyAtomSet::ATOMS, AttributeOperator, "$=");
+		assert_parse!(EmptyAtomSet::ATOMS, AttributeOperator, "*=");
+	}
+}

--- a/crates/css_parse/src/syntax/mod.rs
+++ b/crates/css_parse/src/syntax/mod.rs
@@ -1,3 +1,4 @@
+mod attribute_operator;
 mod bad_declaration;
 mod bang_important;
 mod block;
@@ -16,6 +17,7 @@ mod rule_list;
 mod simple_block;
 mod unknown_rule_block;
 
+pub use attribute_operator::*;
 pub use bad_declaration::*;
 pub use bang_important::*;
 pub use block::*;

--- a/crates/css_value_definition_parser/src/sized_types.rs
+++ b/crates/css_value_definition_parser/src/sized_types.rs
@@ -19,7 +19,6 @@ pub(crate) const SIZED_TYPES: &[&str] = &[
 	"AttrName",
 	"Attribute",
 	"AttributeModifier",
-	"AttributeOperator",
 	"AttributeValue",
 	"Auto",
 	"AutoFillOrFit",

--- a/crates/csskit_ast/src/selector/matcher/property_values.rs
+++ b/crates/csskit_ast/src/selector/matcher/property_values.rs
@@ -1,7 +1,7 @@
 use crate::QueryAttribute;
 use css_ast::visit::VisitNode;
-use css_ast::{AttributeOperator, CssAtomSet, PropertyKind};
-use css_parse::{AtomSet, Cursor};
+use css_ast::{CssAtomSet, PropertyKind};
+use css_parse::{AtomSet, AttributeOperator, Cursor};
 
 /// Stores queryable property values extracted from a node.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -1,12 +1,12 @@
 use super::metadata::{QuerySelectorMetadata, SelectorRequirements, SelectorStructure};
 use crate::{CsskitAtomSet, diagnostics::QueryDiagnostic};
-use css_ast::{AttributeOperator, CssMetadata, Nth, PropertyGroup, PropertyKind, VendorPrefixes, visit::NodeId};
+use css_ast::{CssMetadata, Nth, PropertyGroup, PropertyKind, VendorPrefixes, visit::NodeId};
 use css_lexer::{Span, ToSpan};
 use css_parse::Vec;
 use css_parse::{
-	AtomSet, CompoundSelector as CompoundSelectorTrait, Cursor, CursorSink, Diagnostic, KindSet, NodeMetadata,
-	NodeWithMetadata, Parse, Parser, Peek, Result, SelectorComponent as SelectorComponentTrait, SemanticEq, State, T,
-	ToCursors, pseudo_class, syntax::CommaSeparated,
+	AtomSet, AttributeOperator, CompoundSelector as CompoundSelectorTrait, Cursor, CursorSink, Diagnostic, KindSet,
+	NodeMetadata, NodeWithMetadata, Parse, Parser, Peek, Result, SelectorComponent as SelectorComponentTrait,
+	SemanticEq, State, T, ToCursors, pseudo_class, syntax::CommaSeparated,
 };
 use csskit_derives::*;
 use smallvec::SmallVec;

--- a/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
+++ b/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
@@ -23,7 +23,6 @@ expression: "matches.iter().map(|node|\nnode.input.to_token_stream().to_string()
   "pub enum AspectRatioMediaFeature < \'a > { }",
   "pub enum Attachment { }",
   "pub enum AttributeModifier { }",
-  "pub enum AttributeOperator { }",
   "pub enum AttributeValue { }",
   "pub enum AutoFillOrFit { }",
   "pub enum Autospace < \'a > { }",


### PR DESCRIPTION
This change moves `AttributeOperator` from css_ast to css_parse, as it's used
across both css_ast & csskit_ast, and can be useful more generally.
